### PR TITLE
Fix invalid comparison to js.Undefined() in go1.14.

### DIFF
--- a/core/js/js.go
+++ b/core/js/js.go
@@ -198,6 +198,11 @@ func (v Value) Invoke(args ...interface{}) Value {
 	panic(message)
 }
 
+// IsUndefined reports whether v is the JavaScript value "undefined".
+func (v Value) IsUndefined() bool {
+	panic(message)
+}
+
 // JSValue implements Wrapper interface.
 func (v Value) JSValue() Value {
 	panic(message)

--- a/dom/helper.go
+++ b/dom/helper.go
@@ -1,7 +1,5 @@
 package dom
 
-import js "github.com/gowebapi/webapi/core/js"
-
 // RequestFullscreenByBrowser is an alternative way to
 // request fullscreen that is taking different browser into
 // accound

--- a/dom/helper.go
+++ b/dom/helper.go
@@ -1,8 +1,7 @@
 package dom
 
 // RequestFullscreenByBrowser is an alternative way to
-// request fullscreen that is taking different browser into
-// accound
+// request fullscreen that works for different browsers.
 func (t *Element) RequestFullscreenByBrowser() {
 	elem := t.Value_JS
 	if !elem.Get("requestFullscreen").IsUndefined() {

--- a/dom/helper.go
+++ b/dom/helper.go
@@ -7,13 +7,13 @@ import js "github.com/gowebapi/webapi/core/js"
 // accound
 func (t *Element) RequestFullscreenByBrowser() {
 	elem := t.Value_JS
-	if elem.Get("requestFullscreen") != js.Undefined() {
+	if !elem.Get("requestFullscreen").IsUndefined() {
 		elem.Call("requestFullscreen", "")
-	} else if elem.Get("mozRequestFullScreen") != js.Undefined() { /* Firefox */
+	} else if !elem.Get("mozRequestFullScreen").IsUndefined() { /* Firefox */
 		elem.Call("mozRequestFullScreen", "")
-	} else if elem.Get("webkitRequestFullscreen") != js.Undefined() { /* Chrome, Safari and Opera */
+	} else if !elem.Get("webkitRequestFullscreen").IsUndefined() { /* Chrome, Safari and Opera */
 		elem.Call("webkitRequestFullscreen", "")
-	} else if elem.Get("msRequestFullscreen") != js.Undefined() { /* IE/Edge */
+	} else if !elem.Get("msRequestFullscreen").IsUndefined() { /* IE/Edge */
 		elem.Call("msRequestFullscreen", "")
 	}
 }


### PR DESCRIPTION
After the go 1.14 update the file `dom/helper.go` was failing to compile for wasm (it would still compiles if not wasm). the underlying `syscall/js` `Value` type must have changed, is my guess.

But in any case, it now offers the safer [`IsUndefined()` method](https://godoc.org/syscall/js#Value.IsUndefined). So I added it to the `core/js/js.go` wrappers and changed `helper.go` to use it.



