### PR TITLE
Removing reference to js.Wrapper, dropped in go 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Developers files, IDE, etc.
+go.sum
+go.work
+.idea

--- a/appmanifest/appmanifest.go
+++ b/appmanifest/appmanifest.go
@@ -8,6 +8,7 @@ import js "github.com/gowebapi/webapi/core/js"
 
 import (
 	"github.com/gowebapi/webapi/appmanifest/appmenifestres"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlcommon"
 	"github.com/gowebapi/webapi/javascript"
@@ -264,7 +265,7 @@ type PromptResponseObject struct {
 	UserChoice AppBannerPromptOutcome
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PromptResponseObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -274,15 +275,13 @@ func (_this *PromptResponseObject) JSValue() js.Value {
 }
 
 // PromptResponseObjectFromJS is allocating a new
-// PromptResponseObject object and copy all values from
-// input javascript object
-func PromptResponseObjectFromJS(value js.Wrapper) *PromptResponseObject {
-	input := value.JSValue()
+// PromptResponseObject object and copy all values in the value javascript object.
+func PromptResponseObjectFromJS(value js.Value) *PromptResponseObject {
 	var out PromptResponseObject
 	var (
 		value0 AppBannerPromptOutcome // javascript: AppBannerPromptOutcome {userChoice UserChoice userChoice}
 	)
-	value0 = AppBannerPromptOutcomeFromJS(input.Get("userChoice"))
+	value0 = AppBannerPromptOutcomeFromJS(value.Get("userChoice"))
 	out.UserChoice = value0
 	return &out
 }
@@ -295,7 +294,7 @@ type ServiceWorkerRegistrationObject struct {
 	UpdateViaCache serviceworker.ServiceWorkerUpdateViaCache
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceWorkerRegistrationObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -311,10 +310,8 @@ func (_this *ServiceWorkerRegistrationObject) JSValue() js.Value {
 }
 
 // ServiceWorkerRegistrationObjectFromJS is allocating a new
-// ServiceWorkerRegistrationObject object and copy all values from
-// input javascript object
-func ServiceWorkerRegistrationObjectFromJS(value js.Wrapper) *ServiceWorkerRegistrationObject {
-	input := value.JSValue()
+// ServiceWorkerRegistrationObject object and copy all values in the value javascript object.
+func ServiceWorkerRegistrationObjectFromJS(value js.Value) *ServiceWorkerRegistrationObject {
 	var out ServiceWorkerRegistrationObject
 	var (
 		value0 string                                    // javascript: USVString {src Src src}
@@ -322,13 +319,13 @@ func ServiceWorkerRegistrationObjectFromJS(value js.Wrapper) *ServiceWorkerRegis
 		value2 htmlcommon.WorkerType                     // javascript: WorkerType {type Type _type}
 		value3 serviceworker.ServiceWorkerUpdateViaCache // javascript: ServiceWorkerUpdateViaCache {update_via_cache UpdateViaCache updateViaCache}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("scope")).String()
+	value1 = (value.Get("scope")).String()
 	out.Scope = value1
-	value2 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value2 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value2
-	value3 = serviceworker.ServiceWorkerUpdateViaCacheFromJS(input.Get("update_via_cache"))
+	value3 = serviceworker.ServiceWorkerUpdateViaCacheFromJS(value.Get("update_via_cache"))
 	out.UpdateViaCache = value3
 	return &out
 }
@@ -355,7 +352,7 @@ type WebAppManifest struct {
 	PreferRelatedApplications bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WebAppManifest) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -415,10 +412,8 @@ func (_this *WebAppManifest) JSValue() js.Value {
 }
 
 // WebAppManifestFromJS is allocating a new
-// WebAppManifest object and copy all values from
-// input javascript object
-func WebAppManifestFromJS(value js.Wrapper) *WebAppManifest {
-	input := value.JSValue()
+// WebAppManifest object and copy all values in the value javascript object.
+func WebAppManifestFromJS(value js.Value) *WebAppManifest {
 	var out WebAppManifest
 	var (
 		value0  TextDirectionType                             // javascript: TextDirectionType {dir Dir dir}
@@ -440,73 +435,73 @@ func WebAppManifestFromJS(value js.Wrapper) *WebAppManifest {
 		value16 []*appmenifestres.ExternalApplicationResource // javascript: sequence<ExternalApplicationResource> {related_applications RelatedApplications relatedApplications}
 		value17 bool                                          // javascript: boolean {prefer_related_applications PreferRelatedApplications preferRelatedApplications}
 	)
-	value0 = TextDirectionTypeFromJS(input.Get("dir"))
+	value0 = TextDirectionTypeFromJS(value.Get("dir"))
 	out.Dir = value0
-	value1 = (input.Get("lang")).String()
+	value1 = (value.Get("lang")).String()
 	out.Lang = value1
-	value2 = (input.Get("name")).String()
+	value2 = (value.Get("name")).String()
 	out.Name = value2
-	value3 = (input.Get("short_name")).String()
+	value3 = (value.Get("short_name")).String()
 	out.ShortName = value3
-	value4 = (input.Get("description")).String()
+	value4 = (value.Get("description")).String()
 	out.Description = value4
-	__length5 := input.Get("icons").Length()
+	__length5 := value.Get("icons").Length()
 	__array5 := make([]*appmenifestres.ImageResource, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *appmenifestres.ImageResource
-		__seq_in5 := input.Get("icons").Index(__idx5)
+		__seq_in5 := value.Get("icons").Index(__idx5)
 		__seq_out5 = appmenifestres.ImageResourceFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Icons = value5
-	__length6 := input.Get("screenshots").Length()
+	__length6 := value.Get("screenshots").Length()
 	__array6 := make([]*appmenifestres.ImageResource, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 *appmenifestres.ImageResource
-		__seq_in6 := input.Get("screenshots").Index(__idx6)
+		__seq_in6 := value.Get("screenshots").Index(__idx6)
 		__seq_out6 = appmenifestres.ImageResourceFromJS(__seq_in6)
 		__array6[__idx6] = __seq_out6
 	}
 	value6 = __array6
 	out.Screenshots = value6
-	__length7 := input.Get("categories").Length()
+	__length7 := value.Get("categories").Length()
 	__array7 := make([]string, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 string
-		__seq_in7 := input.Get("categories").Index(__idx7)
+		__seq_in7 := value.Get("categories").Index(__idx7)
 		__seq_out7 = (__seq_in7).String()
 		__array7[__idx7] = __seq_out7
 	}
 	value7 = __array7
 	out.Categories = value7
-	value8 = (input.Get("iarc_rating_id")).String()
+	value8 = (value.Get("iarc_rating_id")).String()
 	out.IarcRatingId = value8
-	value9 = (input.Get("start_url")).String()
+	value9 = (value.Get("start_url")).String()
 	out.StartUrl = value9
-	value10 = DisplayModeTypeFromJS(input.Get("display"))
+	value10 = DisplayModeTypeFromJS(value.Get("display"))
 	out.Display = value10
-	value11 = orientation.OrientationLockTypeFromJS(input.Get("orientation"))
+	value11 = orientation.OrientationLockTypeFromJS(value.Get("orientation"))
 	out.Orientation = value11
-	value12 = (input.Get("theme_color")).String()
+	value12 = (value.Get("theme_color")).String()
 	out.ThemeColor = value12
-	value13 = (input.Get("background_color")).String()
+	value13 = (value.Get("background_color")).String()
 	out.BackgroundColor = value13
-	value14 = (input.Get("scope")).String()
+	value14 = (value.Get("scope")).String()
 	out.Scope = value14
-	value15 = ServiceWorkerRegistrationObjectFromJS(input.Get("serviceworker"))
+	value15 = ServiceWorkerRegistrationObjectFromJS(value.Get("serviceworker"))
 	out.Serviceworker = value15
-	__length16 := input.Get("related_applications").Length()
+	__length16 := value.Get("related_applications").Length()
 	__array16 := make([]*appmenifestres.ExternalApplicationResource, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 *appmenifestres.ExternalApplicationResource
-		__seq_in16 := input.Get("related_applications").Index(__idx16)
+		__seq_in16 := value.Get("related_applications").Index(__idx16)
 		__seq_out16 = appmenifestres.ExternalApplicationResourceFromJS(__seq_in16)
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.RelatedApplications = value16
-	value17 = (input.Get("prefer_related_applications")).Bool()
+	value17 = (value.Get("prefer_related_applications")).Bool()
 	out.PreferRelatedApplications = value17
 	return &out
 }
@@ -516,15 +511,19 @@ type BeforeInstallPromptEvent struct {
 	domcore.Event
 }
 
-// BeforeInstallPromptEventFromJS is casting a js.Wrapper into BeforeInstallPromptEvent.
-func BeforeInstallPromptEventFromJS(value js.Wrapper) *BeforeInstallPromptEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BeforeInstallPromptEventFromJS is casting a js.Value into BeforeInstallPromptEvent.
+func BeforeInstallPromptEventFromJS(value js.Value) *BeforeInstallPromptEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BeforeInstallPromptEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BeforeInstallPromptEventFromJS is casting from something that holds a js.Value into BeforeInstallPromptEvent.
+func BeforeInstallPromptEventFromWrapper(input core.Wrapper) *BeforeInstallPromptEvent {
+	return BeforeInstallPromptEventFromJS(input.JSValue())
 }
 
 func NewBeforeInstallPromptEvent(_type string, eventInitDict *domcore.EventInit) (_result *BeforeInstallPromptEvent) {
@@ -574,15 +573,19 @@ func (_this *PromisePromptResponseObject) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePromptResponseObjectFromJS is casting a js.Wrapper into PromisePromptResponseObject.
-func PromisePromptResponseObjectFromJS(value js.Wrapper) *PromisePromptResponseObject {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePromptResponseObjectFromJS is casting a js.Value into PromisePromptResponseObject.
+func PromisePromptResponseObjectFromJS(value js.Value) *PromisePromptResponseObject {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePromptResponseObject{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePromptResponseObjectFromJS is casting from something that holds a js.Value into PromisePromptResponseObject.
+func PromisePromptResponseObjectFromWrapper(input core.Wrapper) *PromisePromptResponseObject {
+	return PromisePromptResponseObjectFromJS(input.JSValue())
 }
 
 func (_this *PromisePromptResponseObject) Then(onFulfilled *PromisePromptResponseObjectOnFulfilled, onRejected *PromisePromptResponseObjectOnRejected) (_result *PromisePromptResponseObject) {

--- a/appmanifest/appmanifest_js.go
+++ b/appmanifest/appmanifest_js.go
@@ -6,6 +6,7 @@ import "syscall/js"
 
 import (
 	"github.com/gowebapi/webapi/appmanifest/appmenifestres"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlcommon"
 	"github.com/gowebapi/webapi/javascript"
@@ -262,7 +263,7 @@ type PromptResponseObject struct {
 	UserChoice AppBannerPromptOutcome
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PromptResponseObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -272,15 +273,13 @@ func (_this *PromptResponseObject) JSValue() js.Value {
 }
 
 // PromptResponseObjectFromJS is allocating a new
-// PromptResponseObject object and copy all values from
-// input javascript object
-func PromptResponseObjectFromJS(value js.Wrapper) *PromptResponseObject {
-	input := value.JSValue()
+// PromptResponseObject object and copy all values in the value javascript object.
+func PromptResponseObjectFromJS(value js.Value) *PromptResponseObject {
 	var out PromptResponseObject
 	var (
 		value0 AppBannerPromptOutcome // javascript: AppBannerPromptOutcome {userChoice UserChoice userChoice}
 	)
-	value0 = AppBannerPromptOutcomeFromJS(input.Get("userChoice"))
+	value0 = AppBannerPromptOutcomeFromJS(value.Get("userChoice"))
 	out.UserChoice = value0
 	return &out
 }
@@ -293,7 +292,7 @@ type ServiceWorkerRegistrationObject struct {
 	UpdateViaCache serviceworker.ServiceWorkerUpdateViaCache
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceWorkerRegistrationObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -309,10 +308,8 @@ func (_this *ServiceWorkerRegistrationObject) JSValue() js.Value {
 }
 
 // ServiceWorkerRegistrationObjectFromJS is allocating a new
-// ServiceWorkerRegistrationObject object and copy all values from
-// input javascript object
-func ServiceWorkerRegistrationObjectFromJS(value js.Wrapper) *ServiceWorkerRegistrationObject {
-	input := value.JSValue()
+// ServiceWorkerRegistrationObject object and copy all values in the value javascript object.
+func ServiceWorkerRegistrationObjectFromJS(value js.Value) *ServiceWorkerRegistrationObject {
 	var out ServiceWorkerRegistrationObject
 	var (
 		value0 string                                    // javascript: USVString {src Src src}
@@ -320,13 +317,13 @@ func ServiceWorkerRegistrationObjectFromJS(value js.Wrapper) *ServiceWorkerRegis
 		value2 htmlcommon.WorkerType                     // javascript: WorkerType {type Type _type}
 		value3 serviceworker.ServiceWorkerUpdateViaCache // javascript: ServiceWorkerUpdateViaCache {update_via_cache UpdateViaCache updateViaCache}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("scope")).String()
+	value1 = (value.Get("scope")).String()
 	out.Scope = value1
-	value2 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value2 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value2
-	value3 = serviceworker.ServiceWorkerUpdateViaCacheFromJS(input.Get("update_via_cache"))
+	value3 = serviceworker.ServiceWorkerUpdateViaCacheFromJS(value.Get("update_via_cache"))
 	out.UpdateViaCache = value3
 	return &out
 }
@@ -353,7 +350,7 @@ type WebAppManifest struct {
 	PreferRelatedApplications bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WebAppManifest) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -413,10 +410,8 @@ func (_this *WebAppManifest) JSValue() js.Value {
 }
 
 // WebAppManifestFromJS is allocating a new
-// WebAppManifest object and copy all values from
-// input javascript object
-func WebAppManifestFromJS(value js.Wrapper) *WebAppManifest {
-	input := value.JSValue()
+// WebAppManifest object and copy all values in the value javascript object.
+func WebAppManifestFromJS(value js.Value) *WebAppManifest {
 	var out WebAppManifest
 	var (
 		value0  TextDirectionType                             // javascript: TextDirectionType {dir Dir dir}
@@ -438,73 +433,73 @@ func WebAppManifestFromJS(value js.Wrapper) *WebAppManifest {
 		value16 []*appmenifestres.ExternalApplicationResource // javascript: sequence<ExternalApplicationResource> {related_applications RelatedApplications relatedApplications}
 		value17 bool                                          // javascript: boolean {prefer_related_applications PreferRelatedApplications preferRelatedApplications}
 	)
-	value0 = TextDirectionTypeFromJS(input.Get("dir"))
+	value0 = TextDirectionTypeFromJS(value.Get("dir"))
 	out.Dir = value0
-	value1 = (input.Get("lang")).String()
+	value1 = (value.Get("lang")).String()
 	out.Lang = value1
-	value2 = (input.Get("name")).String()
+	value2 = (value.Get("name")).String()
 	out.Name = value2
-	value3 = (input.Get("short_name")).String()
+	value3 = (value.Get("short_name")).String()
 	out.ShortName = value3
-	value4 = (input.Get("description")).String()
+	value4 = (value.Get("description")).String()
 	out.Description = value4
-	__length5 := input.Get("icons").Length()
+	__length5 := value.Get("icons").Length()
 	__array5 := make([]*appmenifestres.ImageResource, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *appmenifestres.ImageResource
-		__seq_in5 := input.Get("icons").Index(__idx5)
+		__seq_in5 := value.Get("icons").Index(__idx5)
 		__seq_out5 = appmenifestres.ImageResourceFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Icons = value5
-	__length6 := input.Get("screenshots").Length()
+	__length6 := value.Get("screenshots").Length()
 	__array6 := make([]*appmenifestres.ImageResource, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 *appmenifestres.ImageResource
-		__seq_in6 := input.Get("screenshots").Index(__idx6)
+		__seq_in6 := value.Get("screenshots").Index(__idx6)
 		__seq_out6 = appmenifestres.ImageResourceFromJS(__seq_in6)
 		__array6[__idx6] = __seq_out6
 	}
 	value6 = __array6
 	out.Screenshots = value6
-	__length7 := input.Get("categories").Length()
+	__length7 := value.Get("categories").Length()
 	__array7 := make([]string, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 string
-		__seq_in7 := input.Get("categories").Index(__idx7)
+		__seq_in7 := value.Get("categories").Index(__idx7)
 		__seq_out7 = (__seq_in7).String()
 		__array7[__idx7] = __seq_out7
 	}
 	value7 = __array7
 	out.Categories = value7
-	value8 = (input.Get("iarc_rating_id")).String()
+	value8 = (value.Get("iarc_rating_id")).String()
 	out.IarcRatingId = value8
-	value9 = (input.Get("start_url")).String()
+	value9 = (value.Get("start_url")).String()
 	out.StartUrl = value9
-	value10 = DisplayModeTypeFromJS(input.Get("display"))
+	value10 = DisplayModeTypeFromJS(value.Get("display"))
 	out.Display = value10
-	value11 = orientation.OrientationLockTypeFromJS(input.Get("orientation"))
+	value11 = orientation.OrientationLockTypeFromJS(value.Get("orientation"))
 	out.Orientation = value11
-	value12 = (input.Get("theme_color")).String()
+	value12 = (value.Get("theme_color")).String()
 	out.ThemeColor = value12
-	value13 = (input.Get("background_color")).String()
+	value13 = (value.Get("background_color")).String()
 	out.BackgroundColor = value13
-	value14 = (input.Get("scope")).String()
+	value14 = (value.Get("scope")).String()
 	out.Scope = value14
-	value15 = ServiceWorkerRegistrationObjectFromJS(input.Get("serviceworker"))
+	value15 = ServiceWorkerRegistrationObjectFromJS(value.Get("serviceworker"))
 	out.Serviceworker = value15
-	__length16 := input.Get("related_applications").Length()
+	__length16 := value.Get("related_applications").Length()
 	__array16 := make([]*appmenifestres.ExternalApplicationResource, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 *appmenifestres.ExternalApplicationResource
-		__seq_in16 := input.Get("related_applications").Index(__idx16)
+		__seq_in16 := value.Get("related_applications").Index(__idx16)
 		__seq_out16 = appmenifestres.ExternalApplicationResourceFromJS(__seq_in16)
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.RelatedApplications = value16
-	value17 = (input.Get("prefer_related_applications")).Bool()
+	value17 = (value.Get("prefer_related_applications")).Bool()
 	out.PreferRelatedApplications = value17
 	return &out
 }
@@ -514,15 +509,19 @@ type BeforeInstallPromptEvent struct {
 	domcore.Event
 }
 
-// BeforeInstallPromptEventFromJS is casting a js.Wrapper into BeforeInstallPromptEvent.
-func BeforeInstallPromptEventFromJS(value js.Wrapper) *BeforeInstallPromptEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BeforeInstallPromptEventFromJS is casting a js.Value into BeforeInstallPromptEvent.
+func BeforeInstallPromptEventFromJS(value js.Value) *BeforeInstallPromptEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BeforeInstallPromptEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BeforeInstallPromptEventFromJS is casting from something that holds a js.Value into BeforeInstallPromptEvent.
+func BeforeInstallPromptEventFromWrapper(input core.Wrapper) *BeforeInstallPromptEvent {
+	return BeforeInstallPromptEventFromJS(input.JSValue())
 }
 
 func NewBeforeInstallPromptEvent(_type string, eventInitDict *domcore.EventInit) (_result *BeforeInstallPromptEvent) {
@@ -572,15 +571,19 @@ func (_this *PromisePromptResponseObject) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePromptResponseObjectFromJS is casting a js.Wrapper into PromisePromptResponseObject.
-func PromisePromptResponseObjectFromJS(value js.Wrapper) *PromisePromptResponseObject {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePromptResponseObjectFromJS is casting a js.Value into PromisePromptResponseObject.
+func PromisePromptResponseObjectFromJS(value js.Value) *PromisePromptResponseObject {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePromptResponseObject{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePromptResponseObjectFromJS is casting from something that holds a js.Value into PromisePromptResponseObject.
+func PromisePromptResponseObjectFromWrapper(input core.Wrapper) *PromisePromptResponseObject {
+	return PromisePromptResponseObjectFromJS(input.JSValue())
 }
 
 func (_this *PromisePromptResponseObject) Then(onFulfilled *PromisePromptResponseObjectOnFulfilled, onRejected *PromisePromptResponseObjectOnRejected) (_result *PromisePromptResponseObject) {

--- a/appmanifest/appmenifestres/appmenifestres.go
+++ b/appmanifest/appmenifestres/appmenifestres.go
@@ -40,7 +40,7 @@ type ExternalApplicationResource struct {
 	Fingerprints []*Fingerprint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExternalApplicationResource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -62,10 +62,8 @@ func (_this *ExternalApplicationResource) JSValue() js.Value {
 }
 
 // ExternalApplicationResourceFromJS is allocating a new
-// ExternalApplicationResource object and copy all values from
-// input javascript object
-func ExternalApplicationResourceFromJS(value js.Wrapper) *ExternalApplicationResource {
-	input := value.JSValue()
+// ExternalApplicationResource object and copy all values in the value javascript object.
+func ExternalApplicationResourceFromJS(value js.Value) *ExternalApplicationResource {
 	var out ExternalApplicationResource
 	var (
 		value0 string         // javascript: USVString {platform Platform platform}
@@ -74,19 +72,19 @@ func ExternalApplicationResourceFromJS(value js.Wrapper) *ExternalApplicationRes
 		value3 string         // javascript: USVString {min_version MinVersion minVersion}
 		value4 []*Fingerprint // javascript: sequence<Fingerprint> {fingerprints Fingerprints fingerprints}
 	)
-	value0 = (input.Get("platform")).String()
+	value0 = (value.Get("platform")).String()
 	out.Platform = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("min_version")).String()
+	value3 = (value.Get("min_version")).String()
 	out.MinVersion = value3
-	__length4 := input.Get("fingerprints").Length()
+	__length4 := value.Get("fingerprints").Length()
 	__array4 := make([]*Fingerprint, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *Fingerprint
-		__seq_in4 := input.Get("fingerprints").Index(__idx4)
+		__seq_in4 := value.Get("fingerprints").Index(__idx4)
 		__seq_out4 = FingerprintFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -101,7 +99,7 @@ type Fingerprint struct {
 	Value string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Fingerprint) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -113,18 +111,16 @@ func (_this *Fingerprint) JSValue() js.Value {
 }
 
 // FingerprintFromJS is allocating a new
-// Fingerprint object and copy all values from
-// input javascript object
-func FingerprintFromJS(value js.Wrapper) *Fingerprint {
-	input := value.JSValue()
+// Fingerprint object and copy all values in the value javascript object.
+func FingerprintFromJS(value js.Value) *Fingerprint {
 	var out Fingerprint
 	var (
 		value0 string // javascript: USVString {type Type _type}
 		value1 string // javascript: USVString {value Value value}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -138,7 +134,7 @@ type ImageResource struct {
 	Platform string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageResource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -156,10 +152,8 @@ func (_this *ImageResource) JSValue() js.Value {
 }
 
 // ImageResourceFromJS is allocating a new
-// ImageResource object and copy all values from
-// input javascript object
-func ImageResourceFromJS(value js.Wrapper) *ImageResource {
-	input := value.JSValue()
+// ImageResource object and copy all values in the value javascript object.
+func ImageResourceFromJS(value js.Value) *ImageResource {
 	var out ImageResource
 	var (
 		value0 string // javascript: USVString {src Src src}
@@ -168,15 +162,15 @@ func ImageResourceFromJS(value js.Wrapper) *ImageResource {
 		value3 string // javascript: USVString {purpose Purpose purpose}
 		value4 string // javascript: USVString {platform Platform platform}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
-	value3 = (input.Get("purpose")).String()
+	value3 = (value.Get("purpose")).String()
 	out.Purpose = value3
-	value4 = (input.Get("platform")).String()
+	value4 = (value.Get("platform")).String()
 	out.Platform = value4
 	return &out
 }

--- a/appmanifest/appmenifestres/appmenifestres_js.go
+++ b/appmanifest/appmenifestres/appmenifestres_js.go
@@ -38,7 +38,7 @@ type ExternalApplicationResource struct {
 	Fingerprints []*Fingerprint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExternalApplicationResource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -60,10 +60,8 @@ func (_this *ExternalApplicationResource) JSValue() js.Value {
 }
 
 // ExternalApplicationResourceFromJS is allocating a new
-// ExternalApplicationResource object and copy all values from
-// input javascript object
-func ExternalApplicationResourceFromJS(value js.Wrapper) *ExternalApplicationResource {
-	input := value.JSValue()
+// ExternalApplicationResource object and copy all values in the value javascript object.
+func ExternalApplicationResourceFromJS(value js.Value) *ExternalApplicationResource {
 	var out ExternalApplicationResource
 	var (
 		value0 string         // javascript: USVString {platform Platform platform}
@@ -72,19 +70,19 @@ func ExternalApplicationResourceFromJS(value js.Wrapper) *ExternalApplicationRes
 		value3 string         // javascript: USVString {min_version MinVersion minVersion}
 		value4 []*Fingerprint // javascript: sequence<Fingerprint> {fingerprints Fingerprints fingerprints}
 	)
-	value0 = (input.Get("platform")).String()
+	value0 = (value.Get("platform")).String()
 	out.Platform = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("min_version")).String()
+	value3 = (value.Get("min_version")).String()
 	out.MinVersion = value3
-	__length4 := input.Get("fingerprints").Length()
+	__length4 := value.Get("fingerprints").Length()
 	__array4 := make([]*Fingerprint, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *Fingerprint
-		__seq_in4 := input.Get("fingerprints").Index(__idx4)
+		__seq_in4 := value.Get("fingerprints").Index(__idx4)
 		__seq_out4 = FingerprintFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -99,7 +97,7 @@ type Fingerprint struct {
 	Value string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Fingerprint) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -111,18 +109,16 @@ func (_this *Fingerprint) JSValue() js.Value {
 }
 
 // FingerprintFromJS is allocating a new
-// Fingerprint object and copy all values from
-// input javascript object
-func FingerprintFromJS(value js.Wrapper) *Fingerprint {
-	input := value.JSValue()
+// Fingerprint object and copy all values in the value javascript object.
+func FingerprintFromJS(value js.Value) *Fingerprint {
 	var out Fingerprint
 	var (
 		value0 string // javascript: USVString {type Type _type}
 		value1 string // javascript: USVString {value Value value}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -136,7 +132,7 @@ type ImageResource struct {
 	Platform string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageResource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -154,10 +150,8 @@ func (_this *ImageResource) JSValue() js.Value {
 }
 
 // ImageResourceFromJS is allocating a new
-// ImageResource object and copy all values from
-// input javascript object
-func ImageResourceFromJS(value js.Wrapper) *ImageResource {
-	input := value.JSValue()
+// ImageResource object and copy all values in the value javascript object.
+func ImageResourceFromJS(value js.Value) *ImageResource {
 	var out ImageResource
 	var (
 		value0 string // javascript: USVString {src Src src}
@@ -166,15 +160,15 @@ func ImageResourceFromJS(value js.Wrapper) *ImageResource {
 		value3 string // javascript: USVString {purpose Purpose purpose}
 		value4 string // javascript: USVString {platform Platform platform}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
-	value3 = (input.Get("purpose")).String()
+	value3 = (value.Get("purpose")).String()
 	out.Purpose = value3
-	value4 = (input.Get("platform")).String()
+	value4 = (value.Get("platform")).String()
 	out.Platform = value4
 	return &out
 }

--- a/backgroundtask/backgroundtask.go
+++ b/backgroundtask/backgroundtask.go
@@ -6,6 +6,10 @@ package backgroundtask
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -76,7 +80,7 @@ type IdleRequestOptions struct {
 	Timeout uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IdleRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -86,15 +90,13 @@ func (_this *IdleRequestOptions) JSValue() js.Value {
 }
 
 // IdleRequestOptionsFromJS is allocating a new
-// IdleRequestOptions object and copy all values from
-// input javascript object
-func IdleRequestOptionsFromJS(value js.Wrapper) *IdleRequestOptions {
-	input := value.JSValue()
+// IdleRequestOptions object and copy all values in the value javascript object.
+func IdleRequestOptionsFromJS(value js.Value) *IdleRequestOptions {
 	var out IdleRequestOptions
 	var (
 		value0 uint // javascript: unsigned long {timeout Timeout timeout}
 	)
-	value0 = (uint)((input.Get("timeout")).Int())
+	value0 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value0
 	return &out
 }
@@ -109,15 +111,19 @@ func (_this *IdleDeadline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IdleDeadlineFromJS is casting a js.Wrapper into IdleDeadline.
-func IdleDeadlineFromJS(value js.Wrapper) *IdleDeadline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IdleDeadlineFromJS is casting a js.Value into IdleDeadline.
+func IdleDeadlineFromJS(value js.Value) *IdleDeadline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IdleDeadline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IdleDeadlineFromJS is casting from something that holds a js.Value into IdleDeadline.
+func IdleDeadlineFromWrapper(input core.Wrapper) *IdleDeadline {
+	return IdleDeadlineFromJS(input.JSValue())
 }
 
 // DidTimeout returning attribute 'didTimeout' with

--- a/backgroundtask/backgroundtask_js.go
+++ b/backgroundtask/backgroundtask_js.go
@@ -4,6 +4,10 @@ package backgroundtask
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -74,7 +78,7 @@ type IdleRequestOptions struct {
 	Timeout uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IdleRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -84,15 +88,13 @@ func (_this *IdleRequestOptions) JSValue() js.Value {
 }
 
 // IdleRequestOptionsFromJS is allocating a new
-// IdleRequestOptions object and copy all values from
-// input javascript object
-func IdleRequestOptionsFromJS(value js.Wrapper) *IdleRequestOptions {
-	input := value.JSValue()
+// IdleRequestOptions object and copy all values in the value javascript object.
+func IdleRequestOptionsFromJS(value js.Value) *IdleRequestOptions {
 	var out IdleRequestOptions
 	var (
 		value0 uint // javascript: unsigned long {timeout Timeout timeout}
 	)
-	value0 = (uint)((input.Get("timeout")).Int())
+	value0 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value0
 	return &out
 }
@@ -107,15 +109,19 @@ func (_this *IdleDeadline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IdleDeadlineFromJS is casting a js.Wrapper into IdleDeadline.
-func IdleDeadlineFromJS(value js.Wrapper) *IdleDeadline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IdleDeadlineFromJS is casting a js.Value into IdleDeadline.
+func IdleDeadlineFromJS(value js.Value) *IdleDeadline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IdleDeadline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IdleDeadlineFromJS is casting from something that holds a js.Value into IdleDeadline.
+func IdleDeadlineFromWrapper(input core.Wrapper) *IdleDeadline {
+	return IdleDeadlineFromJS(input.JSValue())
 }
 
 // DidTimeout returning attribute 'didTimeout' with

--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -7,6 +7,7 @@ package clipboard
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/datatransfer"
 	"github.com/gowebapi/webapi/javascript"
@@ -51,7 +52,7 @@ type ClipboardEventInit struct {
 	ClipboardData *datatransfer.DataTransfer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClipboardEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -67,10 +68,8 @@ func (_this *ClipboardEventInit) JSValue() js.Value {
 }
 
 // ClipboardEventInitFromJS is allocating a new
-// ClipboardEventInit object and copy all values from
-// input javascript object
-func ClipboardEventInitFromJS(value js.Wrapper) *ClipboardEventInit {
-	input := value.JSValue()
+// ClipboardEventInit object and copy all values in the value javascript object.
+func ClipboardEventInitFromJS(value js.Value) *ClipboardEventInit {
 	var out ClipboardEventInit
 	var (
 		value0 bool                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -78,14 +77,14 @@ func ClipboardEventInitFromJS(value js.Wrapper) *ClipboardEventInit {
 		value2 bool                       // javascript: boolean {composed Composed composed}
 		value3 *datatransfer.DataTransfer // javascript: DataTransfer {clipboardData ClipboardData clipboardData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("clipboardData").Type() != js.TypeNull && input.Get("clipboardData").Type() != js.TypeUndefined {
-		value3 = datatransfer.DataTransferFromJS(input.Get("clipboardData"))
+	if value.Get("clipboardData").Type() != js.TypeNull && value.Get("clipboardData").Type() != js.TypeUndefined {
+		value3 = datatransfer.DataTransferFromJS(value.Get("clipboardData"))
 	}
 	out.ClipboardData = value3
 	return &out
@@ -97,7 +96,7 @@ type ClipboardPermissionDescriptor struct {
 	AllowWithoutGesture bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClipboardPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -109,18 +108,16 @@ func (_this *ClipboardPermissionDescriptor) JSValue() js.Value {
 }
 
 // ClipboardPermissionDescriptorFromJS is allocating a new
-// ClipboardPermissionDescriptor object and copy all values from
-// input javascript object
-func ClipboardPermissionDescriptorFromJS(value js.Wrapper) *ClipboardPermissionDescriptor {
-	input := value.JSValue()
+// ClipboardPermissionDescriptor object and copy all values in the value javascript object.
+func ClipboardPermissionDescriptorFromJS(value js.Value) *ClipboardPermissionDescriptor {
 	var out ClipboardPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {allowWithoutGesture AllowWithoutGesture allowWithoutGesture}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("allowWithoutGesture")).Bool()
+	value1 = (value.Get("allowWithoutGesture")).Bool()
 	out.AllowWithoutGesture = value1
 	return &out
 }
@@ -130,15 +127,19 @@ type Clipboard struct {
 	domcore.EventTarget
 }
 
-// ClipboardFromJS is casting a js.Wrapper into Clipboard.
-func ClipboardFromJS(value js.Wrapper) *Clipboard {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClipboardFromJS is casting a js.Value into Clipboard.
+func ClipboardFromJS(value js.Value) *Clipboard {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Clipboard{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClipboardFromJS is casting from something that holds a js.Value into Clipboard.
+func ClipboardFromWrapper(input core.Wrapper) *Clipboard {
+	return ClipboardFromJS(input.JSValue())
 }
 
 func (_this *Clipboard) Read() (_result *datatransfer.PromiseDataTransfer) {
@@ -208,15 +209,19 @@ type ClipboardEvent struct {
 	domcore.Event
 }
 
-// ClipboardEventFromJS is casting a js.Wrapper into ClipboardEvent.
-func ClipboardEventFromJS(value js.Wrapper) *ClipboardEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClipboardEventFromJS is casting a js.Value into ClipboardEvent.
+func ClipboardEventFromJS(value js.Value) *ClipboardEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ClipboardEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClipboardEventFromJS is casting from something that holds a js.Value into ClipboardEvent.
+func ClipboardEventFromWrapper(input core.Wrapper) *ClipboardEvent {
+	return ClipboardEventFromJS(input.JSValue())
 }
 
 func NewClipboardEvent(_type string, eventInitDict *ClipboardEventInit) (_result *ClipboardEvent) {

--- a/clipboard/clipboard_js.go
+++ b/clipboard/clipboard_js.go
@@ -5,6 +5,7 @@ package clipboard
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/datatransfer"
 	"github.com/gowebapi/webapi/javascript"
@@ -49,7 +50,7 @@ type ClipboardEventInit struct {
 	ClipboardData *datatransfer.DataTransfer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClipboardEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -65,10 +66,8 @@ func (_this *ClipboardEventInit) JSValue() js.Value {
 }
 
 // ClipboardEventInitFromJS is allocating a new
-// ClipboardEventInit object and copy all values from
-// input javascript object
-func ClipboardEventInitFromJS(value js.Wrapper) *ClipboardEventInit {
-	input := value.JSValue()
+// ClipboardEventInit object and copy all values in the value javascript object.
+func ClipboardEventInitFromJS(value js.Value) *ClipboardEventInit {
 	var out ClipboardEventInit
 	var (
 		value0 bool                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -76,14 +75,14 @@ func ClipboardEventInitFromJS(value js.Wrapper) *ClipboardEventInit {
 		value2 bool                       // javascript: boolean {composed Composed composed}
 		value3 *datatransfer.DataTransfer // javascript: DataTransfer {clipboardData ClipboardData clipboardData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("clipboardData").Type() != js.TypeNull && input.Get("clipboardData").Type() != js.TypeUndefined {
-		value3 = datatransfer.DataTransferFromJS(input.Get("clipboardData"))
+	if value.Get("clipboardData").Type() != js.TypeNull && value.Get("clipboardData").Type() != js.TypeUndefined {
+		value3 = datatransfer.DataTransferFromJS(value.Get("clipboardData"))
 	}
 	out.ClipboardData = value3
 	return &out
@@ -95,7 +94,7 @@ type ClipboardPermissionDescriptor struct {
 	AllowWithoutGesture bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClipboardPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -107,18 +106,16 @@ func (_this *ClipboardPermissionDescriptor) JSValue() js.Value {
 }
 
 // ClipboardPermissionDescriptorFromJS is allocating a new
-// ClipboardPermissionDescriptor object and copy all values from
-// input javascript object
-func ClipboardPermissionDescriptorFromJS(value js.Wrapper) *ClipboardPermissionDescriptor {
-	input := value.JSValue()
+// ClipboardPermissionDescriptor object and copy all values in the value javascript object.
+func ClipboardPermissionDescriptorFromJS(value js.Value) *ClipboardPermissionDescriptor {
 	var out ClipboardPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {allowWithoutGesture AllowWithoutGesture allowWithoutGesture}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("allowWithoutGesture")).Bool()
+	value1 = (value.Get("allowWithoutGesture")).Bool()
 	out.AllowWithoutGesture = value1
 	return &out
 }
@@ -128,15 +125,19 @@ type Clipboard struct {
 	domcore.EventTarget
 }
 
-// ClipboardFromJS is casting a js.Wrapper into Clipboard.
-func ClipboardFromJS(value js.Wrapper) *Clipboard {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClipboardFromJS is casting a js.Value into Clipboard.
+func ClipboardFromJS(value js.Value) *Clipboard {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Clipboard{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClipboardFromJS is casting from something that holds a js.Value into Clipboard.
+func ClipboardFromWrapper(input core.Wrapper) *Clipboard {
+	return ClipboardFromJS(input.JSValue())
 }
 
 func (_this *Clipboard) Read() (_result *datatransfer.PromiseDataTransfer) {
@@ -206,15 +207,19 @@ type ClipboardEvent struct {
 	domcore.Event
 }
 
-// ClipboardEventFromJS is casting a js.Wrapper into ClipboardEvent.
-func ClipboardEventFromJS(value js.Wrapper) *ClipboardEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClipboardEventFromJS is casting a js.Value into ClipboardEvent.
+func ClipboardEventFromJS(value js.Value) *ClipboardEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ClipboardEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClipboardEventFromJS is casting from something that holds a js.Value into ClipboardEvent.
+func ClipboardEventFromWrapper(input core.Wrapper) *ClipboardEvent {
+	return ClipboardEventFromJS(input.JSValue())
 }
 
 func NewClipboardEvent(_type string, eventInitDict *ClipboardEventInit) (_result *ClipboardEvent) {

--- a/communication/bluetooth/bluetooth.go
+++ b/communication/bluetooth/bluetooth.go
@@ -7,6 +7,7 @@ package bluetooth
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/permissions"
 	"github.com/gowebapi/webapi/javascript"
@@ -841,7 +842,7 @@ type AdvertisingEventInit struct {
 	ServiceData      *ServiceDataMap
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AdvertisingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -875,10 +876,8 @@ func (_this *AdvertisingEventInit) JSValue() js.Value {
 }
 
 // AdvertisingEventInitFromJS is allocating a new
-// AdvertisingEventInit object and copy all values from
-// input javascript object
-func AdvertisingEventInitFromJS(value js.Wrapper) *AdvertisingEventInit {
-	input := value.JSValue()
+// AdvertisingEventInit object and copy all values in the value javascript object.
+func AdvertisingEventInitFromJS(value js.Value) *AdvertisingEventInit {
 	var out AdvertisingEventInit
 	var (
 		value0  bool                 // javascript: boolean {bubbles Bubbles bubbles}
@@ -893,35 +892,35 @@ func AdvertisingEventInitFromJS(value js.Wrapper) *AdvertisingEventInit {
 		value9  *ManufacturerDataMap // javascript: BluetoothManufacturerDataMap {manufacturerData ManufacturerData manufacturerData}
 		value10 *ServiceDataMap      // javascript: BluetoothServiceDataMap {serviceData ServiceData serviceData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DeviceFromJS(input.Get("device"))
+	value3 = DeviceFromJS(value.Get("device"))
 	out.Device = value3
-	__length4 := input.Get("uuids").Length()
+	__length4 := value.Get("uuids").Length()
 	__array4 := make([]*Union, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *Union
-		__seq_in4 := input.Get("uuids").Index(__idx4)
+		__seq_in4 := value.Get("uuids").Index(__idx4)
 		__seq_out4 = UnionFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Uuids = value4
-	value5 = (input.Get("name")).String()
+	value5 = (value.Get("name")).String()
 	out.Name = value5
-	value6 = (input.Get("appearance")).Int()
+	value6 = (value.Get("appearance")).Int()
 	out.Appearance = value6
-	value7 = (input.Get("txPower")).Int()
+	value7 = (value.Get("txPower")).Int()
 	out.TxPower = value7
-	value8 = (input.Get("rssi")).Int()
+	value8 = (value.Get("rssi")).Int()
 	out.Rssi = value8
-	value9 = ManufacturerDataMapFromJS(input.Get("manufacturerData"))
+	value9 = ManufacturerDataMapFromJS(value.Get("manufacturerData"))
 	out.ManufacturerData = value9
-	value10 = ServiceDataMapFromJS(input.Get("serviceData"))
+	value10 = ServiceDataMapFromJS(value.Get("serviceData"))
 	out.ServiceData = value10
 	return &out
 }
@@ -933,7 +932,7 @@ type AllowedDevice struct {
 	AllowedServices *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AllowedDevice) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -947,21 +946,19 @@ func (_this *AllowedDevice) JSValue() js.Value {
 }
 
 // AllowedDeviceFromJS is allocating a new
-// AllowedDevice object and copy all values from
-// input javascript object
-func AllowedDeviceFromJS(value js.Wrapper) *AllowedDevice {
-	input := value.JSValue()
+// AllowedDevice object and copy all values in the value javascript object.
+func AllowedDeviceFromJS(value js.Value) *AllowedDevice {
 	var out AllowedDevice
 	var (
 		value0 string // javascript: DOMString {deviceId DeviceId deviceId}
 		value1 bool   // javascript: boolean {mayUseGATT MayUseGATT mayUseGATT}
 		value2 *Union // javascript: Union {allowedServices AllowedServices allowedServices}
 	)
-	value0 = (input.Get("deviceId")).String()
+	value0 = (value.Get("deviceId")).String()
 	out.DeviceId = value0
-	value1 = (input.Get("mayUseGATT")).Bool()
+	value1 = (value.Get("mayUseGATT")).Bool()
 	out.MayUseGATT = value1
-	value2 = UnionFromJS(input.Get("allowedServices"))
+	value2 = UnionFromJS(value.Get("allowedServices"))
 	out.AllowedServices = value2
 	return &out
 }
@@ -972,7 +969,7 @@ type DataFilterInit struct {
 	Mask       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataFilterInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -984,18 +981,16 @@ func (_this *DataFilterInit) JSValue() js.Value {
 }
 
 // DataFilterInitFromJS is allocating a new
-// DataFilterInit object and copy all values from
-// input javascript object
-func DataFilterInitFromJS(value js.Wrapper) *DataFilterInit {
-	input := value.JSValue()
+// DataFilterInit object and copy all values in the value javascript object.
+func DataFilterInitFromJS(value js.Value) *DataFilterInit {
 	var out DataFilterInit
 	var (
 		value0 *Union // javascript: Union {dataPrefix DataPrefix dataPrefix}
 		value1 *Union // javascript: Union {mask Mask mask}
 	)
-	value0 = UnionFromJS(input.Get("dataPrefix"))
+	value0 = UnionFromJS(value.Get("dataPrefix"))
 	out.DataPrefix = value0
-	value1 = UnionFromJS(input.Get("mask"))
+	value1 = UnionFromJS(value.Get("mask"))
 	out.Mask = value1
 	return &out
 }
@@ -1009,7 +1004,7 @@ type LEScanFilterInit struct {
 	ServiceData      *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LEScanFilterInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1031,10 +1026,8 @@ func (_this *LEScanFilterInit) JSValue() js.Value {
 }
 
 // LEScanFilterInitFromJS is allocating a new
-// LEScanFilterInit object and copy all values from
-// input javascript object
-func LEScanFilterInitFromJS(value js.Wrapper) *LEScanFilterInit {
-	input := value.JSValue()
+// LEScanFilterInit object and copy all values in the value javascript object.
+func LEScanFilterInitFromJS(value js.Value) *LEScanFilterInit {
 	var out LEScanFilterInit
 	var (
 		value0 []*Union           // javascript: sequence<Union> {services Services services}
@@ -1043,23 +1036,23 @@ func LEScanFilterInitFromJS(value js.Wrapper) *LEScanFilterInit {
 		value3 *javascript.Object // javascript: object {manufacturerData ManufacturerData manufacturerData}
 		value4 *javascript.Object // javascript: object {serviceData ServiceData serviceData}
 	)
-	__length0 := input.Get("services").Length()
+	__length0 := value.Get("services").Length()
 	__array0 := make([]*Union, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *Union
-		__seq_in0 := input.Get("services").Index(__idx0)
+		__seq_in0 := value.Get("services").Index(__idx0)
 		__seq_out0 = UnionFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Services = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("namePrefix")).String()
+	value2 = (value.Get("namePrefix")).String()
 	out.NamePrefix = value2
-	value3 = javascript.ObjectFromJS(input.Get("manufacturerData"))
+	value3 = javascript.ObjectFromJS(value.Get("manufacturerData"))
 	out.ManufacturerData = value3
-	value4 = javascript.ObjectFromJS(input.Get("serviceData"))
+	value4 = javascript.ObjectFromJS(value.Get("serviceData"))
 	out.ServiceData = value4
 	return &out
 }
@@ -1070,7 +1063,7 @@ type ManufacturerDataMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1086,26 +1079,24 @@ func (_this *ManufacturerDataMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapEntryIteratorValueFromJS is allocating a new
-// ManufacturerDataMapEntryIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapEntryIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapEntryIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapEntryIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapEntryIteratorValueFromJS(value js.Value) *ManufacturerDataMapEntryIteratorValue {
 	var out ManufacturerDataMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1116,7 +1107,7 @@ type ManufacturerDataMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1128,18 +1119,16 @@ func (_this *ManufacturerDataMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapKeyIteratorValueFromJS is allocating a new
-// ManufacturerDataMapKeyIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapKeyIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapKeyIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapKeyIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapKeyIteratorValueFromJS(value js.Value) *ManufacturerDataMapKeyIteratorValue {
 	var out ManufacturerDataMapKeyIteratorValue
 	var (
 		value0 int  // javascript: unsigned short {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).Int()
+	value0 = (value.Get("value")).Int()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1150,7 +1139,7 @@ type ManufacturerDataMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1162,18 +1151,16 @@ func (_this *ManufacturerDataMapValueIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapValueIteratorValueFromJS is allocating a new
-// ManufacturerDataMapValueIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapValueIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapValueIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapValueIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapValueIteratorValueFromJS(value js.Value) *ManufacturerDataMapValueIteratorValue {
 	var out ManufacturerDataMapValueIteratorValue
 	var (
 		value0 *javascript.DataView // javascript: DataView {value Value value}
 		value1 bool                 // javascript: boolean {done Done done}
 	)
-	value0 = javascript.DataViewFromJS(input.Get("value"))
+	value0 = javascript.DataViewFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1183,7 +1170,7 @@ type PermissionData struct {
 	AllowedDevices []*AllowedDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1197,19 +1184,17 @@ func (_this *PermissionData) JSValue() js.Value {
 }
 
 // PermissionDataFromJS is allocating a new
-// PermissionData object and copy all values from
-// input javascript object
-func PermissionDataFromJS(value js.Wrapper) *PermissionData {
-	input := value.JSValue()
+// PermissionData object and copy all values in the value javascript object.
+func PermissionDataFromJS(value js.Value) *PermissionData {
 	var out PermissionData
 	var (
 		value0 []*AllowedDevice // javascript: sequence<AllowedBluetoothDevice> {allowedDevices AllowedDevices allowedDevices}
 	)
-	__length0 := input.Get("allowedDevices").Length()
+	__length0 := value.Get("allowedDevices").Length()
 	__array0 := make([]*AllowedDevice, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *AllowedDevice
-		__seq_in0 := input.Get("allowedDevices").Index(__idx0)
+		__seq_in0 := value.Get("allowedDevices").Index(__idx0)
 		__seq_out0 = AllowedDeviceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -1227,7 +1212,7 @@ type PermissionDescriptor struct {
 	AcceptAllDevices bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1253,10 +1238,8 @@ func (_this *PermissionDescriptor) JSValue() js.Value {
 }
 
 // PermissionDescriptorFromJS is allocating a new
-// PermissionDescriptor object and copy all values from
-// input javascript object
-func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
-	input := value.JSValue()
+// PermissionDescriptor object and copy all values in the value javascript object.
+func PermissionDescriptorFromJS(value js.Value) *PermissionDescriptor {
 	var out PermissionDescriptor
 	var (
 		value0 string              // javascript: DOMString {name Name name}
@@ -1265,31 +1248,31 @@ func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
 		value3 []*Union            // javascript: sequence<Union> {optionalServices OptionalServices optionalServices}
 		value4 bool                // javascript: boolean {acceptAllDevices AcceptAllDevices acceptAllDevices}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("deviceId")).String()
+	value1 = (value.Get("deviceId")).String()
 	out.DeviceId = value1
-	__length2 := input.Get("filters").Length()
+	__length2 := value.Get("filters").Length()
 	__array2 := make([]*LEScanFilterInit, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *LEScanFilterInit
-		__seq_in2 := input.Get("filters").Index(__idx2)
+		__seq_in2 := value.Get("filters").Index(__idx2)
 		__seq_out2 = LEScanFilterInitFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Filters = value2
-	__length3 := input.Get("optionalServices").Length()
+	__length3 := value.Get("optionalServices").Length()
 	__array3 := make([]*Union, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *Union
-		__seq_in3 := input.Get("optionalServices").Index(__idx3)
+		__seq_in3 := value.Get("optionalServices").Index(__idx3)
 		__seq_out3 = UnionFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.OptionalServices = value3
-	value4 = (input.Get("acceptAllDevices")).Bool()
+	value4 = (value.Get("acceptAllDevices")).Bool()
 	out.AcceptAllDevices = value4
 	return &out
 }
@@ -1301,7 +1284,7 @@ type RequestDeviceOptions struct {
 	AcceptAllDevices bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RequestDeviceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1323,37 +1306,35 @@ func (_this *RequestDeviceOptions) JSValue() js.Value {
 }
 
 // RequestDeviceOptionsFromJS is allocating a new
-// RequestDeviceOptions object and copy all values from
-// input javascript object
-func RequestDeviceOptionsFromJS(value js.Wrapper) *RequestDeviceOptions {
-	input := value.JSValue()
+// RequestDeviceOptions object and copy all values in the value javascript object.
+func RequestDeviceOptionsFromJS(value js.Value) *RequestDeviceOptions {
 	var out RequestDeviceOptions
 	var (
 		value0 []*LEScanFilterInit // javascript: sequence<BluetoothLEScanFilterInit> {filters Filters filters}
 		value1 []*Union            // javascript: sequence<Union> {optionalServices OptionalServices optionalServices}
 		value2 bool                // javascript: boolean {acceptAllDevices AcceptAllDevices acceptAllDevices}
 	)
-	__length0 := input.Get("filters").Length()
+	__length0 := value.Get("filters").Length()
 	__array0 := make([]*LEScanFilterInit, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *LEScanFilterInit
-		__seq_in0 := input.Get("filters").Index(__idx0)
+		__seq_in0 := value.Get("filters").Index(__idx0)
 		__seq_out0 = LEScanFilterInitFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Filters = value0
-	__length1 := input.Get("optionalServices").Length()
+	__length1 := value.Get("optionalServices").Length()
 	__array1 := make([]*Union, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *Union
-		__seq_in1 := input.Get("optionalServices").Index(__idx1)
+		__seq_in1 := value.Get("optionalServices").Index(__idx1)
 		__seq_out1 = UnionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.OptionalServices = value1
-	value2 = (input.Get("acceptAllDevices")).Bool()
+	value2 = (value.Get("acceptAllDevices")).Bool()
 	out.AcceptAllDevices = value2
 	return &out
 }
@@ -1364,7 +1345,7 @@ type ServiceDataMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1380,26 +1361,24 @@ func (_this *ServiceDataMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapEntryIteratorValueFromJS is allocating a new
-// ServiceDataMapEntryIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapEntryIteratorValueFromJS(value js.Wrapper) *ServiceDataMapEntryIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapEntryIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapEntryIteratorValueFromJS(value js.Value) *ServiceDataMapEntryIteratorValue {
 	var out ServiceDataMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1410,7 +1389,7 @@ type ServiceDataMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1422,18 +1401,16 @@ func (_this *ServiceDataMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapKeyIteratorValueFromJS is allocating a new
-// ServiceDataMapKeyIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapKeyIteratorValueFromJS(value js.Wrapper) *ServiceDataMapKeyIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapKeyIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapKeyIteratorValueFromJS(value js.Value) *ServiceDataMapKeyIteratorValue {
 	var out ServiceDataMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1444,7 +1421,7 @@ type ServiceDataMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1456,18 +1433,16 @@ func (_this *ServiceDataMapValueIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapValueIteratorValueFromJS is allocating a new
-// ServiceDataMapValueIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapValueIteratorValueFromJS(value js.Wrapper) *ServiceDataMapValueIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapValueIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapValueIteratorValueFromJS(value js.Value) *ServiceDataMapValueIteratorValue {
 	var out ServiceDataMapValueIteratorValue
 	var (
 		value0 *javascript.DataView // javascript: DataView {value Value value}
 		value1 bool                 // javascript: boolean {done Done done}
 	)
-	value0 = javascript.DataViewFromJS(input.Get("value"))
+	value0 = javascript.DataViewFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1480,7 +1455,7 @@ type ValueEventInit struct {
 	Value      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ValueEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1496,10 +1471,8 @@ func (_this *ValueEventInit) JSValue() js.Value {
 }
 
 // ValueEventInitFromJS is allocating a new
-// ValueEventInit object and copy all values from
-// input javascript object
-func ValueEventInitFromJS(value js.Wrapper) *ValueEventInit {
-	input := value.JSValue()
+// ValueEventInit object and copy all values in the value javascript object.
+func ValueEventInitFromJS(value js.Value) *ValueEventInit {
 	var out ValueEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1507,13 +1480,13 @@ func ValueEventInitFromJS(value js.Wrapper) *ValueEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {value Value value}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("value")
+	value3 = value.Get("value")
 	out.Value = value3
 	return &out
 }
@@ -1523,15 +1496,19 @@ type AdvertisingEvent struct {
 	domcore.Event
 }
 
-// AdvertisingEventFromJS is casting a js.Wrapper into AdvertisingEvent.
-func AdvertisingEventFromJS(value js.Wrapper) *AdvertisingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AdvertisingEventFromJS is casting a js.Value into AdvertisingEvent.
+func AdvertisingEventFromJS(value js.Value) *AdvertisingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AdvertisingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AdvertisingEventFromJS is casting from something that holds a js.Value into AdvertisingEvent.
+func AdvertisingEventFromWrapper(input core.Wrapper) *AdvertisingEvent {
+	return AdvertisingEventFromJS(input.JSValue())
 }
 
 func NewBluetoothAdvertisingEvent(_type string, init *AdvertisingEventInit) (_result *AdvertisingEvent) {
@@ -1644,15 +1621,19 @@ type Bluetooth struct {
 	domcore.EventTarget
 }
 
-// BluetoothFromJS is casting a js.Wrapper into Bluetooth.
-func BluetoothFromJS(value js.Wrapper) *Bluetooth {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BluetoothFromJS is casting a js.Value into Bluetooth.
+func BluetoothFromJS(value js.Value) *Bluetooth {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Bluetooth{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BluetoothFromJS is casting from something that holds a js.Value into Bluetooth.
+func BluetoothFromWrapper(input core.Wrapper) *Bluetooth {
+	return BluetoothFromJS(input.JSValue())
 }
 
 // OnAvailabilityChanged returning attribute 'onavailabilitychanged' with
@@ -1940,15 +1921,19 @@ func (_this *CharacteristicProperties) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CharacteristicPropertiesFromJS is casting a js.Wrapper into CharacteristicProperties.
-func CharacteristicPropertiesFromJS(value js.Wrapper) *CharacteristicProperties {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CharacteristicPropertiesFromJS is casting a js.Value into CharacteristicProperties.
+func CharacteristicPropertiesFromJS(value js.Value) *CharacteristicProperties {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CharacteristicProperties{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CharacteristicPropertiesFromJS is casting from something that holds a js.Value into CharacteristicProperties.
+func CharacteristicPropertiesFromWrapper(input core.Wrapper) *CharacteristicProperties {
+	return CharacteristicPropertiesFromJS(input.JSValue())
 }
 
 // Broadcast returning attribute 'broadcast' with
@@ -2037,15 +2022,19 @@ type Device struct {
 	domcore.EventTarget
 }
 
-// DeviceFromJS is casting a js.Wrapper into Device.
-func DeviceFromJS(value js.Wrapper) *Device {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceFromJS is casting a js.Value into Device.
+func DeviceFromJS(value js.Value) *Device {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Device{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceFromJS is casting from something that holds a js.Value into Device.
+func DeviceFromWrapper(input core.Wrapper) *Device {
+	return DeviceFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -2312,15 +2301,19 @@ func (_this *ManufacturerDataMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapFromJS is casting a js.Wrapper into ManufacturerDataMap.
-func ManufacturerDataMapFromJS(value js.Wrapper) *ManufacturerDataMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapFromJS is casting a js.Value into ManufacturerDataMap.
+func ManufacturerDataMapFromJS(value js.Value) *ManufacturerDataMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapFromJS is casting from something that holds a js.Value into ManufacturerDataMap.
+func ManufacturerDataMapFromWrapper(input core.Wrapper) *ManufacturerDataMap {
+	return ManufacturerDataMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -2444,15 +2437,19 @@ func (_this *ManufacturerDataMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapEntryIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapEntryIterator.
-func ManufacturerDataMapEntryIteratorFromJS(value js.Wrapper) *ManufacturerDataMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapEntryIteratorFromJS is casting a js.Value into ManufacturerDataMapEntryIterator.
+func ManufacturerDataMapEntryIteratorFromJS(value js.Value) *ManufacturerDataMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapEntryIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapEntryIterator.
+func ManufacturerDataMapEntryIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapEntryIterator {
+	return ManufacturerDataMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapEntryIterator) Next() (_result *ManufacturerDataMapEntryIteratorValue) {
@@ -2479,15 +2476,19 @@ func (_this *ManufacturerDataMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapKeyIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapKeyIterator.
-func ManufacturerDataMapKeyIteratorFromJS(value js.Wrapper) *ManufacturerDataMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapKeyIteratorFromJS is casting a js.Value into ManufacturerDataMapKeyIterator.
+func ManufacturerDataMapKeyIteratorFromJS(value js.Value) *ManufacturerDataMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapKeyIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapKeyIterator.
+func ManufacturerDataMapKeyIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapKeyIterator {
+	return ManufacturerDataMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapKeyIterator) Next() (_result *ManufacturerDataMapKeyIteratorValue) {
@@ -2514,15 +2515,19 @@ func (_this *ManufacturerDataMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapValueIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapValueIterator.
-func ManufacturerDataMapValueIteratorFromJS(value js.Wrapper) *ManufacturerDataMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapValueIteratorFromJS is casting a js.Value into ManufacturerDataMapValueIterator.
+func ManufacturerDataMapValueIteratorFromJS(value js.Value) *ManufacturerDataMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapValueIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapValueIterator.
+func ManufacturerDataMapValueIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapValueIterator {
+	return ManufacturerDataMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapValueIterator) Next() (_result *ManufacturerDataMapValueIteratorValue) {
@@ -2544,15 +2549,19 @@ type PermissionResult struct {
 	permissions.PermissionStatus
 }
 
-// PermissionResultFromJS is casting a js.Wrapper into PermissionResult.
-func PermissionResultFromJS(value js.Wrapper) *PermissionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionResultFromJS is casting a js.Value into PermissionResult.
+func PermissionResultFromJS(value js.Value) *PermissionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PermissionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionResultFromJS is casting from something that holds a js.Value into PermissionResult.
+func PermissionResultFromWrapper(input core.Wrapper) *PermissionResult {
+	return PermissionResultFromJS(input.JSValue())
 }
 
 // Devices returning attribute 'devices' with
@@ -2581,15 +2590,19 @@ func (_this *PromiseDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDeviceFromJS is casting a js.Wrapper into PromiseDevice.
-func PromiseDeviceFromJS(value js.Wrapper) *PromiseDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDeviceFromJS is casting a js.Value into PromiseDevice.
+func PromiseDeviceFromJS(value js.Value) *PromiseDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDeviceFromJS is casting from something that holds a js.Value into PromiseDevice.
+func PromiseDeviceFromWrapper(input core.Wrapper) *PromiseDevice {
+	return PromiseDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseDevice) Then(onFulfilled *PromiseDeviceOnFulfilled, onRejected *PromiseDeviceOnRejected) (_result *PromiseDevice) {
@@ -2686,15 +2699,19 @@ func (_this *PromiseRemoteGATTCharacteristic) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTCharacteristicFromJS is casting a js.Wrapper into PromiseRemoteGATTCharacteristic.
-func PromiseRemoteGATTCharacteristicFromJS(value js.Wrapper) *PromiseRemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTCharacteristicFromJS is casting a js.Value into PromiseRemoteGATTCharacteristic.
+func PromiseRemoteGATTCharacteristicFromJS(value js.Value) *PromiseRemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into PromiseRemoteGATTCharacteristic.
+func PromiseRemoteGATTCharacteristicFromWrapper(input core.Wrapper) *PromiseRemoteGATTCharacteristic {
+	return PromiseRemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTCharacteristic) Then(onFulfilled *PromiseRemoteGATTCharacteristicOnFulfilled, onRejected *PromiseRemoteGATTCharacteristicOnRejected) (_result *PromiseRemoteGATTCharacteristic) {
@@ -2791,15 +2808,19 @@ func (_this *PromiseRemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTDescriptorFromJS is casting a js.Wrapper into PromiseRemoteGATTDescriptor.
-func PromiseRemoteGATTDescriptorFromJS(value js.Wrapper) *PromiseRemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTDescriptorFromJS is casting a js.Value into PromiseRemoteGATTDescriptor.
+func PromiseRemoteGATTDescriptorFromJS(value js.Value) *PromiseRemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTDescriptorFromJS is casting from something that holds a js.Value into PromiseRemoteGATTDescriptor.
+func PromiseRemoteGATTDescriptorFromWrapper(input core.Wrapper) *PromiseRemoteGATTDescriptor {
+	return PromiseRemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTDescriptor) Then(onFulfilled *PromiseRemoteGATTDescriptorOnFulfilled, onRejected *PromiseRemoteGATTDescriptorOnRejected) (_result *PromiseRemoteGATTDescriptor) {
@@ -2896,15 +2917,19 @@ func (_this *PromiseRemoteGATTServer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTServerFromJS is casting a js.Wrapper into PromiseRemoteGATTServer.
-func PromiseRemoteGATTServerFromJS(value js.Wrapper) *PromiseRemoteGATTServer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTServerFromJS is casting a js.Value into PromiseRemoteGATTServer.
+func PromiseRemoteGATTServerFromJS(value js.Value) *PromiseRemoteGATTServer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTServer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTServerFromJS is casting from something that holds a js.Value into PromiseRemoteGATTServer.
+func PromiseRemoteGATTServerFromWrapper(input core.Wrapper) *PromiseRemoteGATTServer {
+	return PromiseRemoteGATTServerFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTServer) Then(onFulfilled *PromiseRemoteGATTServerOnFulfilled, onRejected *PromiseRemoteGATTServerOnRejected) (_result *PromiseRemoteGATTServer) {
@@ -3001,15 +3026,19 @@ func (_this *PromiseRemoteGATTService) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTServiceFromJS is casting a js.Wrapper into PromiseRemoteGATTService.
-func PromiseRemoteGATTServiceFromJS(value js.Wrapper) *PromiseRemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTServiceFromJS is casting a js.Value into PromiseRemoteGATTService.
+func PromiseRemoteGATTServiceFromJS(value js.Value) *PromiseRemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTServiceFromJS is casting from something that holds a js.Value into PromiseRemoteGATTService.
+func PromiseRemoteGATTServiceFromWrapper(input core.Wrapper) *PromiseRemoteGATTService {
+	return PromiseRemoteGATTServiceFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTService) Then(onFulfilled *PromiseRemoteGATTServiceOnFulfilled, onRejected *PromiseRemoteGATTServiceOnRejected) (_result *PromiseRemoteGATTService) {
@@ -3106,15 +3135,19 @@ func (_this *PromiseSequenceRemoteGATTCharacteristic) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTCharacteristicFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTCharacteristic.
-func PromiseSequenceRemoteGATTCharacteristicFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTCharacteristicFromJS is casting a js.Value into PromiseSequenceRemoteGATTCharacteristic.
+func PromiseSequenceRemoteGATTCharacteristicFromJS(value js.Value) *PromiseSequenceRemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTCharacteristic.
+func PromiseSequenceRemoteGATTCharacteristicFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTCharacteristic {
+	return PromiseSequenceRemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTCharacteristic) Then(onFulfilled *PromiseSequenceRemoteGATTCharacteristicOnFulfilled, onRejected *PromiseSequenceRemoteGATTCharacteristicOnRejected) (_result *PromiseSequenceRemoteGATTCharacteristic) {
@@ -3211,15 +3244,19 @@ func (_this *PromiseSequenceRemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTDescriptorFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTDescriptor.
-func PromiseSequenceRemoteGATTDescriptorFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTDescriptorFromJS is casting a js.Value into PromiseSequenceRemoteGATTDescriptor.
+func PromiseSequenceRemoteGATTDescriptorFromJS(value js.Value) *PromiseSequenceRemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTDescriptorFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTDescriptor.
+func PromiseSequenceRemoteGATTDescriptorFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTDescriptor {
+	return PromiseSequenceRemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTDescriptor) Then(onFulfilled *PromiseSequenceRemoteGATTDescriptorOnFulfilled, onRejected *PromiseSequenceRemoteGATTDescriptorOnRejected) (_result *PromiseSequenceRemoteGATTDescriptor) {
@@ -3316,15 +3353,19 @@ func (_this *PromiseSequenceRemoteGATTService) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTServiceFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTService.
-func PromiseSequenceRemoteGATTServiceFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTServiceFromJS is casting a js.Value into PromiseSequenceRemoteGATTService.
+func PromiseSequenceRemoteGATTServiceFromJS(value js.Value) *PromiseSequenceRemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTServiceFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTService.
+func PromiseSequenceRemoteGATTServiceFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTService {
+	return PromiseSequenceRemoteGATTServiceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTService) Then(onFulfilled *PromiseSequenceRemoteGATTServiceOnFulfilled, onRejected *PromiseSequenceRemoteGATTServiceOnRejected) (_result *PromiseSequenceRemoteGATTService) {
@@ -3416,15 +3457,19 @@ type RemoteGATTCharacteristic struct {
 	domcore.EventTarget
 }
 
-// RemoteGATTCharacteristicFromJS is casting a js.Wrapper into RemoteGATTCharacteristic.
-func RemoteGATTCharacteristicFromJS(value js.Wrapper) *RemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTCharacteristicFromJS is casting a js.Value into RemoteGATTCharacteristic.
+func RemoteGATTCharacteristicFromJS(value js.Value) *RemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into RemoteGATTCharacteristic.
+func RemoteGATTCharacteristicFromWrapper(input core.Wrapper) *RemoteGATTCharacteristic {
+	return RemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 // Service returning attribute 'service' with
@@ -3611,15 +3656,19 @@ func (_this *RemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RemoteGATTDescriptorFromJS is casting a js.Wrapper into RemoteGATTDescriptor.
-func RemoteGATTDescriptorFromJS(value js.Wrapper) *RemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTDescriptorFromJS is casting a js.Value into RemoteGATTDescriptor.
+func RemoteGATTDescriptorFromJS(value js.Value) *RemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTDescriptorFromJS is casting from something that holds a js.Value into RemoteGATTDescriptor.
+func RemoteGATTDescriptorFromWrapper(input core.Wrapper) *RemoteGATTDescriptor {
+	return RemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 // Characteristic returning attribute 'characteristic' with
@@ -3692,15 +3741,19 @@ func (_this *RemoteGATTServer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RemoteGATTServerFromJS is casting a js.Wrapper into RemoteGATTServer.
-func RemoteGATTServerFromJS(value js.Wrapper) *RemoteGATTServer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTServerFromJS is casting a js.Value into RemoteGATTServer.
+func RemoteGATTServerFromJS(value js.Value) *RemoteGATTServer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTServer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTServerFromJS is casting from something that holds a js.Value into RemoteGATTServer.
+func RemoteGATTServerFromWrapper(input core.Wrapper) *RemoteGATTServer {
+	return RemoteGATTServerFromJS(input.JSValue())
 }
 
 // Device returning attribute 'device' with
@@ -3785,15 +3838,19 @@ type RemoteGATTService struct {
 	domcore.EventTarget
 }
 
-// RemoteGATTServiceFromJS is casting a js.Wrapper into RemoteGATTService.
-func RemoteGATTServiceFromJS(value js.Wrapper) *RemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTServiceFromJS is casting a js.Value into RemoteGATTService.
+func RemoteGATTServiceFromJS(value js.Value) *RemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTServiceFromJS is casting from something that holds a js.Value into RemoteGATTService.
+func RemoteGATTServiceFromWrapper(input core.Wrapper) *RemoteGATTService {
+	return RemoteGATTServiceFromJS(input.JSValue())
 }
 
 // Device returning attribute 'device' with
@@ -4027,15 +4084,19 @@ func (_this *ServiceDataMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapFromJS is casting a js.Wrapper into ServiceDataMap.
-func ServiceDataMapFromJS(value js.Wrapper) *ServiceDataMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapFromJS is casting a js.Value into ServiceDataMap.
+func ServiceDataMapFromJS(value js.Value) *ServiceDataMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapFromJS is casting from something that holds a js.Value into ServiceDataMap.
+func ServiceDataMapFromWrapper(input core.Wrapper) *ServiceDataMap {
+	return ServiceDataMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -4159,15 +4220,19 @@ func (_this *ServiceDataMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapEntryIteratorFromJS is casting a js.Wrapper into ServiceDataMapEntryIterator.
-func ServiceDataMapEntryIteratorFromJS(value js.Wrapper) *ServiceDataMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapEntryIteratorFromJS is casting a js.Value into ServiceDataMapEntryIterator.
+func ServiceDataMapEntryIteratorFromJS(value js.Value) *ServiceDataMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapEntryIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapEntryIterator.
+func ServiceDataMapEntryIteratorFromWrapper(input core.Wrapper) *ServiceDataMapEntryIterator {
+	return ServiceDataMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapEntryIterator) Next() (_result *ServiceDataMapEntryIteratorValue) {
@@ -4194,15 +4259,19 @@ func (_this *ServiceDataMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapKeyIteratorFromJS is casting a js.Wrapper into ServiceDataMapKeyIterator.
-func ServiceDataMapKeyIteratorFromJS(value js.Wrapper) *ServiceDataMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapKeyIteratorFromJS is casting a js.Value into ServiceDataMapKeyIterator.
+func ServiceDataMapKeyIteratorFromJS(value js.Value) *ServiceDataMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapKeyIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapKeyIterator.
+func ServiceDataMapKeyIteratorFromWrapper(input core.Wrapper) *ServiceDataMapKeyIterator {
+	return ServiceDataMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapKeyIterator) Next() (_result *ServiceDataMapKeyIteratorValue) {
@@ -4229,15 +4298,19 @@ func (_this *ServiceDataMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapValueIteratorFromJS is casting a js.Wrapper into ServiceDataMapValueIterator.
-func ServiceDataMapValueIteratorFromJS(value js.Wrapper) *ServiceDataMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapValueIteratorFromJS is casting a js.Value into ServiceDataMapValueIterator.
+func ServiceDataMapValueIteratorFromJS(value js.Value) *ServiceDataMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapValueIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapValueIterator.
+func ServiceDataMapValueIteratorFromWrapper(input core.Wrapper) *ServiceDataMapValueIterator {
+	return ServiceDataMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapValueIterator) Next() (_result *ServiceDataMapValueIteratorValue) {
@@ -4335,15 +4408,19 @@ type ValueEvent struct {
 	domcore.Event
 }
 
-// ValueEventFromJS is casting a js.Wrapper into ValueEvent.
-func ValueEventFromJS(value js.Wrapper) *ValueEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ValueEventFromJS is casting a js.Value into ValueEvent.
+func ValueEventFromJS(value js.Value) *ValueEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ValueEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ValueEventFromJS is casting from something that holds a js.Value into ValueEvent.
+func ValueEventFromWrapper(input core.Wrapper) *ValueEvent {
+	return ValueEventFromJS(input.JSValue())
 }
 
 func NewValueEvent(_type string, initDict *ValueEventInit) (_result *ValueEvent) {

--- a/communication/bluetooth/bluetooth_js.go
+++ b/communication/bluetooth/bluetooth_js.go
@@ -5,6 +5,7 @@ package bluetooth
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/permissions"
 	"github.com/gowebapi/webapi/javascript"
@@ -839,7 +840,7 @@ type AdvertisingEventInit struct {
 	ServiceData      *ServiceDataMap
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AdvertisingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -873,10 +874,8 @@ func (_this *AdvertisingEventInit) JSValue() js.Value {
 }
 
 // AdvertisingEventInitFromJS is allocating a new
-// AdvertisingEventInit object and copy all values from
-// input javascript object
-func AdvertisingEventInitFromJS(value js.Wrapper) *AdvertisingEventInit {
-	input := value.JSValue()
+// AdvertisingEventInit object and copy all values in the value javascript object.
+func AdvertisingEventInitFromJS(value js.Value) *AdvertisingEventInit {
 	var out AdvertisingEventInit
 	var (
 		value0  bool                 // javascript: boolean {bubbles Bubbles bubbles}
@@ -891,35 +890,35 @@ func AdvertisingEventInitFromJS(value js.Wrapper) *AdvertisingEventInit {
 		value9  *ManufacturerDataMap // javascript: BluetoothManufacturerDataMap {manufacturerData ManufacturerData manufacturerData}
 		value10 *ServiceDataMap      // javascript: BluetoothServiceDataMap {serviceData ServiceData serviceData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DeviceFromJS(input.Get("device"))
+	value3 = DeviceFromJS(value.Get("device"))
 	out.Device = value3
-	__length4 := input.Get("uuids").Length()
+	__length4 := value.Get("uuids").Length()
 	__array4 := make([]*Union, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *Union
-		__seq_in4 := input.Get("uuids").Index(__idx4)
+		__seq_in4 := value.Get("uuids").Index(__idx4)
 		__seq_out4 = UnionFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Uuids = value4
-	value5 = (input.Get("name")).String()
+	value5 = (value.Get("name")).String()
 	out.Name = value5
-	value6 = (input.Get("appearance")).Int()
+	value6 = (value.Get("appearance")).Int()
 	out.Appearance = value6
-	value7 = (input.Get("txPower")).Int()
+	value7 = (value.Get("txPower")).Int()
 	out.TxPower = value7
-	value8 = (input.Get("rssi")).Int()
+	value8 = (value.Get("rssi")).Int()
 	out.Rssi = value8
-	value9 = ManufacturerDataMapFromJS(input.Get("manufacturerData"))
+	value9 = ManufacturerDataMapFromJS(value.Get("manufacturerData"))
 	out.ManufacturerData = value9
-	value10 = ServiceDataMapFromJS(input.Get("serviceData"))
+	value10 = ServiceDataMapFromJS(value.Get("serviceData"))
 	out.ServiceData = value10
 	return &out
 }
@@ -931,7 +930,7 @@ type AllowedDevice struct {
 	AllowedServices *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AllowedDevice) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -945,21 +944,19 @@ func (_this *AllowedDevice) JSValue() js.Value {
 }
 
 // AllowedDeviceFromJS is allocating a new
-// AllowedDevice object and copy all values from
-// input javascript object
-func AllowedDeviceFromJS(value js.Wrapper) *AllowedDevice {
-	input := value.JSValue()
+// AllowedDevice object and copy all values in the value javascript object.
+func AllowedDeviceFromJS(value js.Value) *AllowedDevice {
 	var out AllowedDevice
 	var (
 		value0 string // javascript: DOMString {deviceId DeviceId deviceId}
 		value1 bool   // javascript: boolean {mayUseGATT MayUseGATT mayUseGATT}
 		value2 *Union // javascript: Union {allowedServices AllowedServices allowedServices}
 	)
-	value0 = (input.Get("deviceId")).String()
+	value0 = (value.Get("deviceId")).String()
 	out.DeviceId = value0
-	value1 = (input.Get("mayUseGATT")).Bool()
+	value1 = (value.Get("mayUseGATT")).Bool()
 	out.MayUseGATT = value1
-	value2 = UnionFromJS(input.Get("allowedServices"))
+	value2 = UnionFromJS(value.Get("allowedServices"))
 	out.AllowedServices = value2
 	return &out
 }
@@ -970,7 +967,7 @@ type DataFilterInit struct {
 	Mask       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataFilterInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -982,18 +979,16 @@ func (_this *DataFilterInit) JSValue() js.Value {
 }
 
 // DataFilterInitFromJS is allocating a new
-// DataFilterInit object and copy all values from
-// input javascript object
-func DataFilterInitFromJS(value js.Wrapper) *DataFilterInit {
-	input := value.JSValue()
+// DataFilterInit object and copy all values in the value javascript object.
+func DataFilterInitFromJS(value js.Value) *DataFilterInit {
 	var out DataFilterInit
 	var (
 		value0 *Union // javascript: Union {dataPrefix DataPrefix dataPrefix}
 		value1 *Union // javascript: Union {mask Mask mask}
 	)
-	value0 = UnionFromJS(input.Get("dataPrefix"))
+	value0 = UnionFromJS(value.Get("dataPrefix"))
 	out.DataPrefix = value0
-	value1 = UnionFromJS(input.Get("mask"))
+	value1 = UnionFromJS(value.Get("mask"))
 	out.Mask = value1
 	return &out
 }
@@ -1007,7 +1002,7 @@ type LEScanFilterInit struct {
 	ServiceData      *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LEScanFilterInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1029,10 +1024,8 @@ func (_this *LEScanFilterInit) JSValue() js.Value {
 }
 
 // LEScanFilterInitFromJS is allocating a new
-// LEScanFilterInit object and copy all values from
-// input javascript object
-func LEScanFilterInitFromJS(value js.Wrapper) *LEScanFilterInit {
-	input := value.JSValue()
+// LEScanFilterInit object and copy all values in the value javascript object.
+func LEScanFilterInitFromJS(value js.Value) *LEScanFilterInit {
 	var out LEScanFilterInit
 	var (
 		value0 []*Union           // javascript: sequence<Union> {services Services services}
@@ -1041,23 +1034,23 @@ func LEScanFilterInitFromJS(value js.Wrapper) *LEScanFilterInit {
 		value3 *javascript.Object // javascript: object {manufacturerData ManufacturerData manufacturerData}
 		value4 *javascript.Object // javascript: object {serviceData ServiceData serviceData}
 	)
-	__length0 := input.Get("services").Length()
+	__length0 := value.Get("services").Length()
 	__array0 := make([]*Union, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *Union
-		__seq_in0 := input.Get("services").Index(__idx0)
+		__seq_in0 := value.Get("services").Index(__idx0)
 		__seq_out0 = UnionFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Services = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("namePrefix")).String()
+	value2 = (value.Get("namePrefix")).String()
 	out.NamePrefix = value2
-	value3 = javascript.ObjectFromJS(input.Get("manufacturerData"))
+	value3 = javascript.ObjectFromJS(value.Get("manufacturerData"))
 	out.ManufacturerData = value3
-	value4 = javascript.ObjectFromJS(input.Get("serviceData"))
+	value4 = javascript.ObjectFromJS(value.Get("serviceData"))
 	out.ServiceData = value4
 	return &out
 }
@@ -1068,7 +1061,7 @@ type ManufacturerDataMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1084,26 +1077,24 @@ func (_this *ManufacturerDataMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapEntryIteratorValueFromJS is allocating a new
-// ManufacturerDataMapEntryIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapEntryIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapEntryIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapEntryIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapEntryIteratorValueFromJS(value js.Value) *ManufacturerDataMapEntryIteratorValue {
 	var out ManufacturerDataMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1114,7 +1105,7 @@ type ManufacturerDataMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1126,18 +1117,16 @@ func (_this *ManufacturerDataMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapKeyIteratorValueFromJS is allocating a new
-// ManufacturerDataMapKeyIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapKeyIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapKeyIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapKeyIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapKeyIteratorValueFromJS(value js.Value) *ManufacturerDataMapKeyIteratorValue {
 	var out ManufacturerDataMapKeyIteratorValue
 	var (
 		value0 int  // javascript: unsigned short {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).Int()
+	value0 = (value.Get("value")).Int()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1148,7 +1137,7 @@ type ManufacturerDataMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ManufacturerDataMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1160,18 +1149,16 @@ func (_this *ManufacturerDataMapValueIteratorValue) JSValue() js.Value {
 }
 
 // ManufacturerDataMapValueIteratorValueFromJS is allocating a new
-// ManufacturerDataMapValueIteratorValue object and copy all values from
-// input javascript object
-func ManufacturerDataMapValueIteratorValueFromJS(value js.Wrapper) *ManufacturerDataMapValueIteratorValue {
-	input := value.JSValue()
+// ManufacturerDataMapValueIteratorValue object and copy all values in the value javascript object.
+func ManufacturerDataMapValueIteratorValueFromJS(value js.Value) *ManufacturerDataMapValueIteratorValue {
 	var out ManufacturerDataMapValueIteratorValue
 	var (
 		value0 *javascript.DataView // javascript: DataView {value Value value}
 		value1 bool                 // javascript: boolean {done Done done}
 	)
-	value0 = javascript.DataViewFromJS(input.Get("value"))
+	value0 = javascript.DataViewFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1181,7 +1168,7 @@ type PermissionData struct {
 	AllowedDevices []*AllowedDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1195,19 +1182,17 @@ func (_this *PermissionData) JSValue() js.Value {
 }
 
 // PermissionDataFromJS is allocating a new
-// PermissionData object and copy all values from
-// input javascript object
-func PermissionDataFromJS(value js.Wrapper) *PermissionData {
-	input := value.JSValue()
+// PermissionData object and copy all values in the value javascript object.
+func PermissionDataFromJS(value js.Value) *PermissionData {
 	var out PermissionData
 	var (
 		value0 []*AllowedDevice // javascript: sequence<AllowedBluetoothDevice> {allowedDevices AllowedDevices allowedDevices}
 	)
-	__length0 := input.Get("allowedDevices").Length()
+	__length0 := value.Get("allowedDevices").Length()
 	__array0 := make([]*AllowedDevice, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *AllowedDevice
-		__seq_in0 := input.Get("allowedDevices").Index(__idx0)
+		__seq_in0 := value.Get("allowedDevices").Index(__idx0)
 		__seq_out0 = AllowedDeviceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -1225,7 +1210,7 @@ type PermissionDescriptor struct {
 	AcceptAllDevices bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1251,10 +1236,8 @@ func (_this *PermissionDescriptor) JSValue() js.Value {
 }
 
 // PermissionDescriptorFromJS is allocating a new
-// PermissionDescriptor object and copy all values from
-// input javascript object
-func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
-	input := value.JSValue()
+// PermissionDescriptor object and copy all values in the value javascript object.
+func PermissionDescriptorFromJS(value js.Value) *PermissionDescriptor {
 	var out PermissionDescriptor
 	var (
 		value0 string              // javascript: DOMString {name Name name}
@@ -1263,31 +1246,31 @@ func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
 		value3 []*Union            // javascript: sequence<Union> {optionalServices OptionalServices optionalServices}
 		value4 bool                // javascript: boolean {acceptAllDevices AcceptAllDevices acceptAllDevices}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("deviceId")).String()
+	value1 = (value.Get("deviceId")).String()
 	out.DeviceId = value1
-	__length2 := input.Get("filters").Length()
+	__length2 := value.Get("filters").Length()
 	__array2 := make([]*LEScanFilterInit, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *LEScanFilterInit
-		__seq_in2 := input.Get("filters").Index(__idx2)
+		__seq_in2 := value.Get("filters").Index(__idx2)
 		__seq_out2 = LEScanFilterInitFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Filters = value2
-	__length3 := input.Get("optionalServices").Length()
+	__length3 := value.Get("optionalServices").Length()
 	__array3 := make([]*Union, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *Union
-		__seq_in3 := input.Get("optionalServices").Index(__idx3)
+		__seq_in3 := value.Get("optionalServices").Index(__idx3)
 		__seq_out3 = UnionFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.OptionalServices = value3
-	value4 = (input.Get("acceptAllDevices")).Bool()
+	value4 = (value.Get("acceptAllDevices")).Bool()
 	out.AcceptAllDevices = value4
 	return &out
 }
@@ -1299,7 +1282,7 @@ type RequestDeviceOptions struct {
 	AcceptAllDevices bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RequestDeviceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1321,37 +1304,35 @@ func (_this *RequestDeviceOptions) JSValue() js.Value {
 }
 
 // RequestDeviceOptionsFromJS is allocating a new
-// RequestDeviceOptions object and copy all values from
-// input javascript object
-func RequestDeviceOptionsFromJS(value js.Wrapper) *RequestDeviceOptions {
-	input := value.JSValue()
+// RequestDeviceOptions object and copy all values in the value javascript object.
+func RequestDeviceOptionsFromJS(value js.Value) *RequestDeviceOptions {
 	var out RequestDeviceOptions
 	var (
 		value0 []*LEScanFilterInit // javascript: sequence<BluetoothLEScanFilterInit> {filters Filters filters}
 		value1 []*Union            // javascript: sequence<Union> {optionalServices OptionalServices optionalServices}
 		value2 bool                // javascript: boolean {acceptAllDevices AcceptAllDevices acceptAllDevices}
 	)
-	__length0 := input.Get("filters").Length()
+	__length0 := value.Get("filters").Length()
 	__array0 := make([]*LEScanFilterInit, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *LEScanFilterInit
-		__seq_in0 := input.Get("filters").Index(__idx0)
+		__seq_in0 := value.Get("filters").Index(__idx0)
 		__seq_out0 = LEScanFilterInitFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Filters = value0
-	__length1 := input.Get("optionalServices").Length()
+	__length1 := value.Get("optionalServices").Length()
 	__array1 := make([]*Union, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *Union
-		__seq_in1 := input.Get("optionalServices").Index(__idx1)
+		__seq_in1 := value.Get("optionalServices").Index(__idx1)
 		__seq_out1 = UnionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.OptionalServices = value1
-	value2 = (input.Get("acceptAllDevices")).Bool()
+	value2 = (value.Get("acceptAllDevices")).Bool()
 	out.AcceptAllDevices = value2
 	return &out
 }
@@ -1362,7 +1343,7 @@ type ServiceDataMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1378,26 +1359,24 @@ func (_this *ServiceDataMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapEntryIteratorValueFromJS is allocating a new
-// ServiceDataMapEntryIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapEntryIteratorValueFromJS(value js.Wrapper) *ServiceDataMapEntryIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapEntryIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapEntryIteratorValueFromJS(value js.Value) *ServiceDataMapEntryIteratorValue {
 	var out ServiceDataMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1408,7 +1387,7 @@ type ServiceDataMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1420,18 +1399,16 @@ func (_this *ServiceDataMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapKeyIteratorValueFromJS is allocating a new
-// ServiceDataMapKeyIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapKeyIteratorValueFromJS(value js.Wrapper) *ServiceDataMapKeyIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapKeyIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapKeyIteratorValueFromJS(value js.Value) *ServiceDataMapKeyIteratorValue {
 	var out ServiceDataMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1442,7 +1419,7 @@ type ServiceDataMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ServiceDataMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1454,18 +1431,16 @@ func (_this *ServiceDataMapValueIteratorValue) JSValue() js.Value {
 }
 
 // ServiceDataMapValueIteratorValueFromJS is allocating a new
-// ServiceDataMapValueIteratorValue object and copy all values from
-// input javascript object
-func ServiceDataMapValueIteratorValueFromJS(value js.Wrapper) *ServiceDataMapValueIteratorValue {
-	input := value.JSValue()
+// ServiceDataMapValueIteratorValue object and copy all values in the value javascript object.
+func ServiceDataMapValueIteratorValueFromJS(value js.Value) *ServiceDataMapValueIteratorValue {
 	var out ServiceDataMapValueIteratorValue
 	var (
 		value0 *javascript.DataView // javascript: DataView {value Value value}
 		value1 bool                 // javascript: boolean {done Done done}
 	)
-	value0 = javascript.DataViewFromJS(input.Get("value"))
+	value0 = javascript.DataViewFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1478,7 +1453,7 @@ type ValueEventInit struct {
 	Value      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ValueEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1494,10 +1469,8 @@ func (_this *ValueEventInit) JSValue() js.Value {
 }
 
 // ValueEventInitFromJS is allocating a new
-// ValueEventInit object and copy all values from
-// input javascript object
-func ValueEventInitFromJS(value js.Wrapper) *ValueEventInit {
-	input := value.JSValue()
+// ValueEventInit object and copy all values in the value javascript object.
+func ValueEventInitFromJS(value js.Value) *ValueEventInit {
 	var out ValueEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1505,13 +1478,13 @@ func ValueEventInitFromJS(value js.Wrapper) *ValueEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {value Value value}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("value")
+	value3 = value.Get("value")
 	out.Value = value3
 	return &out
 }
@@ -1521,15 +1494,19 @@ type AdvertisingEvent struct {
 	domcore.Event
 }
 
-// AdvertisingEventFromJS is casting a js.Wrapper into AdvertisingEvent.
-func AdvertisingEventFromJS(value js.Wrapper) *AdvertisingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AdvertisingEventFromJS is casting a js.Value into AdvertisingEvent.
+func AdvertisingEventFromJS(value js.Value) *AdvertisingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AdvertisingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AdvertisingEventFromJS is casting from something that holds a js.Value into AdvertisingEvent.
+func AdvertisingEventFromWrapper(input core.Wrapper) *AdvertisingEvent {
+	return AdvertisingEventFromJS(input.JSValue())
 }
 
 func NewBluetoothAdvertisingEvent(_type string, init *AdvertisingEventInit) (_result *AdvertisingEvent) {
@@ -1642,15 +1619,19 @@ type Bluetooth struct {
 	domcore.EventTarget
 }
 
-// BluetoothFromJS is casting a js.Wrapper into Bluetooth.
-func BluetoothFromJS(value js.Wrapper) *Bluetooth {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BluetoothFromJS is casting a js.Value into Bluetooth.
+func BluetoothFromJS(value js.Value) *Bluetooth {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Bluetooth{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BluetoothFromJS is casting from something that holds a js.Value into Bluetooth.
+func BluetoothFromWrapper(input core.Wrapper) *Bluetooth {
+	return BluetoothFromJS(input.JSValue())
 }
 
 // OnAvailabilityChanged returning attribute 'onavailabilitychanged' with
@@ -1938,15 +1919,19 @@ func (_this *CharacteristicProperties) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CharacteristicPropertiesFromJS is casting a js.Wrapper into CharacteristicProperties.
-func CharacteristicPropertiesFromJS(value js.Wrapper) *CharacteristicProperties {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CharacteristicPropertiesFromJS is casting a js.Value into CharacteristicProperties.
+func CharacteristicPropertiesFromJS(value js.Value) *CharacteristicProperties {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CharacteristicProperties{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CharacteristicPropertiesFromJS is casting from something that holds a js.Value into CharacteristicProperties.
+func CharacteristicPropertiesFromWrapper(input core.Wrapper) *CharacteristicProperties {
+	return CharacteristicPropertiesFromJS(input.JSValue())
 }
 
 // Broadcast returning attribute 'broadcast' with
@@ -2035,15 +2020,19 @@ type Device struct {
 	domcore.EventTarget
 }
 
-// DeviceFromJS is casting a js.Wrapper into Device.
-func DeviceFromJS(value js.Wrapper) *Device {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceFromJS is casting a js.Value into Device.
+func DeviceFromJS(value js.Value) *Device {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Device{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceFromJS is casting from something that holds a js.Value into Device.
+func DeviceFromWrapper(input core.Wrapper) *Device {
+	return DeviceFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -2310,15 +2299,19 @@ func (_this *ManufacturerDataMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapFromJS is casting a js.Wrapper into ManufacturerDataMap.
-func ManufacturerDataMapFromJS(value js.Wrapper) *ManufacturerDataMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapFromJS is casting a js.Value into ManufacturerDataMap.
+func ManufacturerDataMapFromJS(value js.Value) *ManufacturerDataMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapFromJS is casting from something that holds a js.Value into ManufacturerDataMap.
+func ManufacturerDataMapFromWrapper(input core.Wrapper) *ManufacturerDataMap {
+	return ManufacturerDataMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -2442,15 +2435,19 @@ func (_this *ManufacturerDataMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapEntryIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapEntryIterator.
-func ManufacturerDataMapEntryIteratorFromJS(value js.Wrapper) *ManufacturerDataMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapEntryIteratorFromJS is casting a js.Value into ManufacturerDataMapEntryIterator.
+func ManufacturerDataMapEntryIteratorFromJS(value js.Value) *ManufacturerDataMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapEntryIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapEntryIterator.
+func ManufacturerDataMapEntryIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapEntryIterator {
+	return ManufacturerDataMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapEntryIterator) Next() (_result *ManufacturerDataMapEntryIteratorValue) {
@@ -2477,15 +2474,19 @@ func (_this *ManufacturerDataMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapKeyIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapKeyIterator.
-func ManufacturerDataMapKeyIteratorFromJS(value js.Wrapper) *ManufacturerDataMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapKeyIteratorFromJS is casting a js.Value into ManufacturerDataMapKeyIterator.
+func ManufacturerDataMapKeyIteratorFromJS(value js.Value) *ManufacturerDataMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapKeyIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapKeyIterator.
+func ManufacturerDataMapKeyIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapKeyIterator {
+	return ManufacturerDataMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapKeyIterator) Next() (_result *ManufacturerDataMapKeyIteratorValue) {
@@ -2512,15 +2513,19 @@ func (_this *ManufacturerDataMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManufacturerDataMapValueIteratorFromJS is casting a js.Wrapper into ManufacturerDataMapValueIterator.
-func ManufacturerDataMapValueIteratorFromJS(value js.Wrapper) *ManufacturerDataMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManufacturerDataMapValueIteratorFromJS is casting a js.Value into ManufacturerDataMapValueIterator.
+func ManufacturerDataMapValueIteratorFromJS(value js.Value) *ManufacturerDataMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ManufacturerDataMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManufacturerDataMapValueIteratorFromJS is casting from something that holds a js.Value into ManufacturerDataMapValueIterator.
+func ManufacturerDataMapValueIteratorFromWrapper(input core.Wrapper) *ManufacturerDataMapValueIterator {
+	return ManufacturerDataMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ManufacturerDataMapValueIterator) Next() (_result *ManufacturerDataMapValueIteratorValue) {
@@ -2542,15 +2547,19 @@ type PermissionResult struct {
 	permissions.PermissionStatus
 }
 
-// PermissionResultFromJS is casting a js.Wrapper into PermissionResult.
-func PermissionResultFromJS(value js.Wrapper) *PermissionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionResultFromJS is casting a js.Value into PermissionResult.
+func PermissionResultFromJS(value js.Value) *PermissionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PermissionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionResultFromJS is casting from something that holds a js.Value into PermissionResult.
+func PermissionResultFromWrapper(input core.Wrapper) *PermissionResult {
+	return PermissionResultFromJS(input.JSValue())
 }
 
 // Devices returning attribute 'devices' with
@@ -2579,15 +2588,19 @@ func (_this *PromiseDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDeviceFromJS is casting a js.Wrapper into PromiseDevice.
-func PromiseDeviceFromJS(value js.Wrapper) *PromiseDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDeviceFromJS is casting a js.Value into PromiseDevice.
+func PromiseDeviceFromJS(value js.Value) *PromiseDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDeviceFromJS is casting from something that holds a js.Value into PromiseDevice.
+func PromiseDeviceFromWrapper(input core.Wrapper) *PromiseDevice {
+	return PromiseDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseDevice) Then(onFulfilled *PromiseDeviceOnFulfilled, onRejected *PromiseDeviceOnRejected) (_result *PromiseDevice) {
@@ -2684,15 +2697,19 @@ func (_this *PromiseRemoteGATTCharacteristic) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTCharacteristicFromJS is casting a js.Wrapper into PromiseRemoteGATTCharacteristic.
-func PromiseRemoteGATTCharacteristicFromJS(value js.Wrapper) *PromiseRemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTCharacteristicFromJS is casting a js.Value into PromiseRemoteGATTCharacteristic.
+func PromiseRemoteGATTCharacteristicFromJS(value js.Value) *PromiseRemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into PromiseRemoteGATTCharacteristic.
+func PromiseRemoteGATTCharacteristicFromWrapper(input core.Wrapper) *PromiseRemoteGATTCharacteristic {
+	return PromiseRemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTCharacteristic) Then(onFulfilled *PromiseRemoteGATTCharacteristicOnFulfilled, onRejected *PromiseRemoteGATTCharacteristicOnRejected) (_result *PromiseRemoteGATTCharacteristic) {
@@ -2789,15 +2806,19 @@ func (_this *PromiseRemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTDescriptorFromJS is casting a js.Wrapper into PromiseRemoteGATTDescriptor.
-func PromiseRemoteGATTDescriptorFromJS(value js.Wrapper) *PromiseRemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTDescriptorFromJS is casting a js.Value into PromiseRemoteGATTDescriptor.
+func PromiseRemoteGATTDescriptorFromJS(value js.Value) *PromiseRemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTDescriptorFromJS is casting from something that holds a js.Value into PromiseRemoteGATTDescriptor.
+func PromiseRemoteGATTDescriptorFromWrapper(input core.Wrapper) *PromiseRemoteGATTDescriptor {
+	return PromiseRemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTDescriptor) Then(onFulfilled *PromiseRemoteGATTDescriptorOnFulfilled, onRejected *PromiseRemoteGATTDescriptorOnRejected) (_result *PromiseRemoteGATTDescriptor) {
@@ -2894,15 +2915,19 @@ func (_this *PromiseRemoteGATTServer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTServerFromJS is casting a js.Wrapper into PromiseRemoteGATTServer.
-func PromiseRemoteGATTServerFromJS(value js.Wrapper) *PromiseRemoteGATTServer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTServerFromJS is casting a js.Value into PromiseRemoteGATTServer.
+func PromiseRemoteGATTServerFromJS(value js.Value) *PromiseRemoteGATTServer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTServer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTServerFromJS is casting from something that holds a js.Value into PromiseRemoteGATTServer.
+func PromiseRemoteGATTServerFromWrapper(input core.Wrapper) *PromiseRemoteGATTServer {
+	return PromiseRemoteGATTServerFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTServer) Then(onFulfilled *PromiseRemoteGATTServerOnFulfilled, onRejected *PromiseRemoteGATTServerOnRejected) (_result *PromiseRemoteGATTServer) {
@@ -2999,15 +3024,19 @@ func (_this *PromiseRemoteGATTService) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseRemoteGATTServiceFromJS is casting a js.Wrapper into PromiseRemoteGATTService.
-func PromiseRemoteGATTServiceFromJS(value js.Wrapper) *PromiseRemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRemoteGATTServiceFromJS is casting a js.Value into PromiseRemoteGATTService.
+func PromiseRemoteGATTServiceFromJS(value js.Value) *PromiseRemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRemoteGATTServiceFromJS is casting from something that holds a js.Value into PromiseRemoteGATTService.
+func PromiseRemoteGATTServiceFromWrapper(input core.Wrapper) *PromiseRemoteGATTService {
+	return PromiseRemoteGATTServiceFromJS(input.JSValue())
 }
 
 func (_this *PromiseRemoteGATTService) Then(onFulfilled *PromiseRemoteGATTServiceOnFulfilled, onRejected *PromiseRemoteGATTServiceOnRejected) (_result *PromiseRemoteGATTService) {
@@ -3104,15 +3133,19 @@ func (_this *PromiseSequenceRemoteGATTCharacteristic) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTCharacteristicFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTCharacteristic.
-func PromiseSequenceRemoteGATTCharacteristicFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTCharacteristicFromJS is casting a js.Value into PromiseSequenceRemoteGATTCharacteristic.
+func PromiseSequenceRemoteGATTCharacteristicFromJS(value js.Value) *PromiseSequenceRemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTCharacteristic.
+func PromiseSequenceRemoteGATTCharacteristicFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTCharacteristic {
+	return PromiseSequenceRemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTCharacteristic) Then(onFulfilled *PromiseSequenceRemoteGATTCharacteristicOnFulfilled, onRejected *PromiseSequenceRemoteGATTCharacteristicOnRejected) (_result *PromiseSequenceRemoteGATTCharacteristic) {
@@ -3209,15 +3242,19 @@ func (_this *PromiseSequenceRemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTDescriptorFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTDescriptor.
-func PromiseSequenceRemoteGATTDescriptorFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTDescriptorFromJS is casting a js.Value into PromiseSequenceRemoteGATTDescriptor.
+func PromiseSequenceRemoteGATTDescriptorFromJS(value js.Value) *PromiseSequenceRemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTDescriptorFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTDescriptor.
+func PromiseSequenceRemoteGATTDescriptorFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTDescriptor {
+	return PromiseSequenceRemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTDescriptor) Then(onFulfilled *PromiseSequenceRemoteGATTDescriptorOnFulfilled, onRejected *PromiseSequenceRemoteGATTDescriptorOnRejected) (_result *PromiseSequenceRemoteGATTDescriptor) {
@@ -3314,15 +3351,19 @@ func (_this *PromiseSequenceRemoteGATTService) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceRemoteGATTServiceFromJS is casting a js.Wrapper into PromiseSequenceRemoteGATTService.
-func PromiseSequenceRemoteGATTServiceFromJS(value js.Wrapper) *PromiseSequenceRemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceRemoteGATTServiceFromJS is casting a js.Value into PromiseSequenceRemoteGATTService.
+func PromiseSequenceRemoteGATTServiceFromJS(value js.Value) *PromiseSequenceRemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceRemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceRemoteGATTServiceFromJS is casting from something that holds a js.Value into PromiseSequenceRemoteGATTService.
+func PromiseSequenceRemoteGATTServiceFromWrapper(input core.Wrapper) *PromiseSequenceRemoteGATTService {
+	return PromiseSequenceRemoteGATTServiceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceRemoteGATTService) Then(onFulfilled *PromiseSequenceRemoteGATTServiceOnFulfilled, onRejected *PromiseSequenceRemoteGATTServiceOnRejected) (_result *PromiseSequenceRemoteGATTService) {
@@ -3414,15 +3455,19 @@ type RemoteGATTCharacteristic struct {
 	domcore.EventTarget
 }
 
-// RemoteGATTCharacteristicFromJS is casting a js.Wrapper into RemoteGATTCharacteristic.
-func RemoteGATTCharacteristicFromJS(value js.Wrapper) *RemoteGATTCharacteristic {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTCharacteristicFromJS is casting a js.Value into RemoteGATTCharacteristic.
+func RemoteGATTCharacteristicFromJS(value js.Value) *RemoteGATTCharacteristic {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTCharacteristic{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTCharacteristicFromJS is casting from something that holds a js.Value into RemoteGATTCharacteristic.
+func RemoteGATTCharacteristicFromWrapper(input core.Wrapper) *RemoteGATTCharacteristic {
+	return RemoteGATTCharacteristicFromJS(input.JSValue())
 }
 
 // Service returning attribute 'service' with
@@ -3609,15 +3654,19 @@ func (_this *RemoteGATTDescriptor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RemoteGATTDescriptorFromJS is casting a js.Wrapper into RemoteGATTDescriptor.
-func RemoteGATTDescriptorFromJS(value js.Wrapper) *RemoteGATTDescriptor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTDescriptorFromJS is casting a js.Value into RemoteGATTDescriptor.
+func RemoteGATTDescriptorFromJS(value js.Value) *RemoteGATTDescriptor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTDescriptor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTDescriptorFromJS is casting from something that holds a js.Value into RemoteGATTDescriptor.
+func RemoteGATTDescriptorFromWrapper(input core.Wrapper) *RemoteGATTDescriptor {
+	return RemoteGATTDescriptorFromJS(input.JSValue())
 }
 
 // Characteristic returning attribute 'characteristic' with
@@ -3690,15 +3739,19 @@ func (_this *RemoteGATTServer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RemoteGATTServerFromJS is casting a js.Wrapper into RemoteGATTServer.
-func RemoteGATTServerFromJS(value js.Wrapper) *RemoteGATTServer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTServerFromJS is casting a js.Value into RemoteGATTServer.
+func RemoteGATTServerFromJS(value js.Value) *RemoteGATTServer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTServer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTServerFromJS is casting from something that holds a js.Value into RemoteGATTServer.
+func RemoteGATTServerFromWrapper(input core.Wrapper) *RemoteGATTServer {
+	return RemoteGATTServerFromJS(input.JSValue())
 }
 
 // Device returning attribute 'device' with
@@ -3783,15 +3836,19 @@ type RemoteGATTService struct {
 	domcore.EventTarget
 }
 
-// RemoteGATTServiceFromJS is casting a js.Wrapper into RemoteGATTService.
-func RemoteGATTServiceFromJS(value js.Wrapper) *RemoteGATTService {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemoteGATTServiceFromJS is casting a js.Value into RemoteGATTService.
+func RemoteGATTServiceFromJS(value js.Value) *RemoteGATTService {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemoteGATTService{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemoteGATTServiceFromJS is casting from something that holds a js.Value into RemoteGATTService.
+func RemoteGATTServiceFromWrapper(input core.Wrapper) *RemoteGATTService {
+	return RemoteGATTServiceFromJS(input.JSValue())
 }
 
 // Device returning attribute 'device' with
@@ -4025,15 +4082,19 @@ func (_this *ServiceDataMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapFromJS is casting a js.Wrapper into ServiceDataMap.
-func ServiceDataMapFromJS(value js.Wrapper) *ServiceDataMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapFromJS is casting a js.Value into ServiceDataMap.
+func ServiceDataMapFromJS(value js.Value) *ServiceDataMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapFromJS is casting from something that holds a js.Value into ServiceDataMap.
+func ServiceDataMapFromWrapper(input core.Wrapper) *ServiceDataMap {
+	return ServiceDataMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -4157,15 +4218,19 @@ func (_this *ServiceDataMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapEntryIteratorFromJS is casting a js.Wrapper into ServiceDataMapEntryIterator.
-func ServiceDataMapEntryIteratorFromJS(value js.Wrapper) *ServiceDataMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapEntryIteratorFromJS is casting a js.Value into ServiceDataMapEntryIterator.
+func ServiceDataMapEntryIteratorFromJS(value js.Value) *ServiceDataMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapEntryIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapEntryIterator.
+func ServiceDataMapEntryIteratorFromWrapper(input core.Wrapper) *ServiceDataMapEntryIterator {
+	return ServiceDataMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapEntryIterator) Next() (_result *ServiceDataMapEntryIteratorValue) {
@@ -4192,15 +4257,19 @@ func (_this *ServiceDataMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapKeyIteratorFromJS is casting a js.Wrapper into ServiceDataMapKeyIterator.
-func ServiceDataMapKeyIteratorFromJS(value js.Wrapper) *ServiceDataMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapKeyIteratorFromJS is casting a js.Value into ServiceDataMapKeyIterator.
+func ServiceDataMapKeyIteratorFromJS(value js.Value) *ServiceDataMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapKeyIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapKeyIterator.
+func ServiceDataMapKeyIteratorFromWrapper(input core.Wrapper) *ServiceDataMapKeyIterator {
+	return ServiceDataMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapKeyIterator) Next() (_result *ServiceDataMapKeyIteratorValue) {
@@ -4227,15 +4296,19 @@ func (_this *ServiceDataMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServiceDataMapValueIteratorFromJS is casting a js.Wrapper into ServiceDataMapValueIterator.
-func ServiceDataMapValueIteratorFromJS(value js.Wrapper) *ServiceDataMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceDataMapValueIteratorFromJS is casting a js.Value into ServiceDataMapValueIterator.
+func ServiceDataMapValueIteratorFromJS(value js.Value) *ServiceDataMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceDataMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceDataMapValueIteratorFromJS is casting from something that holds a js.Value into ServiceDataMapValueIterator.
+func ServiceDataMapValueIteratorFromWrapper(input core.Wrapper) *ServiceDataMapValueIterator {
+	return ServiceDataMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ServiceDataMapValueIterator) Next() (_result *ServiceDataMapValueIteratorValue) {
@@ -4333,15 +4406,19 @@ type ValueEvent struct {
 	domcore.Event
 }
 
-// ValueEventFromJS is casting a js.Wrapper into ValueEvent.
-func ValueEventFromJS(value js.Wrapper) *ValueEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ValueEventFromJS is casting a js.Value into ValueEvent.
+func ValueEventFromJS(value js.Value) *ValueEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ValueEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ValueEventFromJS is casting from something that holds a js.Value into ValueEvent.
+func ValueEventFromWrapper(input core.Wrapper) *ValueEvent {
+	return ValueEventFromJS(input.JSValue())
 }
 
 func NewValueEvent(_type string, initDict *ValueEventInit) (_result *ValueEvent) {

--- a/communication/netinfo/netinfo.go
+++ b/communication/netinfo/netinfo.go
@@ -7,6 +7,7 @@ package netinfo
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -136,15 +137,19 @@ type NetworkInformation struct {
 	domcore.EventTarget
 }
 
-// NetworkInformationFromJS is casting a js.Wrapper into NetworkInformation.
-func NetworkInformationFromJS(value js.Wrapper) *NetworkInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NetworkInformationFromJS is casting a js.Value into NetworkInformation.
+func NetworkInformationFromJS(value js.Value) *NetworkInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NetworkInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NetworkInformationFromJS is casting from something that holds a js.Value into NetworkInformation.
+func NetworkInformationFromWrapper(input core.Wrapper) *NetworkInformation {
+	return NetworkInformationFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with

--- a/communication/netinfo/netinfo_js.go
+++ b/communication/netinfo/netinfo_js.go
@@ -5,6 +5,7 @@ package netinfo
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -134,15 +135,19 @@ type NetworkInformation struct {
 	domcore.EventTarget
 }
 
-// NetworkInformationFromJS is casting a js.Wrapper into NetworkInformation.
-func NetworkInformationFromJS(value js.Wrapper) *NetworkInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NetworkInformationFromJS is casting a js.Value into NetworkInformation.
+func NetworkInformationFromJS(value js.Value) *NetworkInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NetworkInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NetworkInformationFromJS is casting from something that holds a js.Value into NetworkInformation.
+func NetworkInformationFromWrapper(input core.Wrapper) *NetworkInformation {
+	return NetworkInformationFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with

--- a/communication/nfc/nfc.go
+++ b/communication/nfc/nfc.go
@@ -7,6 +7,7 @@ package nfc
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -181,7 +182,7 @@ type ErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -197,10 +198,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -208,13 +207,13 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -225,7 +224,7 @@ type NDEFMessage struct {
 	Url     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NDEFMessage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -241,26 +240,24 @@ func (_this *NDEFMessage) JSValue() js.Value {
 }
 
 // NDEFMessageFromJS is allocating a new
-// NDEFMessage object and copy all values from
-// input javascript object
-func NDEFMessageFromJS(value js.Wrapper) *NDEFMessage {
-	input := value.JSValue()
+// NDEFMessage object and copy all values in the value javascript object.
+func NDEFMessageFromJS(value js.Value) *NDEFMessage {
 	var out NDEFMessage
 	var (
 		value0 []*NDEFRecord // javascript: sequence<NDEFRecord> {records Records records}
 		value1 string        // javascript: USVString {url Url url}
 	)
-	__length0 := input.Get("records").Length()
+	__length0 := value.Get("records").Length()
 	__array0 := make([]*NDEFRecord, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *NDEFRecord
-		__seq_in0 := input.Get("records").Index(__idx0)
+		__seq_in0 := value.Get("records").Index(__idx0)
 		__seq_out0 = NDEFRecordFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Records = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
 	return &out
 }
@@ -272,7 +269,7 @@ type NDEFRecord struct {
 	Data       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NDEFRecord) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -286,21 +283,19 @@ func (_this *NDEFRecord) JSValue() js.Value {
 }
 
 // NDEFRecordFromJS is allocating a new
-// NDEFRecord object and copy all values from
-// input javascript object
-func NDEFRecordFromJS(value js.Wrapper) *NDEFRecord {
-	input := value.JSValue()
+// NDEFRecord object and copy all values in the value javascript object.
+func NDEFRecordFromJS(value js.Value) *NDEFRecord {
 	var out NDEFRecord
 	var (
 		value0 NDEFRecordType // javascript: NDEFRecordType {recordType RecordType recordType}
 		value1 string         // javascript: USVString {mediaType MediaType mediaType}
 		value2 *Union         // javascript: Union {data Data data}
 	)
-	value0 = NDEFRecordTypeFromJS(input.Get("recordType"))
+	value0 = NDEFRecordTypeFromJS(value.Get("recordType"))
 	out.RecordType = value0
-	value1 = (input.Get("mediaType")).String()
+	value1 = (value.Get("mediaType")).String()
 	out.MediaType = value1
-	value2 = UnionFromJS(input.Get("data"))
+	value2 = UnionFromJS(value.Get("data"))
 	out.Data = value2
 	return &out
 }
@@ -314,7 +309,7 @@ type PushOptions struct {
 	Compatibility NDEFCompatibility
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PushOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -332,10 +327,8 @@ func (_this *PushOptions) JSValue() js.Value {
 }
 
 // PushOptionsFromJS is allocating a new
-// PushOptions object and copy all values from
-// input javascript object
-func PushOptionsFromJS(value js.Wrapper) *PushOptions {
-	input := value.JSValue()
+// PushOptions object and copy all values in the value javascript object.
+func PushOptionsFromJS(value js.Value) *PushOptions {
 	var out PushOptions
 	var (
 		value0 PushTarget           // javascript: NFCPushTarget {target Target target}
@@ -344,17 +337,17 @@ func PushOptionsFromJS(value js.Wrapper) *PushOptions {
 		value3 *domcore.AbortSignal // javascript: AbortSignal {signal Signal signal}
 		value4 NDEFCompatibility    // javascript: NDEFCompatibility {compatibility Compatibility compatibility}
 	)
-	value0 = PushTargetFromJS(input.Get("target"))
+	value0 = PushTargetFromJS(value.Get("target"))
 	out.Target = value0
-	value1 = (input.Get("timeout")).Float()
+	value1 = (value.Get("timeout")).Float()
 	out.Timeout = value1
-	value2 = (input.Get("ignoreRead")).Bool()
+	value2 = (value.Get("ignoreRead")).Bool()
 	out.IgnoreRead = value2
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value3 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value3 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value3
-	value4 = NDEFCompatibilityFromJS(input.Get("compatibility"))
+	value4 = NDEFCompatibilityFromJS(value.Get("compatibility"))
 	out.Compatibility = value4
 	return &out
 }
@@ -367,7 +360,7 @@ type ReaderOptions struct {
 	Compatibility NDEFCompatibility
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReaderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -383,10 +376,8 @@ func (_this *ReaderOptions) JSValue() js.Value {
 }
 
 // ReaderOptionsFromJS is allocating a new
-// ReaderOptions object and copy all values from
-// input javascript object
-func ReaderOptionsFromJS(value js.Wrapper) *ReaderOptions {
-	input := value.JSValue()
+// ReaderOptions object and copy all values in the value javascript object.
+func ReaderOptionsFromJS(value js.Value) *ReaderOptions {
 	var out ReaderOptions
 	var (
 		value0 string            // javascript: USVString {url Url url}
@@ -394,13 +385,13 @@ func ReaderOptionsFromJS(value js.Wrapper) *ReaderOptions {
 		value2 string            // javascript: USVString {mediaType MediaType mediaType}
 		value3 NDEFCompatibility // javascript: NDEFCompatibility {compatibility Compatibility compatibility}
 	)
-	value0 = (input.Get("url")).String()
+	value0 = (value.Get("url")).String()
 	out.Url = value0
-	value1 = NDEFRecordTypeFromJS(input.Get("recordType"))
+	value1 = NDEFRecordTypeFromJS(value.Get("recordType"))
 	out.RecordType = value1
-	value2 = (input.Get("mediaType")).String()
+	value2 = (value.Get("mediaType")).String()
 	out.MediaType = value2
-	value3 = NDEFCompatibilityFromJS(input.Get("compatibility"))
+	value3 = NDEFCompatibilityFromJS(value.Get("compatibility"))
 	out.Compatibility = value3
 	return &out
 }
@@ -413,7 +404,7 @@ type ReadingEventInit struct {
 	Message    *NDEFMessage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReadingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -429,10 +420,8 @@ func (_this *ReadingEventInit) JSValue() js.Value {
 }
 
 // ReadingEventInitFromJS is allocating a new
-// ReadingEventInit object and copy all values from
-// input javascript object
-func ReadingEventInitFromJS(value js.Wrapper) *ReadingEventInit {
-	input := value.JSValue()
+// ReadingEventInit object and copy all values in the value javascript object.
+func ReadingEventInitFromJS(value js.Value) *ReadingEventInit {
 	var out ReadingEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -440,13 +429,13 @@ func ReadingEventInitFromJS(value js.Wrapper) *ReadingEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *NDEFMessage // javascript: NDEFMessage {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = NDEFMessageFromJS(input.Get("message"))
+	value3 = NDEFMessageFromJS(value.Get("message"))
 	out.Message = value3
 	return &out
 }
@@ -456,15 +445,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewNFCErrorEvent(_type string, errorEventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -502,15 +495,19 @@ type Reader struct {
 	domcore.EventTarget
 }
 
-// ReaderFromJS is casting a js.Wrapper into Reader.
-func ReaderFromJS(value js.Wrapper) *Reader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReaderFromJS is casting a js.Value into Reader.
+func ReaderFromJS(value js.Value) *Reader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Reader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReaderFromJS is casting from something that holds a js.Value into Reader.
+func ReaderFromWrapper(input core.Wrapper) *Reader {
+	return ReaderFromJS(input.JSValue())
 }
 
 func NewNFCReader(options *ReaderOptions) (_result *Reader) {
@@ -638,15 +635,19 @@ type ReadingEvent struct {
 	domcore.Event
 }
 
-// ReadingEventFromJS is casting a js.Wrapper into ReadingEvent.
-func ReadingEventFromJS(value js.Wrapper) *ReadingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReadingEventFromJS is casting a js.Value into ReadingEvent.
+func ReadingEventFromJS(value js.Value) *ReadingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReadingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReadingEventFromJS is casting from something that holds a js.Value into ReadingEvent.
+func ReadingEventFromWrapper(input core.Wrapper) *ReadingEvent {
+	return ReadingEventFromJS(input.JSValue())
 }
 
 func NewNFCReadingEvent(_type string, readingEventInitDict *ReadingEventInit) (_result *ReadingEvent) {
@@ -689,15 +690,19 @@ func (_this *Writer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WriterFromJS is casting a js.Wrapper into Writer.
-func WriterFromJS(value js.Wrapper) *Writer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WriterFromJS is casting a js.Value into Writer.
+func WriterFromJS(value js.Value) *Writer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Writer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WriterFromJS is casting from something that holds a js.Value into Writer.
+func WriterFromWrapper(input core.Wrapper) *Writer {
+	return WriterFromJS(input.JSValue())
 }
 
 func NewNFCWriter() (_result *Writer) {

--- a/communication/nfc/nfc_js.go
+++ b/communication/nfc/nfc_js.go
@@ -5,6 +5,7 @@ package nfc
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -179,7 +180,7 @@ type ErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -195,10 +196,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -206,13 +205,13 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -223,7 +222,7 @@ type NDEFMessage struct {
 	Url     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NDEFMessage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -239,26 +238,24 @@ func (_this *NDEFMessage) JSValue() js.Value {
 }
 
 // NDEFMessageFromJS is allocating a new
-// NDEFMessage object and copy all values from
-// input javascript object
-func NDEFMessageFromJS(value js.Wrapper) *NDEFMessage {
-	input := value.JSValue()
+// NDEFMessage object and copy all values in the value javascript object.
+func NDEFMessageFromJS(value js.Value) *NDEFMessage {
 	var out NDEFMessage
 	var (
 		value0 []*NDEFRecord // javascript: sequence<NDEFRecord> {records Records records}
 		value1 string        // javascript: USVString {url Url url}
 	)
-	__length0 := input.Get("records").Length()
+	__length0 := value.Get("records").Length()
 	__array0 := make([]*NDEFRecord, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *NDEFRecord
-		__seq_in0 := input.Get("records").Index(__idx0)
+		__seq_in0 := value.Get("records").Index(__idx0)
 		__seq_out0 = NDEFRecordFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Records = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
 	return &out
 }
@@ -270,7 +267,7 @@ type NDEFRecord struct {
 	Data       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NDEFRecord) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -284,21 +281,19 @@ func (_this *NDEFRecord) JSValue() js.Value {
 }
 
 // NDEFRecordFromJS is allocating a new
-// NDEFRecord object and copy all values from
-// input javascript object
-func NDEFRecordFromJS(value js.Wrapper) *NDEFRecord {
-	input := value.JSValue()
+// NDEFRecord object and copy all values in the value javascript object.
+func NDEFRecordFromJS(value js.Value) *NDEFRecord {
 	var out NDEFRecord
 	var (
 		value0 NDEFRecordType // javascript: NDEFRecordType {recordType RecordType recordType}
 		value1 string         // javascript: USVString {mediaType MediaType mediaType}
 		value2 *Union         // javascript: Union {data Data data}
 	)
-	value0 = NDEFRecordTypeFromJS(input.Get("recordType"))
+	value0 = NDEFRecordTypeFromJS(value.Get("recordType"))
 	out.RecordType = value0
-	value1 = (input.Get("mediaType")).String()
+	value1 = (value.Get("mediaType")).String()
 	out.MediaType = value1
-	value2 = UnionFromJS(input.Get("data"))
+	value2 = UnionFromJS(value.Get("data"))
 	out.Data = value2
 	return &out
 }
@@ -312,7 +307,7 @@ type PushOptions struct {
 	Compatibility NDEFCompatibility
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PushOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -330,10 +325,8 @@ func (_this *PushOptions) JSValue() js.Value {
 }
 
 // PushOptionsFromJS is allocating a new
-// PushOptions object and copy all values from
-// input javascript object
-func PushOptionsFromJS(value js.Wrapper) *PushOptions {
-	input := value.JSValue()
+// PushOptions object and copy all values in the value javascript object.
+func PushOptionsFromJS(value js.Value) *PushOptions {
 	var out PushOptions
 	var (
 		value0 PushTarget           // javascript: NFCPushTarget {target Target target}
@@ -342,17 +335,17 @@ func PushOptionsFromJS(value js.Wrapper) *PushOptions {
 		value3 *domcore.AbortSignal // javascript: AbortSignal {signal Signal signal}
 		value4 NDEFCompatibility    // javascript: NDEFCompatibility {compatibility Compatibility compatibility}
 	)
-	value0 = PushTargetFromJS(input.Get("target"))
+	value0 = PushTargetFromJS(value.Get("target"))
 	out.Target = value0
-	value1 = (input.Get("timeout")).Float()
+	value1 = (value.Get("timeout")).Float()
 	out.Timeout = value1
-	value2 = (input.Get("ignoreRead")).Bool()
+	value2 = (value.Get("ignoreRead")).Bool()
 	out.IgnoreRead = value2
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value3 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value3 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value3
-	value4 = NDEFCompatibilityFromJS(input.Get("compatibility"))
+	value4 = NDEFCompatibilityFromJS(value.Get("compatibility"))
 	out.Compatibility = value4
 	return &out
 }
@@ -365,7 +358,7 @@ type ReaderOptions struct {
 	Compatibility NDEFCompatibility
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReaderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -381,10 +374,8 @@ func (_this *ReaderOptions) JSValue() js.Value {
 }
 
 // ReaderOptionsFromJS is allocating a new
-// ReaderOptions object and copy all values from
-// input javascript object
-func ReaderOptionsFromJS(value js.Wrapper) *ReaderOptions {
-	input := value.JSValue()
+// ReaderOptions object and copy all values in the value javascript object.
+func ReaderOptionsFromJS(value js.Value) *ReaderOptions {
 	var out ReaderOptions
 	var (
 		value0 string            // javascript: USVString {url Url url}
@@ -392,13 +383,13 @@ func ReaderOptionsFromJS(value js.Wrapper) *ReaderOptions {
 		value2 string            // javascript: USVString {mediaType MediaType mediaType}
 		value3 NDEFCompatibility // javascript: NDEFCompatibility {compatibility Compatibility compatibility}
 	)
-	value0 = (input.Get("url")).String()
+	value0 = (value.Get("url")).String()
 	out.Url = value0
-	value1 = NDEFRecordTypeFromJS(input.Get("recordType"))
+	value1 = NDEFRecordTypeFromJS(value.Get("recordType"))
 	out.RecordType = value1
-	value2 = (input.Get("mediaType")).String()
+	value2 = (value.Get("mediaType")).String()
 	out.MediaType = value2
-	value3 = NDEFCompatibilityFromJS(input.Get("compatibility"))
+	value3 = NDEFCompatibilityFromJS(value.Get("compatibility"))
 	out.Compatibility = value3
 	return &out
 }
@@ -411,7 +402,7 @@ type ReadingEventInit struct {
 	Message    *NDEFMessage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReadingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -427,10 +418,8 @@ func (_this *ReadingEventInit) JSValue() js.Value {
 }
 
 // ReadingEventInitFromJS is allocating a new
-// ReadingEventInit object and copy all values from
-// input javascript object
-func ReadingEventInitFromJS(value js.Wrapper) *ReadingEventInit {
-	input := value.JSValue()
+// ReadingEventInit object and copy all values in the value javascript object.
+func ReadingEventInitFromJS(value js.Value) *ReadingEventInit {
 	var out ReadingEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -438,13 +427,13 @@ func ReadingEventInitFromJS(value js.Wrapper) *ReadingEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *NDEFMessage // javascript: NDEFMessage {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = NDEFMessageFromJS(input.Get("message"))
+	value3 = NDEFMessageFromJS(value.Get("message"))
 	out.Message = value3
 	return &out
 }
@@ -454,15 +443,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewNFCErrorEvent(_type string, errorEventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -500,15 +493,19 @@ type Reader struct {
 	domcore.EventTarget
 }
 
-// ReaderFromJS is casting a js.Wrapper into Reader.
-func ReaderFromJS(value js.Wrapper) *Reader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReaderFromJS is casting a js.Value into Reader.
+func ReaderFromJS(value js.Value) *Reader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Reader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReaderFromJS is casting from something that holds a js.Value into Reader.
+func ReaderFromWrapper(input core.Wrapper) *Reader {
+	return ReaderFromJS(input.JSValue())
 }
 
 func NewNFCReader(options *ReaderOptions) (_result *Reader) {
@@ -636,15 +633,19 @@ type ReadingEvent struct {
 	domcore.Event
 }
 
-// ReadingEventFromJS is casting a js.Wrapper into ReadingEvent.
-func ReadingEventFromJS(value js.Wrapper) *ReadingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReadingEventFromJS is casting a js.Value into ReadingEvent.
+func ReadingEventFromJS(value js.Value) *ReadingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReadingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReadingEventFromJS is casting from something that holds a js.Value into ReadingEvent.
+func ReadingEventFromWrapper(input core.Wrapper) *ReadingEvent {
+	return ReadingEventFromJS(input.JSValue())
 }
 
 func NewNFCReadingEvent(_type string, readingEventInitDict *ReadingEventInit) (_result *ReadingEvent) {
@@ -687,15 +688,19 @@ func (_this *Writer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WriterFromJS is casting a js.Wrapper into Writer.
-func WriterFromJS(value js.Wrapper) *Writer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WriterFromJS is casting a js.Value into Writer.
+func WriterFromJS(value js.Value) *Writer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Writer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WriterFromJS is casting from something that holds a js.Value into Writer.
+func WriterFromWrapper(input core.Wrapper) *Writer {
+	return WriterFromJS(input.JSValue())
 }
 
 func NewNFCWriter() (_result *Writer) {

--- a/communication/xhr/xhr.go
+++ b/communication/xhr/xhr.go
@@ -7,6 +7,7 @@ package xhr
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/patch"
 )
@@ -96,7 +97,7 @@ type ProgressEventInit struct {
 	Total            int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ProgressEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -116,10 +117,8 @@ func (_this *ProgressEventInit) JSValue() js.Value {
 }
 
 // ProgressEventInitFromJS is allocating a new
-// ProgressEventInit object and copy all values from
-// input javascript object
-func ProgressEventInitFromJS(value js.Wrapper) *ProgressEventInit {
-	input := value.JSValue()
+// ProgressEventInit object and copy all values in the value javascript object.
+func ProgressEventInitFromJS(value js.Value) *ProgressEventInit {
 	var out ProgressEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -129,17 +128,17 @@ func ProgressEventInitFromJS(value js.Wrapper) *ProgressEventInit {
 		value4 int  // javascript: unsigned long long {loaded Loaded loaded}
 		value5 int  // javascript: unsigned long long {total Total total}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("lengthComputable")).Bool()
+	value3 = (value.Get("lengthComputable")).Bool()
 	out.LengthComputable = value3
-	value4 = (input.Get("loaded")).Int()
+	value4 = (value.Get("loaded")).Int()
 	out.Loaded = value4
-	value5 = (input.Get("total")).Int()
+	value5 = (value.Get("total")).Int()
 	out.Total = value5
 	return &out
 }
@@ -149,15 +148,19 @@ type ProgressEvent struct {
 	domcore.Event
 }
 
-// ProgressEventFromJS is casting a js.Wrapper into ProgressEvent.
-func ProgressEventFromJS(value js.Wrapper) *ProgressEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProgressEventFromJS is casting a js.Value into ProgressEvent.
+func ProgressEventFromJS(value js.Value) *ProgressEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProgressEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProgressEventFromJS is casting from something that holds a js.Value into ProgressEvent.
+func ProgressEventFromWrapper(input core.Wrapper) *ProgressEvent {
+	return ProgressEventFromJS(input.JSValue())
 }
 
 func NewProgressEvent(_type string, eventInitDict *ProgressEventInit) (_result *ProgressEvent) {
@@ -215,15 +218,19 @@ type XMLHttpRequest struct {
 	XMLHttpRequestEventTarget
 }
 
-// XMLHttpRequestFromJS is casting a js.Wrapper into XMLHttpRequest.
-func XMLHttpRequestFromJS(value js.Wrapper) *XMLHttpRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestFromJS is casting a js.Value into XMLHttpRequest.
+func XMLHttpRequestFromJS(value js.Value) *XMLHttpRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestFromJS is casting from something that holds a js.Value into XMLHttpRequest.
+func XMLHttpRequestFromWrapper(input core.Wrapper) *XMLHttpRequest {
+	return XMLHttpRequestFromJS(input.JSValue())
 }
 
 const (
@@ -553,15 +560,19 @@ type XMLHttpRequestEventTarget struct {
 	domcore.EventTarget
 }
 
-// XMLHttpRequestEventTargetFromJS is casting a js.Wrapper into XMLHttpRequestEventTarget.
-func XMLHttpRequestEventTargetFromJS(value js.Wrapper) *XMLHttpRequestEventTarget {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestEventTargetFromJS is casting a js.Value into XMLHttpRequestEventTarget.
+func XMLHttpRequestEventTargetFromJS(value js.Value) *XMLHttpRequestEventTarget {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequestEventTarget{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestEventTargetFromJS is casting from something that holds a js.Value into XMLHttpRequestEventTarget.
+func XMLHttpRequestEventTargetFromWrapper(input core.Wrapper) *XMLHttpRequestEventTarget {
+	return XMLHttpRequestEventTargetFromJS(input.JSValue())
 }
 
 // OnLoadStart returning attribute 'onloadstart' with
@@ -772,13 +783,17 @@ type XMLHttpRequestUpload struct {
 	XMLHttpRequestEventTarget
 }
 
-// XMLHttpRequestUploadFromJS is casting a js.Wrapper into XMLHttpRequestUpload.
-func XMLHttpRequestUploadFromJS(value js.Wrapper) *XMLHttpRequestUpload {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestUploadFromJS is casting a js.Value into XMLHttpRequestUpload.
+func XMLHttpRequestUploadFromJS(value js.Value) *XMLHttpRequestUpload {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequestUpload{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestUploadFromJS is casting from something that holds a js.Value into XMLHttpRequestUpload.
+func XMLHttpRequestUploadFromWrapper(input core.Wrapper) *XMLHttpRequestUpload {
+	return XMLHttpRequestUploadFromJS(input.JSValue())
 }

--- a/communication/xhr/xhr_js.go
+++ b/communication/xhr/xhr_js.go
@@ -5,6 +5,7 @@ package xhr
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/patch"
 )
@@ -94,7 +95,7 @@ type ProgressEventInit struct {
 	Total            int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ProgressEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -114,10 +115,8 @@ func (_this *ProgressEventInit) JSValue() js.Value {
 }
 
 // ProgressEventInitFromJS is allocating a new
-// ProgressEventInit object and copy all values from
-// input javascript object
-func ProgressEventInitFromJS(value js.Wrapper) *ProgressEventInit {
-	input := value.JSValue()
+// ProgressEventInit object and copy all values in the value javascript object.
+func ProgressEventInitFromJS(value js.Value) *ProgressEventInit {
 	var out ProgressEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -127,17 +126,17 @@ func ProgressEventInitFromJS(value js.Wrapper) *ProgressEventInit {
 		value4 int  // javascript: unsigned long long {loaded Loaded loaded}
 		value5 int  // javascript: unsigned long long {total Total total}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("lengthComputable")).Bool()
+	value3 = (value.Get("lengthComputable")).Bool()
 	out.LengthComputable = value3
-	value4 = (input.Get("loaded")).Int()
+	value4 = (value.Get("loaded")).Int()
 	out.Loaded = value4
-	value5 = (input.Get("total")).Int()
+	value5 = (value.Get("total")).Int()
 	out.Total = value5
 	return &out
 }
@@ -147,15 +146,19 @@ type ProgressEvent struct {
 	domcore.Event
 }
 
-// ProgressEventFromJS is casting a js.Wrapper into ProgressEvent.
-func ProgressEventFromJS(value js.Wrapper) *ProgressEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProgressEventFromJS is casting a js.Value into ProgressEvent.
+func ProgressEventFromJS(value js.Value) *ProgressEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProgressEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProgressEventFromJS is casting from something that holds a js.Value into ProgressEvent.
+func ProgressEventFromWrapper(input core.Wrapper) *ProgressEvent {
+	return ProgressEventFromJS(input.JSValue())
 }
 
 func NewProgressEvent(_type string, eventInitDict *ProgressEventInit) (_result *ProgressEvent) {
@@ -213,15 +216,19 @@ type XMLHttpRequest struct {
 	XMLHttpRequestEventTarget
 }
 
-// XMLHttpRequestFromJS is casting a js.Wrapper into XMLHttpRequest.
-func XMLHttpRequestFromJS(value js.Wrapper) *XMLHttpRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestFromJS is casting a js.Value into XMLHttpRequest.
+func XMLHttpRequestFromJS(value js.Value) *XMLHttpRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestFromJS is casting from something that holds a js.Value into XMLHttpRequest.
+func XMLHttpRequestFromWrapper(input core.Wrapper) *XMLHttpRequest {
+	return XMLHttpRequestFromJS(input.JSValue())
 }
 
 const (
@@ -551,15 +558,19 @@ type XMLHttpRequestEventTarget struct {
 	domcore.EventTarget
 }
 
-// XMLHttpRequestEventTargetFromJS is casting a js.Wrapper into XMLHttpRequestEventTarget.
-func XMLHttpRequestEventTargetFromJS(value js.Wrapper) *XMLHttpRequestEventTarget {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestEventTargetFromJS is casting a js.Value into XMLHttpRequestEventTarget.
+func XMLHttpRequestEventTargetFromJS(value js.Value) *XMLHttpRequestEventTarget {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequestEventTarget{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestEventTargetFromJS is casting from something that holds a js.Value into XMLHttpRequestEventTarget.
+func XMLHttpRequestEventTargetFromWrapper(input core.Wrapper) *XMLHttpRequestEventTarget {
+	return XMLHttpRequestEventTargetFromJS(input.JSValue())
 }
 
 // OnLoadStart returning attribute 'onloadstart' with
@@ -770,13 +781,17 @@ type XMLHttpRequestUpload struct {
 	XMLHttpRequestEventTarget
 }
 
-// XMLHttpRequestUploadFromJS is casting a js.Wrapper into XMLHttpRequestUpload.
-func XMLHttpRequestUploadFromJS(value js.Wrapper) *XMLHttpRequestUpload {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLHttpRequestUploadFromJS is casting a js.Value into XMLHttpRequestUpload.
+func XMLHttpRequestUploadFromJS(value js.Value) *XMLHttpRequestUpload {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLHttpRequestUpload{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLHttpRequestUploadFromJS is casting from something that holds a js.Value into XMLHttpRequestUpload.
+func XMLHttpRequestUploadFromWrapper(input core.Wrapper) *XMLHttpRequestUpload {
+	return XMLHttpRequestUploadFromJS(input.JSValue())
 }

--- a/cookie/cookie.go
+++ b/cookie/cookie.go
@@ -7,6 +7,7 @@ package cookie
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -402,7 +403,7 @@ type CookieChangeEventInit struct {
 	Deleted    []*CookieListItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -428,10 +429,8 @@ func (_this *CookieChangeEventInit) JSValue() js.Value {
 }
 
 // CookieChangeEventInitFromJS is allocating a new
-// CookieChangeEventInit object and copy all values from
-// input javascript object
-func CookieChangeEventInitFromJS(value js.Wrapper) *CookieChangeEventInit {
-	input := value.JSValue()
+// CookieChangeEventInit object and copy all values in the value javascript object.
+func CookieChangeEventInitFromJS(value js.Value) *CookieChangeEventInit {
 	var out CookieChangeEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -440,27 +439,27 @@ func CookieChangeEventInitFromJS(value js.Wrapper) *CookieChangeEventInit {
 		value3 []*CookieListItem // javascript: sequence<CookieListItem> {changed Changed changed}
 		value4 []*CookieListItem // javascript: sequence<CookieListItem> {deleted Deleted deleted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("changed").Length()
+	__length3 := value.Get("changed").Length()
 	__array3 := make([]*CookieListItem, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *CookieListItem
-		__seq_in3 := input.Get("changed").Index(__idx3)
+		__seq_in3 := value.Get("changed").Index(__idx3)
 		__seq_out3 = CookieListItemFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.Changed = value3
-	__length4 := input.Get("deleted").Length()
+	__length4 := value.Get("deleted").Length()
 	__array4 := make([]*CookieListItem, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *CookieListItem
-		__seq_in4 := input.Get("deleted").Index(__idx4)
+		__seq_in4 := value.Get("deleted").Index(__idx4)
 		__seq_out4 = CookieListItemFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -480,7 +479,7 @@ type CookieListItem struct {
 	SameSite CookieSameSite
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieListItem) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -514,10 +513,8 @@ func (_this *CookieListItem) JSValue() js.Value {
 }
 
 // CookieListItemFromJS is allocating a new
-// CookieListItem object and copy all values from
-// input javascript object
-func CookieListItemFromJS(value js.Wrapper) *CookieListItem {
-	input := value.JSValue()
+// CookieListItem object and copy all values in the value javascript object.
+func CookieListItemFromJS(value js.Value) *CookieListItem {
 	var out CookieListItem
 	var (
 		value0 string         // javascript: USVString {name Name name}
@@ -528,25 +525,25 @@ func CookieListItemFromJS(value js.Wrapper) *CookieListItem {
 		value5 bool           // javascript: boolean {secure Secure secure}
 		value6 CookieSameSite // javascript: CookieSameSite {sameSite SameSite sameSite}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value2 = &__tmp
 	}
 	out.Domain = value2
-	value3 = (input.Get("path")).String()
+	value3 = (value.Get("path")).String()
 	out.Path = value3
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value4 = &__tmp
 	}
 	out.Expires = value4
-	value5 = (input.Get("secure")).Bool()
+	value5 = (value.Get("secure")).Bool()
 	out.Secure = value5
-	value6 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value6 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value6
 	return &out
 }
@@ -558,7 +555,7 @@ type CookieStoreDeleteOptions struct {
 	Path   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreDeleteOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -578,24 +575,22 @@ func (_this *CookieStoreDeleteOptions) JSValue() js.Value {
 }
 
 // CookieStoreDeleteOptionsFromJS is allocating a new
-// CookieStoreDeleteOptions object and copy all values from
-// input javascript object
-func CookieStoreDeleteOptionsFromJS(value js.Wrapper) *CookieStoreDeleteOptions {
-	input := value.JSValue()
+// CookieStoreDeleteOptions object and copy all values in the value javascript object.
+func CookieStoreDeleteOptionsFromJS(value js.Value) *CookieStoreDeleteOptions {
 	var out CookieStoreDeleteOptions
 	var (
 		value0 string  // javascript: USVString {name Name name}
 		value1 *string // javascript: USVString {domain Domain domain}
 		value2 string  // javascript: USVString {path Path path}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
 	return &out
 }
@@ -607,7 +602,7 @@ type CookieStoreGetOptions struct {
 	MatchType CookieMatchType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreGetOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -621,21 +616,19 @@ func (_this *CookieStoreGetOptions) JSValue() js.Value {
 }
 
 // CookieStoreGetOptionsFromJS is allocating a new
-// CookieStoreGetOptions object and copy all values from
-// input javascript object
-func CookieStoreGetOptionsFromJS(value js.Wrapper) *CookieStoreGetOptions {
-	input := value.JSValue()
+// CookieStoreGetOptions object and copy all values in the value javascript object.
+func CookieStoreGetOptionsFromJS(value js.Value) *CookieStoreGetOptions {
 	var out CookieStoreGetOptions
 	var (
 		value0 string          // javascript: USVString {name Name name}
 		value1 string          // javascript: USVString {url Url url}
 		value2 CookieMatchType // javascript: CookieMatchType {matchType MatchType matchType}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
-	value2 = CookieMatchTypeFromJS(input.Get("matchType"))
+	value2 = CookieMatchTypeFromJS(value.Get("matchType"))
 	out.MatchType = value2
 	return &out
 }
@@ -651,7 +644,7 @@ type CookieStoreSetExtraOptions struct {
 	Value    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreSetExtraOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -685,10 +678,8 @@ func (_this *CookieStoreSetExtraOptions) JSValue() js.Value {
 }
 
 // CookieStoreSetExtraOptionsFromJS is allocating a new
-// CookieStoreSetExtraOptions object and copy all values from
-// input javascript object
-func CookieStoreSetExtraOptionsFromJS(value js.Wrapper) *CookieStoreSetExtraOptions {
-	input := value.JSValue()
+// CookieStoreSetExtraOptions object and copy all values in the value javascript object.
+func CookieStoreSetExtraOptionsFromJS(value js.Value) *CookieStoreSetExtraOptions {
 	var out CookieStoreSetExtraOptions
 	var (
 		value0 *int           // javascript: unsigned long long {expires Expires expires}
@@ -699,25 +690,25 @@ func CookieStoreSetExtraOptionsFromJS(value js.Wrapper) *CookieStoreSetExtraOpti
 		value5 string         // javascript: USVString {name Name name}
 		value6 string         // javascript: USVString {value Value value}
 	)
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value0 = &__tmp
 	}
 	out.Expires = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
-	value3 = (input.Get("secure")).Bool()
+	value3 = (value.Get("secure")).Bool()
 	out.Secure = value3
-	value4 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value4 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value4
-	value5 = (input.Get("name")).String()
+	value5 = (value.Get("name")).String()
 	out.Name = value5
-	value6 = (input.Get("value")).String()
+	value6 = (value.Get("value")).String()
 	out.Value = value6
 	return &out
 }
@@ -731,7 +722,7 @@ type CookieStoreSetOptions struct {
 	SameSite CookieSameSite
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreSetOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -761,10 +752,8 @@ func (_this *CookieStoreSetOptions) JSValue() js.Value {
 }
 
 // CookieStoreSetOptionsFromJS is allocating a new
-// CookieStoreSetOptions object and copy all values from
-// input javascript object
-func CookieStoreSetOptionsFromJS(value js.Wrapper) *CookieStoreSetOptions {
-	input := value.JSValue()
+// CookieStoreSetOptions object and copy all values in the value javascript object.
+func CookieStoreSetOptionsFromJS(value js.Value) *CookieStoreSetOptions {
 	var out CookieStoreSetOptions
 	var (
 		value0 *int           // javascript: unsigned long long {expires Expires expires}
@@ -773,21 +762,21 @@ func CookieStoreSetOptionsFromJS(value js.Wrapper) *CookieStoreSetOptions {
 		value3 bool           // javascript: boolean {secure Secure secure}
 		value4 CookieSameSite // javascript: CookieSameSite {sameSite SameSite sameSite}
 	)
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value0 = &__tmp
 	}
 	out.Expires = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
-	value3 = (input.Get("secure")).Bool()
+	value3 = (value.Get("secure")).Bool()
 	out.Secure = value3
-	value4 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value4 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value4
 	return &out
 }
@@ -801,7 +790,7 @@ type ExtendableCookieChangeEventInit struct {
 	Deleted    []*CookieListItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableCookieChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -827,10 +816,8 @@ func (_this *ExtendableCookieChangeEventInit) JSValue() js.Value {
 }
 
 // ExtendableCookieChangeEventInitFromJS is allocating a new
-// ExtendableCookieChangeEventInit object and copy all values from
-// input javascript object
-func ExtendableCookieChangeEventInitFromJS(value js.Wrapper) *ExtendableCookieChangeEventInit {
-	input := value.JSValue()
+// ExtendableCookieChangeEventInit object and copy all values in the value javascript object.
+func ExtendableCookieChangeEventInitFromJS(value js.Value) *ExtendableCookieChangeEventInit {
 	var out ExtendableCookieChangeEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -839,27 +826,27 @@ func ExtendableCookieChangeEventInitFromJS(value js.Wrapper) *ExtendableCookieCh
 		value3 []*CookieListItem // javascript: sequence<CookieListItem> {changed Changed changed}
 		value4 []*CookieListItem // javascript: sequence<CookieListItem> {deleted Deleted deleted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("changed").Length()
+	__length3 := value.Get("changed").Length()
 	__array3 := make([]*CookieListItem, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *CookieListItem
-		__seq_in3 := input.Get("changed").Index(__idx3)
+		__seq_in3 := value.Get("changed").Index(__idx3)
 		__seq_out3 = CookieListItemFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.Changed = value3
-	__length4 := input.Get("deleted").Length()
+	__length4 := value.Get("deleted").Length()
 	__array4 := make([]*CookieListItem, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *CookieListItem
-		__seq_in4 := input.Get("deleted").Index(__idx4)
+		__seq_in4 := value.Get("deleted").Index(__idx4)
 		__seq_out4 = CookieListItemFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -873,15 +860,19 @@ type CookieChangeEvent struct {
 	domcore.Event
 }
 
-// CookieChangeEventFromJS is casting a js.Wrapper into CookieChangeEvent.
-func CookieChangeEventFromJS(value js.Wrapper) *CookieChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CookieChangeEventFromJS is casting a js.Value into CookieChangeEvent.
+func CookieChangeEventFromJS(value js.Value) *CookieChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CookieChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CookieChangeEventFromJS is casting from something that holds a js.Value into CookieChangeEvent.
+func CookieChangeEventFromWrapper(input core.Wrapper) *CookieChangeEvent {
+	return CookieChangeEventFromJS(input.JSValue())
 }
 
 func NewCookieChangeEvent(_type string, eventInitDict *CookieChangeEventInit) (_result *CookieChangeEvent) {
@@ -946,15 +937,19 @@ type CookieStore struct {
 	domcore.EventTarget
 }
 
-// CookieStoreFromJS is casting a js.Wrapper into CookieStore.
-func CookieStoreFromJS(value js.Wrapper) *CookieStore {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CookieStoreFromJS is casting a js.Value into CookieStore.
+func CookieStoreFromJS(value js.Value) *CookieStore {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CookieStore{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CookieStoreFromJS is casting from something that holds a js.Value into CookieStore.
+func CookieStoreFromWrapper(input core.Wrapper) *CookieStore {
+	return CookieStoreFromJS(input.JSValue())
 }
 
 // OnChange returning attribute 'onchange' with
@@ -1186,15 +1181,19 @@ type ExtendableCookieChangeEvent struct {
 	domcore.ExtendableEvent
 }
 
-// ExtendableCookieChangeEventFromJS is casting a js.Wrapper into ExtendableCookieChangeEvent.
-func ExtendableCookieChangeEventFromJS(value js.Wrapper) *ExtendableCookieChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableCookieChangeEventFromJS is casting a js.Value into ExtendableCookieChangeEvent.
+func ExtendableCookieChangeEventFromJS(value js.Value) *ExtendableCookieChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableCookieChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableCookieChangeEventFromJS is casting from something that holds a js.Value into ExtendableCookieChangeEvent.
+func ExtendableCookieChangeEventFromWrapper(input core.Wrapper) *ExtendableCookieChangeEvent {
+	return ExtendableCookieChangeEventFromJS(input.JSValue())
 }
 
 func NewExtendableCookieChangeEvent(_type string, eventInitDict *ExtendableCookieChangeEventInit) (_result *ExtendableCookieChangeEvent) {
@@ -1264,15 +1263,19 @@ func (_this *PromiseNilCookieListItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilCookieListItemFromJS is casting a js.Wrapper into PromiseNilCookieListItem.
-func PromiseNilCookieListItemFromJS(value js.Wrapper) *PromiseNilCookieListItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilCookieListItemFromJS is casting a js.Value into PromiseNilCookieListItem.
+func PromiseNilCookieListItemFromJS(value js.Value) *PromiseNilCookieListItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilCookieListItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilCookieListItemFromJS is casting from something that holds a js.Value into PromiseNilCookieListItem.
+func PromiseNilCookieListItemFromWrapper(input core.Wrapper) *PromiseNilCookieListItem {
+	return PromiseNilCookieListItemFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilCookieListItem) Then(onFulfilled *PromiseNilCookieListItemOnFulfilled, onRejected *PromiseNilCookieListItemOnRejected) (_result *PromiseNilCookieListItem) {
@@ -1369,15 +1372,19 @@ func (_this *PromiseSequenceCookieListItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceCookieListItemFromJS is casting a js.Wrapper into PromiseSequenceCookieListItem.
-func PromiseSequenceCookieListItemFromJS(value js.Wrapper) *PromiseSequenceCookieListItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceCookieListItemFromJS is casting a js.Value into PromiseSequenceCookieListItem.
+func PromiseSequenceCookieListItemFromJS(value js.Value) *PromiseSequenceCookieListItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceCookieListItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceCookieListItemFromJS is casting from something that holds a js.Value into PromiseSequenceCookieListItem.
+func PromiseSequenceCookieListItemFromWrapper(input core.Wrapper) *PromiseSequenceCookieListItem {
+	return PromiseSequenceCookieListItemFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceCookieListItem) Then(onFulfilled *PromiseSequenceCookieListItemOnFulfilled, onRejected *PromiseSequenceCookieListItemOnRejected) (_result *PromiseSequenceCookieListItem) {
@@ -1474,15 +1481,19 @@ func (_this *PromiseSequenceCookieStoreGetOptions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceCookieStoreGetOptionsFromJS is casting a js.Wrapper into PromiseSequenceCookieStoreGetOptions.
-func PromiseSequenceCookieStoreGetOptionsFromJS(value js.Wrapper) *PromiseSequenceCookieStoreGetOptions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceCookieStoreGetOptionsFromJS is casting a js.Value into PromiseSequenceCookieStoreGetOptions.
+func PromiseSequenceCookieStoreGetOptionsFromJS(value js.Value) *PromiseSequenceCookieStoreGetOptions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceCookieStoreGetOptions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceCookieStoreGetOptionsFromJS is casting from something that holds a js.Value into PromiseSequenceCookieStoreGetOptions.
+func PromiseSequenceCookieStoreGetOptionsFromWrapper(input core.Wrapper) *PromiseSequenceCookieStoreGetOptions {
+	return PromiseSequenceCookieStoreGetOptionsFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceCookieStoreGetOptions) Then(onFulfilled *PromiseSequenceCookieStoreGetOptionsOnFulfilled, onRejected *PromiseSequenceCookieStoreGetOptionsOnRejected) (_result *PromiseSequenceCookieStoreGetOptions) {

--- a/cookie/cookie_js.go
+++ b/cookie/cookie_js.go
@@ -5,6 +5,7 @@ package cookie
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -400,7 +401,7 @@ type CookieChangeEventInit struct {
 	Deleted    []*CookieListItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -426,10 +427,8 @@ func (_this *CookieChangeEventInit) JSValue() js.Value {
 }
 
 // CookieChangeEventInitFromJS is allocating a new
-// CookieChangeEventInit object and copy all values from
-// input javascript object
-func CookieChangeEventInitFromJS(value js.Wrapper) *CookieChangeEventInit {
-	input := value.JSValue()
+// CookieChangeEventInit object and copy all values in the value javascript object.
+func CookieChangeEventInitFromJS(value js.Value) *CookieChangeEventInit {
 	var out CookieChangeEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -438,27 +437,27 @@ func CookieChangeEventInitFromJS(value js.Wrapper) *CookieChangeEventInit {
 		value3 []*CookieListItem // javascript: sequence<CookieListItem> {changed Changed changed}
 		value4 []*CookieListItem // javascript: sequence<CookieListItem> {deleted Deleted deleted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("changed").Length()
+	__length3 := value.Get("changed").Length()
 	__array3 := make([]*CookieListItem, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *CookieListItem
-		__seq_in3 := input.Get("changed").Index(__idx3)
+		__seq_in3 := value.Get("changed").Index(__idx3)
 		__seq_out3 = CookieListItemFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.Changed = value3
-	__length4 := input.Get("deleted").Length()
+	__length4 := value.Get("deleted").Length()
 	__array4 := make([]*CookieListItem, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *CookieListItem
-		__seq_in4 := input.Get("deleted").Index(__idx4)
+		__seq_in4 := value.Get("deleted").Index(__idx4)
 		__seq_out4 = CookieListItemFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -478,7 +477,7 @@ type CookieListItem struct {
 	SameSite CookieSameSite
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieListItem) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -512,10 +511,8 @@ func (_this *CookieListItem) JSValue() js.Value {
 }
 
 // CookieListItemFromJS is allocating a new
-// CookieListItem object and copy all values from
-// input javascript object
-func CookieListItemFromJS(value js.Wrapper) *CookieListItem {
-	input := value.JSValue()
+// CookieListItem object and copy all values in the value javascript object.
+func CookieListItemFromJS(value js.Value) *CookieListItem {
 	var out CookieListItem
 	var (
 		value0 string         // javascript: USVString {name Name name}
@@ -526,25 +523,25 @@ func CookieListItemFromJS(value js.Wrapper) *CookieListItem {
 		value5 bool           // javascript: boolean {secure Secure secure}
 		value6 CookieSameSite // javascript: CookieSameSite {sameSite SameSite sameSite}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value2 = &__tmp
 	}
 	out.Domain = value2
-	value3 = (input.Get("path")).String()
+	value3 = (value.Get("path")).String()
 	out.Path = value3
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value4 = &__tmp
 	}
 	out.Expires = value4
-	value5 = (input.Get("secure")).Bool()
+	value5 = (value.Get("secure")).Bool()
 	out.Secure = value5
-	value6 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value6 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value6
 	return &out
 }
@@ -556,7 +553,7 @@ type CookieStoreDeleteOptions struct {
 	Path   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreDeleteOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -576,24 +573,22 @@ func (_this *CookieStoreDeleteOptions) JSValue() js.Value {
 }
 
 // CookieStoreDeleteOptionsFromJS is allocating a new
-// CookieStoreDeleteOptions object and copy all values from
-// input javascript object
-func CookieStoreDeleteOptionsFromJS(value js.Wrapper) *CookieStoreDeleteOptions {
-	input := value.JSValue()
+// CookieStoreDeleteOptions object and copy all values in the value javascript object.
+func CookieStoreDeleteOptionsFromJS(value js.Value) *CookieStoreDeleteOptions {
 	var out CookieStoreDeleteOptions
 	var (
 		value0 string  // javascript: USVString {name Name name}
 		value1 *string // javascript: USVString {domain Domain domain}
 		value2 string  // javascript: USVString {path Path path}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
 	return &out
 }
@@ -605,7 +600,7 @@ type CookieStoreGetOptions struct {
 	MatchType CookieMatchType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreGetOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -619,21 +614,19 @@ func (_this *CookieStoreGetOptions) JSValue() js.Value {
 }
 
 // CookieStoreGetOptionsFromJS is allocating a new
-// CookieStoreGetOptions object and copy all values from
-// input javascript object
-func CookieStoreGetOptionsFromJS(value js.Wrapper) *CookieStoreGetOptions {
-	input := value.JSValue()
+// CookieStoreGetOptions object and copy all values in the value javascript object.
+func CookieStoreGetOptionsFromJS(value js.Value) *CookieStoreGetOptions {
 	var out CookieStoreGetOptions
 	var (
 		value0 string          // javascript: USVString {name Name name}
 		value1 string          // javascript: USVString {url Url url}
 		value2 CookieMatchType // javascript: CookieMatchType {matchType MatchType matchType}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("url")).String()
+	value1 = (value.Get("url")).String()
 	out.Url = value1
-	value2 = CookieMatchTypeFromJS(input.Get("matchType"))
+	value2 = CookieMatchTypeFromJS(value.Get("matchType"))
 	out.MatchType = value2
 	return &out
 }
@@ -649,7 +642,7 @@ type CookieStoreSetExtraOptions struct {
 	Value    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreSetExtraOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -683,10 +676,8 @@ func (_this *CookieStoreSetExtraOptions) JSValue() js.Value {
 }
 
 // CookieStoreSetExtraOptionsFromJS is allocating a new
-// CookieStoreSetExtraOptions object and copy all values from
-// input javascript object
-func CookieStoreSetExtraOptionsFromJS(value js.Wrapper) *CookieStoreSetExtraOptions {
-	input := value.JSValue()
+// CookieStoreSetExtraOptions object and copy all values in the value javascript object.
+func CookieStoreSetExtraOptionsFromJS(value js.Value) *CookieStoreSetExtraOptions {
 	var out CookieStoreSetExtraOptions
 	var (
 		value0 *int           // javascript: unsigned long long {expires Expires expires}
@@ -697,25 +688,25 @@ func CookieStoreSetExtraOptionsFromJS(value js.Wrapper) *CookieStoreSetExtraOpti
 		value5 string         // javascript: USVString {name Name name}
 		value6 string         // javascript: USVString {value Value value}
 	)
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value0 = &__tmp
 	}
 	out.Expires = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
-	value3 = (input.Get("secure")).Bool()
+	value3 = (value.Get("secure")).Bool()
 	out.Secure = value3
-	value4 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value4 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value4
-	value5 = (input.Get("name")).String()
+	value5 = (value.Get("name")).String()
 	out.Name = value5
-	value6 = (input.Get("value")).String()
+	value6 = (value.Get("value")).String()
 	out.Value = value6
 	return &out
 }
@@ -729,7 +720,7 @@ type CookieStoreSetOptions struct {
 	SameSite CookieSameSite
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CookieStoreSetOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -759,10 +750,8 @@ func (_this *CookieStoreSetOptions) JSValue() js.Value {
 }
 
 // CookieStoreSetOptionsFromJS is allocating a new
-// CookieStoreSetOptions object and copy all values from
-// input javascript object
-func CookieStoreSetOptionsFromJS(value js.Wrapper) *CookieStoreSetOptions {
-	input := value.JSValue()
+// CookieStoreSetOptions object and copy all values in the value javascript object.
+func CookieStoreSetOptionsFromJS(value js.Value) *CookieStoreSetOptions {
 	var out CookieStoreSetOptions
 	var (
 		value0 *int           // javascript: unsigned long long {expires Expires expires}
@@ -771,21 +760,21 @@ func CookieStoreSetOptionsFromJS(value js.Wrapper) *CookieStoreSetOptions {
 		value3 bool           // javascript: boolean {secure Secure secure}
 		value4 CookieSameSite // javascript: CookieSameSite {sameSite SameSite sameSite}
 	)
-	if input.Get("expires").Type() != js.TypeNull && input.Get("expires").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expires")).Int()
+	if value.Get("expires").Type() != js.TypeNull && value.Get("expires").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expires")).Int()
 		value0 = &__tmp
 	}
 	out.Expires = value0
-	if input.Get("domain").Type() != js.TypeNull && input.Get("domain").Type() != js.TypeUndefined {
-		__tmp := (input.Get("domain")).String()
+	if value.Get("domain").Type() != js.TypeNull && value.Get("domain").Type() != js.TypeUndefined {
+		__tmp := (value.Get("domain")).String()
 		value1 = &__tmp
 	}
 	out.Domain = value1
-	value2 = (input.Get("path")).String()
+	value2 = (value.Get("path")).String()
 	out.Path = value2
-	value3 = (input.Get("secure")).Bool()
+	value3 = (value.Get("secure")).Bool()
 	out.Secure = value3
-	value4 = CookieSameSiteFromJS(input.Get("sameSite"))
+	value4 = CookieSameSiteFromJS(value.Get("sameSite"))
 	out.SameSite = value4
 	return &out
 }
@@ -799,7 +788,7 @@ type ExtendableCookieChangeEventInit struct {
 	Deleted    []*CookieListItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableCookieChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -825,10 +814,8 @@ func (_this *ExtendableCookieChangeEventInit) JSValue() js.Value {
 }
 
 // ExtendableCookieChangeEventInitFromJS is allocating a new
-// ExtendableCookieChangeEventInit object and copy all values from
-// input javascript object
-func ExtendableCookieChangeEventInitFromJS(value js.Wrapper) *ExtendableCookieChangeEventInit {
-	input := value.JSValue()
+// ExtendableCookieChangeEventInit object and copy all values in the value javascript object.
+func ExtendableCookieChangeEventInitFromJS(value js.Value) *ExtendableCookieChangeEventInit {
 	var out ExtendableCookieChangeEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -837,27 +824,27 @@ func ExtendableCookieChangeEventInitFromJS(value js.Wrapper) *ExtendableCookieCh
 		value3 []*CookieListItem // javascript: sequence<CookieListItem> {changed Changed changed}
 		value4 []*CookieListItem // javascript: sequence<CookieListItem> {deleted Deleted deleted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("changed").Length()
+	__length3 := value.Get("changed").Length()
 	__array3 := make([]*CookieListItem, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *CookieListItem
-		__seq_in3 := input.Get("changed").Index(__idx3)
+		__seq_in3 := value.Get("changed").Index(__idx3)
 		__seq_out3 = CookieListItemFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.Changed = value3
-	__length4 := input.Get("deleted").Length()
+	__length4 := value.Get("deleted").Length()
 	__array4 := make([]*CookieListItem, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *CookieListItem
-		__seq_in4 := input.Get("deleted").Index(__idx4)
+		__seq_in4 := value.Get("deleted").Index(__idx4)
 		__seq_out4 = CookieListItemFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
@@ -871,15 +858,19 @@ type CookieChangeEvent struct {
 	domcore.Event
 }
 
-// CookieChangeEventFromJS is casting a js.Wrapper into CookieChangeEvent.
-func CookieChangeEventFromJS(value js.Wrapper) *CookieChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CookieChangeEventFromJS is casting a js.Value into CookieChangeEvent.
+func CookieChangeEventFromJS(value js.Value) *CookieChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CookieChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CookieChangeEventFromJS is casting from something that holds a js.Value into CookieChangeEvent.
+func CookieChangeEventFromWrapper(input core.Wrapper) *CookieChangeEvent {
+	return CookieChangeEventFromJS(input.JSValue())
 }
 
 func NewCookieChangeEvent(_type string, eventInitDict *CookieChangeEventInit) (_result *CookieChangeEvent) {
@@ -944,15 +935,19 @@ type CookieStore struct {
 	domcore.EventTarget
 }
 
-// CookieStoreFromJS is casting a js.Wrapper into CookieStore.
-func CookieStoreFromJS(value js.Wrapper) *CookieStore {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CookieStoreFromJS is casting a js.Value into CookieStore.
+func CookieStoreFromJS(value js.Value) *CookieStore {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CookieStore{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CookieStoreFromJS is casting from something that holds a js.Value into CookieStore.
+func CookieStoreFromWrapper(input core.Wrapper) *CookieStore {
+	return CookieStoreFromJS(input.JSValue())
 }
 
 // OnChange returning attribute 'onchange' with
@@ -1184,15 +1179,19 @@ type ExtendableCookieChangeEvent struct {
 	domcore.ExtendableEvent
 }
 
-// ExtendableCookieChangeEventFromJS is casting a js.Wrapper into ExtendableCookieChangeEvent.
-func ExtendableCookieChangeEventFromJS(value js.Wrapper) *ExtendableCookieChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableCookieChangeEventFromJS is casting a js.Value into ExtendableCookieChangeEvent.
+func ExtendableCookieChangeEventFromJS(value js.Value) *ExtendableCookieChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableCookieChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableCookieChangeEventFromJS is casting from something that holds a js.Value into ExtendableCookieChangeEvent.
+func ExtendableCookieChangeEventFromWrapper(input core.Wrapper) *ExtendableCookieChangeEvent {
+	return ExtendableCookieChangeEventFromJS(input.JSValue())
 }
 
 func NewExtendableCookieChangeEvent(_type string, eventInitDict *ExtendableCookieChangeEventInit) (_result *ExtendableCookieChangeEvent) {
@@ -1262,15 +1261,19 @@ func (_this *PromiseNilCookieListItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilCookieListItemFromJS is casting a js.Wrapper into PromiseNilCookieListItem.
-func PromiseNilCookieListItemFromJS(value js.Wrapper) *PromiseNilCookieListItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilCookieListItemFromJS is casting a js.Value into PromiseNilCookieListItem.
+func PromiseNilCookieListItemFromJS(value js.Value) *PromiseNilCookieListItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilCookieListItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilCookieListItemFromJS is casting from something that holds a js.Value into PromiseNilCookieListItem.
+func PromiseNilCookieListItemFromWrapper(input core.Wrapper) *PromiseNilCookieListItem {
+	return PromiseNilCookieListItemFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilCookieListItem) Then(onFulfilled *PromiseNilCookieListItemOnFulfilled, onRejected *PromiseNilCookieListItemOnRejected) (_result *PromiseNilCookieListItem) {
@@ -1367,15 +1370,19 @@ func (_this *PromiseSequenceCookieListItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceCookieListItemFromJS is casting a js.Wrapper into PromiseSequenceCookieListItem.
-func PromiseSequenceCookieListItemFromJS(value js.Wrapper) *PromiseSequenceCookieListItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceCookieListItemFromJS is casting a js.Value into PromiseSequenceCookieListItem.
+func PromiseSequenceCookieListItemFromJS(value js.Value) *PromiseSequenceCookieListItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceCookieListItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceCookieListItemFromJS is casting from something that holds a js.Value into PromiseSequenceCookieListItem.
+func PromiseSequenceCookieListItemFromWrapper(input core.Wrapper) *PromiseSequenceCookieListItem {
+	return PromiseSequenceCookieListItemFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceCookieListItem) Then(onFulfilled *PromiseSequenceCookieListItemOnFulfilled, onRejected *PromiseSequenceCookieListItemOnRejected) (_result *PromiseSequenceCookieListItem) {
@@ -1472,15 +1479,19 @@ func (_this *PromiseSequenceCookieStoreGetOptions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceCookieStoreGetOptionsFromJS is casting a js.Wrapper into PromiseSequenceCookieStoreGetOptions.
-func PromiseSequenceCookieStoreGetOptionsFromJS(value js.Wrapper) *PromiseSequenceCookieStoreGetOptions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceCookieStoreGetOptionsFromJS is casting a js.Value into PromiseSequenceCookieStoreGetOptions.
+func PromiseSequenceCookieStoreGetOptionsFromJS(value js.Value) *PromiseSequenceCookieStoreGetOptions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceCookieStoreGetOptions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceCookieStoreGetOptionsFromJS is casting from something that holds a js.Value into PromiseSequenceCookieStoreGetOptions.
+func PromiseSequenceCookieStoreGetOptionsFromWrapper(input core.Wrapper) *PromiseSequenceCookieStoreGetOptions {
+	return PromiseSequenceCookieStoreGetOptionsFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceCookieStoreGetOptions) Then(onFulfilled *PromiseSequenceCookieStoreGetOptionsOnFulfilled, onRejected *PromiseSequenceCookieStoreGetOptionsOnRejected) (_result *PromiseSequenceCookieStoreGetOptions) {

--- a/core/core.go
+++ b/core/core.go
@@ -1,0 +1,12 @@
+//go:build !js
+
+// Package core adds core components needed by the library that is not auto-generated.
+package core
+
+import "github.com/gowebapi/webapi/core/js"
+
+// Wrapper is implemented by types that are backed by a JavaScript value.
+type Wrapper interface {
+	// JSValue returns a JavaScript value associated with an object.
+	JSValue() js.Value
+}

--- a/core/core_js.go
+++ b/core/core_js.go
@@ -1,0 +1,10 @@
+// Package core adds core components needed by the library that is not auto-generated.
+package core
+
+import "syscall/js"
+
+// Wrapper is implemented by types that are backed by a JavaScript value.
+type Wrapper interface {
+	// JSValue returns a JavaScript value associated with an object.
+	JSValue() js.Value
+}

--- a/core/js/js.go
+++ b/core/js/js.go
@@ -1,16 +1,16 @@
+//go:build !js
+
 // Part of this is taken from Go language source code:
 //
 // Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !js
-
-// Package js is equal api to syscall/js but is panic on all method invocation
-// when compiled under none wasm taget.
+// Package js is the same api as syscall/js, but when not
+// compiling under WASM target it panics.
 //
-// The usage is to get a tab complession to work inside an IDE
-// (e.g. Visual Studio Code) without changing to GOOS to js
+// The objective is to get tab completion to work inside an IDE
+// (e.g. Visual Studio Code, GoLand) without having to change GOOS to js.
 //
 // Original documentation:
 //

--- a/core/js/js_js.go
+++ b/core/js/js_js.go
@@ -4,11 +4,11 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package js is equal api to syscall/js but is panic on all method invocation
-// when compiled under none wasm taget.
+// Package js is the same api as syscall/js, but when not
+// compiling under WASM target it panics.
 //
-// The usage is to get a tab complession to work inside an IDE
-// (e.g. Visual Studio Code) without changing to GOOS to js
+// The objective is to get tab completion to work inside an IDE
+// (e.g. Visual Studio Code, GoLand) without having to change GOOS to js.
 //
 // Original documentation:
 //
@@ -114,6 +114,3 @@ func ValueOf(x interface{}) Value {
 // a Value that does not support it. Such cases are documented
 // in the description of each method.
 type ValueError = js.ValueError
-
-// Wrapper is implemented by types that are backed by a JavaScript value.
-type Wrapper = js.Wrapper

--- a/crypto/authentication/authentication.go
+++ b/crypto/authentication/authentication.go
@@ -7,6 +7,7 @@ package authentication
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/sensor"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -264,7 +265,7 @@ type AuthenticationExtensionsClientInputs struct {
 	Uvm           bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticationExtensionsClientInputs) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -292,10 +293,8 @@ func (_this *AuthenticationExtensionsClientInputs) JSValue() js.Value {
 }
 
 // AuthenticationExtensionsClientInputsFromJS is allocating a new
-// AuthenticationExtensionsClientInputs object and copy all values from
-// input javascript object
-func AuthenticationExtensionsClientInputsFromJS(value js.Wrapper) *AuthenticationExtensionsClientInputs {
-	input := value.JSValue()
+// AuthenticationExtensionsClientInputs object and copy all values in the value javascript object.
+func AuthenticationExtensionsClientInputsFromJS(value js.Value) *AuthenticationExtensionsClientInputs {
 	var out AuthenticationExtensionsClientInputs
 	var (
 		value0 string            // javascript: USVString {appid Appid appid}
@@ -307,29 +306,29 @@ func AuthenticationExtensionsClientInputsFromJS(value js.Wrapper) *Authenticatio
 		value6 bool              // javascript: boolean {loc Loc loc}
 		value7 bool              // javascript: boolean {uvm Uvm uvm}
 	)
-	value0 = (input.Get("appid")).String()
+	value0 = (value.Get("appid")).String()
 	out.Appid = value0
-	value1 = (input.Get("txAuthSimple")).String()
+	value1 = (value.Get("txAuthSimple")).String()
 	out.TxAuthSimple = value1
-	value2 = TxAuthGenericArgFromJS(input.Get("txAuthGeneric"))
+	value2 = TxAuthGenericArgFromJS(value.Get("txAuthGeneric"))
 	out.TxAuthGeneric = value2
-	__length3 := input.Get("authnSel").Length()
+	__length3 := value.Get("authnSel").Length()
 	__array3 := make([]*Union, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *Union
-		__seq_in3 := input.Get("authnSel").Index(__idx3)
+		__seq_in3 := value.Get("authnSel").Index(__idx3)
 		__seq_out3 = UnionFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.AuthnSel = value3
-	value4 = (input.Get("exts")).Bool()
+	value4 = (value.Get("exts")).Bool()
 	out.Exts = value4
-	value5 = (input.Get("uvi")).Bool()
+	value5 = (value.Get("uvi")).Bool()
 	out.Uvi = value5
-	value6 = (input.Get("loc")).Bool()
+	value6 = (value.Get("loc")).Bool()
 	out.Loc = value6
-	value7 = (input.Get("uvm")).Bool()
+	value7 = (value.Get("uvm")).Bool()
 	out.Uvm = value7
 	return &out
 }
@@ -346,7 +345,7 @@ type AuthenticationExtensionsClientOutputs struct {
 	Uvm           [][]uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticationExtensionsClientOutputs) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -382,10 +381,8 @@ func (_this *AuthenticationExtensionsClientOutputs) JSValue() js.Value {
 }
 
 // AuthenticationExtensionsClientOutputsFromJS is allocating a new
-// AuthenticationExtensionsClientOutputs object and copy all values from
-// input javascript object
-func AuthenticationExtensionsClientOutputsFromJS(value js.Wrapper) *AuthenticationExtensionsClientOutputs {
-	input := value.JSValue()
+// AuthenticationExtensionsClientOutputs object and copy all values in the value javascript object.
+func AuthenticationExtensionsClientOutputsFromJS(value js.Value) *AuthenticationExtensionsClientOutputs {
 	var out AuthenticationExtensionsClientOutputs
 	var (
 		value0 bool                    // javascript: boolean {appid Appid appid}
@@ -397,33 +394,33 @@ func AuthenticationExtensionsClientOutputsFromJS(value js.Wrapper) *Authenticati
 		value6 *sensor.Coordinates     // javascript: Coordinates {loc Loc loc}
 		value7 [][]uint                // javascript: sequence<sequence<unsigned long>> {uvm Uvm uvm}
 	)
-	value0 = (input.Get("appid")).Bool()
+	value0 = (value.Get("appid")).Bool()
 	out.Appid = value0
-	value1 = (input.Get("txAuthSimple")).String()
+	value1 = (value.Get("txAuthSimple")).String()
 	out.TxAuthSimple = value1
-	value2 = javascript.ArrayBufferFromJS(input.Get("txAuthGeneric"))
+	value2 = javascript.ArrayBufferFromJS(value.Get("txAuthGeneric"))
 	out.TxAuthGeneric = value2
-	value3 = (input.Get("authnSel")).Bool()
+	value3 = (value.Get("authnSel")).Bool()
 	out.AuthnSel = value3
-	__length4 := input.Get("exts").Length()
+	__length4 := value.Get("exts").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("exts").Index(__idx4)
+		__seq_in4 := value.Get("exts").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Exts = value4
-	value5 = javascript.ArrayBufferFromJS(input.Get("uvi"))
+	value5 = javascript.ArrayBufferFromJS(value.Get("uvi"))
 	out.Uvi = value5
-	value6 = sensor.CoordinatesFromJS(input.Get("loc"))
+	value6 = sensor.CoordinatesFromJS(value.Get("loc"))
 	out.Loc = value6
-	__length7 := input.Get("uvm").Length()
+	__length7 := value.Get("uvm").Length()
 	__array7 := make([][]uint, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 []uint
-		__seq_in7 := input.Get("uvm").Index(__idx7)
+		__seq_in7 := value.Get("uvm").Index(__idx7)
 		__length8 := __seq_in7.Length()
 		__array8 := make([]uint, __length8, __length8)
 		for __idx8 := 0; __idx8 < __length8; __idx8++ {
@@ -446,7 +443,7 @@ type AuthenticatorBiometricPerfBounds struct {
 	FRR float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticatorBiometricPerfBounds) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -458,18 +455,16 @@ func (_this *AuthenticatorBiometricPerfBounds) JSValue() js.Value {
 }
 
 // AuthenticatorBiometricPerfBoundsFromJS is allocating a new
-// AuthenticatorBiometricPerfBounds object and copy all values from
-// input javascript object
-func AuthenticatorBiometricPerfBoundsFromJS(value js.Wrapper) *AuthenticatorBiometricPerfBounds {
-	input := value.JSValue()
+// AuthenticatorBiometricPerfBounds object and copy all values in the value javascript object.
+func AuthenticatorBiometricPerfBoundsFromJS(value js.Value) *AuthenticatorBiometricPerfBounds {
 	var out AuthenticatorBiometricPerfBounds
 	var (
 		value0 float32 // javascript: float {FAR FAR fAR}
 		value1 float32 // javascript: float {FRR FRR fRR}
 	)
-	value0 = (float32)((input.Get("FAR")).Float())
+	value0 = (float32)((value.Get("FAR")).Float())
 	out.FAR = value0
-	value1 = (float32)((input.Get("FRR")).Float())
+	value1 = (float32)((value.Get("FRR")).Float())
 	out.FRR = value1
 	return &out
 }
@@ -482,7 +477,7 @@ type CollectedClientData struct {
 	TokenBinding *TokenBinding
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CollectedClientData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -498,10 +493,8 @@ func (_this *CollectedClientData) JSValue() js.Value {
 }
 
 // CollectedClientDataFromJS is allocating a new
-// CollectedClientData object and copy all values from
-// input javascript object
-func CollectedClientDataFromJS(value js.Wrapper) *CollectedClientData {
-	input := value.JSValue()
+// CollectedClientData object and copy all values in the value javascript object.
+func CollectedClientDataFromJS(value js.Value) *CollectedClientData {
 	var out CollectedClientData
 	var (
 		value0 string        // javascript: DOMString {type Type _type}
@@ -509,13 +502,13 @@ func CollectedClientDataFromJS(value js.Wrapper) *CollectedClientData {
 		value2 string        // javascript: DOMString {origin Origin origin}
 		value3 *TokenBinding // javascript: TokenBinding {tokenBinding TokenBinding tokenBinding}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("challenge")).String()
+	value1 = (value.Get("challenge")).String()
 	out.Challenge = value1
-	value2 = (input.Get("origin")).String()
+	value2 = (value.Get("origin")).String()
 	out.Origin = value2
-	value3 = TokenBindingFromJS(input.Get("tokenBinding"))
+	value3 = TokenBindingFromJS(value.Get("tokenBinding"))
 	out.TokenBinding = value3
 	return &out
 }
@@ -527,7 +520,7 @@ type SelectionCriteria struct {
 	UserVerification        UserVerificationRequirement
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SelectionCriteria) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -541,21 +534,19 @@ func (_this *SelectionCriteria) JSValue() js.Value {
 }
 
 // SelectionCriteriaFromJS is allocating a new
-// SelectionCriteria object and copy all values from
-// input javascript object
-func SelectionCriteriaFromJS(value js.Wrapper) *SelectionCriteria {
-	input := value.JSValue()
+// SelectionCriteria object and copy all values in the value javascript object.
+func SelectionCriteriaFromJS(value js.Value) *SelectionCriteria {
 	var out SelectionCriteria
 	var (
 		value0 Attachment                  // javascript: AuthenticatorAttachment {authenticatorAttachment AuthenticatorAttachment authenticatorAttachment}
 		value1 bool                        // javascript: boolean {requireResidentKey RequireResidentKey requireResidentKey}
 		value2 UserVerificationRequirement // javascript: UserVerificationRequirement {userVerification UserVerification userVerification}
 	)
-	value0 = AttachmentFromJS(input.Get("authenticatorAttachment"))
+	value0 = AttachmentFromJS(value.Get("authenticatorAttachment"))
 	out.AuthenticatorAttachment = value0
-	value1 = (input.Get("requireResidentKey")).Bool()
+	value1 = (value.Get("requireResidentKey")).Bool()
 	out.RequireResidentKey = value1
-	value2 = UserVerificationRequirementFromJS(input.Get("userVerification"))
+	value2 = UserVerificationRequirementFromJS(value.Get("userVerification"))
 	out.UserVerification = value2
 	return &out
 }
@@ -566,7 +557,7 @@ type TokenBinding struct {
 	Id     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TokenBinding) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -578,18 +569,16 @@ func (_this *TokenBinding) JSValue() js.Value {
 }
 
 // TokenBindingFromJS is allocating a new
-// TokenBinding object and copy all values from
-// input javascript object
-func TokenBindingFromJS(value js.Wrapper) *TokenBinding {
-	input := value.JSValue()
+// TokenBinding object and copy all values in the value javascript object.
+func TokenBindingFromJS(value js.Value) *TokenBinding {
 	var out TokenBinding
 	var (
 		value0 TokenBindingStatus // javascript: TokenBindingStatus {status Status status}
 		value1 string             // javascript: DOMString {id Id id}
 	)
-	value0 = TokenBindingStatusFromJS(input.Get("status"))
+	value0 = TokenBindingStatusFromJS(value.Get("status"))
 	out.Status = value0
-	value1 = (input.Get("id")).String()
+	value1 = (value.Get("id")).String()
 	out.Id = value1
 	return &out
 }
@@ -600,7 +589,7 @@ type TxAuthGenericArg struct {
 	Content     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TxAuthGenericArg) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -612,18 +601,16 @@ func (_this *TxAuthGenericArg) JSValue() js.Value {
 }
 
 // TxAuthGenericArgFromJS is allocating a new
-// TxAuthGenericArg object and copy all values from
-// input javascript object
-func TxAuthGenericArgFromJS(value js.Wrapper) *TxAuthGenericArg {
-	input := value.JSValue()
+// TxAuthGenericArg object and copy all values in the value javascript object.
+func TxAuthGenericArgFromJS(value js.Value) *TxAuthGenericArg {
 	var out TxAuthGenericArg
 	var (
 		value0 string                  // javascript: USVString {contentType ContentType contentType}
 		value1 *javascript.ArrayBuffer // javascript: ArrayBuffer {content Content content}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = javascript.ArrayBufferFromJS(input.Get("content"))
+	value1 = javascript.ArrayBufferFromJS(value.Get("content"))
 	out.Content = value1
 	return &out
 }
@@ -633,15 +620,19 @@ type AssertionResponse struct {
 	Response
 }
 
-// AssertionResponseFromJS is casting a js.Wrapper into AssertionResponse.
-func AssertionResponseFromJS(value js.Wrapper) *AssertionResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AssertionResponseFromJS is casting a js.Value into AssertionResponse.
+func AssertionResponseFromJS(value js.Value) *AssertionResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AssertionResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AssertionResponseFromJS is casting from something that holds a js.Value into AssertionResponse.
+func AssertionResponseFromWrapper(input core.Wrapper) *AssertionResponse {
+	return AssertionResponseFromJS(input.JSValue())
 }
 
 // AuthenticatorData returning attribute 'authenticatorData' with
@@ -678,15 +669,19 @@ type AttestationResponse struct {
 	Response
 }
 
-// AttestationResponseFromJS is casting a js.Wrapper into AttestationResponse.
-func AttestationResponseFromJS(value js.Wrapper) *AttestationResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AttestationResponseFromJS is casting a js.Value into AttestationResponse.
+func AttestationResponseFromJS(value js.Value) *AttestationResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AttestationResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AttestationResponseFromJS is casting from something that holds a js.Value into AttestationResponse.
+func AttestationResponseFromWrapper(input core.Wrapper) *AttestationResponse {
+	return AttestationResponseFromJS(input.JSValue())
 }
 
 // AttestationObject returning attribute 'attestationObject' with
@@ -708,15 +703,19 @@ func (_this *Response) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResponseFromJS is casting a js.Wrapper into Response.
-func ResponseFromJS(value js.Wrapper) *Response {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResponseFromJS is casting a js.Value into Response.
+func ResponseFromJS(value js.Value) *Response {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Response{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResponseFromJS is casting from something that holds a js.Value into Response.
+func ResponseFromWrapper(input core.Wrapper) *Response {
+	return ResponseFromJS(input.JSValue())
 }
 
 // ClientDataJSON returning attribute 'clientDataJSON' with

--- a/crypto/authentication/authentication_js.go
+++ b/crypto/authentication/authentication_js.go
@@ -5,6 +5,7 @@ package authentication
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/sensor"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -262,7 +263,7 @@ type AuthenticationExtensionsClientInputs struct {
 	Uvm           bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticationExtensionsClientInputs) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -290,10 +291,8 @@ func (_this *AuthenticationExtensionsClientInputs) JSValue() js.Value {
 }
 
 // AuthenticationExtensionsClientInputsFromJS is allocating a new
-// AuthenticationExtensionsClientInputs object and copy all values from
-// input javascript object
-func AuthenticationExtensionsClientInputsFromJS(value js.Wrapper) *AuthenticationExtensionsClientInputs {
-	input := value.JSValue()
+// AuthenticationExtensionsClientInputs object and copy all values in the value javascript object.
+func AuthenticationExtensionsClientInputsFromJS(value js.Value) *AuthenticationExtensionsClientInputs {
 	var out AuthenticationExtensionsClientInputs
 	var (
 		value0 string            // javascript: USVString {appid Appid appid}
@@ -305,29 +304,29 @@ func AuthenticationExtensionsClientInputsFromJS(value js.Wrapper) *Authenticatio
 		value6 bool              // javascript: boolean {loc Loc loc}
 		value7 bool              // javascript: boolean {uvm Uvm uvm}
 	)
-	value0 = (input.Get("appid")).String()
+	value0 = (value.Get("appid")).String()
 	out.Appid = value0
-	value1 = (input.Get("txAuthSimple")).String()
+	value1 = (value.Get("txAuthSimple")).String()
 	out.TxAuthSimple = value1
-	value2 = TxAuthGenericArgFromJS(input.Get("txAuthGeneric"))
+	value2 = TxAuthGenericArgFromJS(value.Get("txAuthGeneric"))
 	out.TxAuthGeneric = value2
-	__length3 := input.Get("authnSel").Length()
+	__length3 := value.Get("authnSel").Length()
 	__array3 := make([]*Union, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *Union
-		__seq_in3 := input.Get("authnSel").Index(__idx3)
+		__seq_in3 := value.Get("authnSel").Index(__idx3)
 		__seq_out3 = UnionFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.AuthnSel = value3
-	value4 = (input.Get("exts")).Bool()
+	value4 = (value.Get("exts")).Bool()
 	out.Exts = value4
-	value5 = (input.Get("uvi")).Bool()
+	value5 = (value.Get("uvi")).Bool()
 	out.Uvi = value5
-	value6 = (input.Get("loc")).Bool()
+	value6 = (value.Get("loc")).Bool()
 	out.Loc = value6
-	value7 = (input.Get("uvm")).Bool()
+	value7 = (value.Get("uvm")).Bool()
 	out.Uvm = value7
 	return &out
 }
@@ -344,7 +343,7 @@ type AuthenticationExtensionsClientOutputs struct {
 	Uvm           [][]uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticationExtensionsClientOutputs) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -380,10 +379,8 @@ func (_this *AuthenticationExtensionsClientOutputs) JSValue() js.Value {
 }
 
 // AuthenticationExtensionsClientOutputsFromJS is allocating a new
-// AuthenticationExtensionsClientOutputs object and copy all values from
-// input javascript object
-func AuthenticationExtensionsClientOutputsFromJS(value js.Wrapper) *AuthenticationExtensionsClientOutputs {
-	input := value.JSValue()
+// AuthenticationExtensionsClientOutputs object and copy all values in the value javascript object.
+func AuthenticationExtensionsClientOutputsFromJS(value js.Value) *AuthenticationExtensionsClientOutputs {
 	var out AuthenticationExtensionsClientOutputs
 	var (
 		value0 bool                    // javascript: boolean {appid Appid appid}
@@ -395,33 +392,33 @@ func AuthenticationExtensionsClientOutputsFromJS(value js.Wrapper) *Authenticati
 		value6 *sensor.Coordinates     // javascript: Coordinates {loc Loc loc}
 		value7 [][]uint                // javascript: sequence<sequence<unsigned long>> {uvm Uvm uvm}
 	)
-	value0 = (input.Get("appid")).Bool()
+	value0 = (value.Get("appid")).Bool()
 	out.Appid = value0
-	value1 = (input.Get("txAuthSimple")).String()
+	value1 = (value.Get("txAuthSimple")).String()
 	out.TxAuthSimple = value1
-	value2 = javascript.ArrayBufferFromJS(input.Get("txAuthGeneric"))
+	value2 = javascript.ArrayBufferFromJS(value.Get("txAuthGeneric"))
 	out.TxAuthGeneric = value2
-	value3 = (input.Get("authnSel")).Bool()
+	value3 = (value.Get("authnSel")).Bool()
 	out.AuthnSel = value3
-	__length4 := input.Get("exts").Length()
+	__length4 := value.Get("exts").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("exts").Index(__idx4)
+		__seq_in4 := value.Get("exts").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Exts = value4
-	value5 = javascript.ArrayBufferFromJS(input.Get("uvi"))
+	value5 = javascript.ArrayBufferFromJS(value.Get("uvi"))
 	out.Uvi = value5
-	value6 = sensor.CoordinatesFromJS(input.Get("loc"))
+	value6 = sensor.CoordinatesFromJS(value.Get("loc"))
 	out.Loc = value6
-	__length7 := input.Get("uvm").Length()
+	__length7 := value.Get("uvm").Length()
 	__array7 := make([][]uint, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 []uint
-		__seq_in7 := input.Get("uvm").Index(__idx7)
+		__seq_in7 := value.Get("uvm").Index(__idx7)
 		__length8 := __seq_in7.Length()
 		__array8 := make([]uint, __length8, __length8)
 		for __idx8 := 0; __idx8 < __length8; __idx8++ {
@@ -444,7 +441,7 @@ type AuthenticatorBiometricPerfBounds struct {
 	FRR float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AuthenticatorBiometricPerfBounds) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -456,18 +453,16 @@ func (_this *AuthenticatorBiometricPerfBounds) JSValue() js.Value {
 }
 
 // AuthenticatorBiometricPerfBoundsFromJS is allocating a new
-// AuthenticatorBiometricPerfBounds object and copy all values from
-// input javascript object
-func AuthenticatorBiometricPerfBoundsFromJS(value js.Wrapper) *AuthenticatorBiometricPerfBounds {
-	input := value.JSValue()
+// AuthenticatorBiometricPerfBounds object and copy all values in the value javascript object.
+func AuthenticatorBiometricPerfBoundsFromJS(value js.Value) *AuthenticatorBiometricPerfBounds {
 	var out AuthenticatorBiometricPerfBounds
 	var (
 		value0 float32 // javascript: float {FAR FAR fAR}
 		value1 float32 // javascript: float {FRR FRR fRR}
 	)
-	value0 = (float32)((input.Get("FAR")).Float())
+	value0 = (float32)((value.Get("FAR")).Float())
 	out.FAR = value0
-	value1 = (float32)((input.Get("FRR")).Float())
+	value1 = (float32)((value.Get("FRR")).Float())
 	out.FRR = value1
 	return &out
 }
@@ -480,7 +475,7 @@ type CollectedClientData struct {
 	TokenBinding *TokenBinding
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CollectedClientData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -496,10 +491,8 @@ func (_this *CollectedClientData) JSValue() js.Value {
 }
 
 // CollectedClientDataFromJS is allocating a new
-// CollectedClientData object and copy all values from
-// input javascript object
-func CollectedClientDataFromJS(value js.Wrapper) *CollectedClientData {
-	input := value.JSValue()
+// CollectedClientData object and copy all values in the value javascript object.
+func CollectedClientDataFromJS(value js.Value) *CollectedClientData {
 	var out CollectedClientData
 	var (
 		value0 string        // javascript: DOMString {type Type _type}
@@ -507,13 +500,13 @@ func CollectedClientDataFromJS(value js.Wrapper) *CollectedClientData {
 		value2 string        // javascript: DOMString {origin Origin origin}
 		value3 *TokenBinding // javascript: TokenBinding {tokenBinding TokenBinding tokenBinding}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("challenge")).String()
+	value1 = (value.Get("challenge")).String()
 	out.Challenge = value1
-	value2 = (input.Get("origin")).String()
+	value2 = (value.Get("origin")).String()
 	out.Origin = value2
-	value3 = TokenBindingFromJS(input.Get("tokenBinding"))
+	value3 = TokenBindingFromJS(value.Get("tokenBinding"))
 	out.TokenBinding = value3
 	return &out
 }
@@ -525,7 +518,7 @@ type SelectionCriteria struct {
 	UserVerification        UserVerificationRequirement
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SelectionCriteria) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -539,21 +532,19 @@ func (_this *SelectionCriteria) JSValue() js.Value {
 }
 
 // SelectionCriteriaFromJS is allocating a new
-// SelectionCriteria object and copy all values from
-// input javascript object
-func SelectionCriteriaFromJS(value js.Wrapper) *SelectionCriteria {
-	input := value.JSValue()
+// SelectionCriteria object and copy all values in the value javascript object.
+func SelectionCriteriaFromJS(value js.Value) *SelectionCriteria {
 	var out SelectionCriteria
 	var (
 		value0 Attachment                  // javascript: AuthenticatorAttachment {authenticatorAttachment AuthenticatorAttachment authenticatorAttachment}
 		value1 bool                        // javascript: boolean {requireResidentKey RequireResidentKey requireResidentKey}
 		value2 UserVerificationRequirement // javascript: UserVerificationRequirement {userVerification UserVerification userVerification}
 	)
-	value0 = AttachmentFromJS(input.Get("authenticatorAttachment"))
+	value0 = AttachmentFromJS(value.Get("authenticatorAttachment"))
 	out.AuthenticatorAttachment = value0
-	value1 = (input.Get("requireResidentKey")).Bool()
+	value1 = (value.Get("requireResidentKey")).Bool()
 	out.RequireResidentKey = value1
-	value2 = UserVerificationRequirementFromJS(input.Get("userVerification"))
+	value2 = UserVerificationRequirementFromJS(value.Get("userVerification"))
 	out.UserVerification = value2
 	return &out
 }
@@ -564,7 +555,7 @@ type TokenBinding struct {
 	Id     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TokenBinding) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -576,18 +567,16 @@ func (_this *TokenBinding) JSValue() js.Value {
 }
 
 // TokenBindingFromJS is allocating a new
-// TokenBinding object and copy all values from
-// input javascript object
-func TokenBindingFromJS(value js.Wrapper) *TokenBinding {
-	input := value.JSValue()
+// TokenBinding object and copy all values in the value javascript object.
+func TokenBindingFromJS(value js.Value) *TokenBinding {
 	var out TokenBinding
 	var (
 		value0 TokenBindingStatus // javascript: TokenBindingStatus {status Status status}
 		value1 string             // javascript: DOMString {id Id id}
 	)
-	value0 = TokenBindingStatusFromJS(input.Get("status"))
+	value0 = TokenBindingStatusFromJS(value.Get("status"))
 	out.Status = value0
-	value1 = (input.Get("id")).String()
+	value1 = (value.Get("id")).String()
 	out.Id = value1
 	return &out
 }
@@ -598,7 +587,7 @@ type TxAuthGenericArg struct {
 	Content     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TxAuthGenericArg) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -610,18 +599,16 @@ func (_this *TxAuthGenericArg) JSValue() js.Value {
 }
 
 // TxAuthGenericArgFromJS is allocating a new
-// TxAuthGenericArg object and copy all values from
-// input javascript object
-func TxAuthGenericArgFromJS(value js.Wrapper) *TxAuthGenericArg {
-	input := value.JSValue()
+// TxAuthGenericArg object and copy all values in the value javascript object.
+func TxAuthGenericArgFromJS(value js.Value) *TxAuthGenericArg {
 	var out TxAuthGenericArg
 	var (
 		value0 string                  // javascript: USVString {contentType ContentType contentType}
 		value1 *javascript.ArrayBuffer // javascript: ArrayBuffer {content Content content}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = javascript.ArrayBufferFromJS(input.Get("content"))
+	value1 = javascript.ArrayBufferFromJS(value.Get("content"))
 	out.Content = value1
 	return &out
 }
@@ -631,15 +618,19 @@ type AssertionResponse struct {
 	Response
 }
 
-// AssertionResponseFromJS is casting a js.Wrapper into AssertionResponse.
-func AssertionResponseFromJS(value js.Wrapper) *AssertionResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AssertionResponseFromJS is casting a js.Value into AssertionResponse.
+func AssertionResponseFromJS(value js.Value) *AssertionResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AssertionResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AssertionResponseFromJS is casting from something that holds a js.Value into AssertionResponse.
+func AssertionResponseFromWrapper(input core.Wrapper) *AssertionResponse {
+	return AssertionResponseFromJS(input.JSValue())
 }
 
 // AuthenticatorData returning attribute 'authenticatorData' with
@@ -676,15 +667,19 @@ type AttestationResponse struct {
 	Response
 }
 
-// AttestationResponseFromJS is casting a js.Wrapper into AttestationResponse.
-func AttestationResponseFromJS(value js.Wrapper) *AttestationResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AttestationResponseFromJS is casting a js.Value into AttestationResponse.
+func AttestationResponseFromJS(value js.Value) *AttestationResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AttestationResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AttestationResponseFromJS is casting from something that holds a js.Value into AttestationResponse.
+func AttestationResponseFromWrapper(input core.Wrapper) *AttestationResponse {
+	return AttestationResponseFromJS(input.JSValue())
 }
 
 // AttestationObject returning attribute 'attestationObject' with
@@ -706,15 +701,19 @@ func (_this *Response) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResponseFromJS is casting a js.Wrapper into Response.
-func ResponseFromJS(value js.Wrapper) *Response {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResponseFromJS is casting a js.Value into Response.
+func ResponseFromJS(value js.Value) *Response {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Response{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResponseFromJS is casting from something that holds a js.Value into Response.
+func ResponseFromWrapper(input core.Wrapper) *Response {
+	return ResponseFromJS(input.JSValue())
 }
 
 // ClientDataJSON returning attribute 'clientDataJSON' with

--- a/crypto/credential/credential.go
+++ b/crypto/credential/credential.go
@@ -7,6 +7,7 @@ package credential
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto/authentication"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
@@ -305,7 +306,7 @@ type CredentialCreationOptions struct {
 	PublicKey *PublicKeyCredentialCreationOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -321,10 +322,8 @@ func (_this *CredentialCreationOptions) JSValue() js.Value {
 }
 
 // CredentialCreationOptionsFromJS is allocating a new
-// CredentialCreationOptions object and copy all values from
-// input javascript object
-func CredentialCreationOptionsFromJS(value js.Wrapper) *CredentialCreationOptions {
-	input := value.JSValue()
+// CredentialCreationOptions object and copy all values in the value javascript object.
+func CredentialCreationOptionsFromJS(value js.Value) *CredentialCreationOptions {
 	var out CredentialCreationOptions
 	var (
 		value0 *domcore.AbortSignal                // javascript: AbortSignal {signal Signal signal}
@@ -332,13 +331,13 @@ func CredentialCreationOptionsFromJS(value js.Wrapper) *CredentialCreationOption
 		value2 *FederatedCredentialInit            // javascript: FederatedCredentialInit {federated Federated federated}
 		value3 *PublicKeyCredentialCreationOptions // javascript: PublicKeyCredentialCreationOptions {publicKey PublicKey publicKey}
 	)
-	value0 = domcore.AbortSignalFromJS(input.Get("signal"))
+	value0 = domcore.AbortSignalFromJS(value.Get("signal"))
 	out.Signal = value0
-	value1 = UnionFromJS(input.Get("password"))
+	value1 = UnionFromJS(value.Get("password"))
 	out.Password = value1
-	value2 = FederatedCredentialInitFromJS(input.Get("federated"))
+	value2 = FederatedCredentialInitFromJS(value.Get("federated"))
 	out.Federated = value2
-	value3 = PublicKeyCredentialCreationOptionsFromJS(input.Get("publicKey"))
+	value3 = PublicKeyCredentialCreationOptionsFromJS(value.Get("publicKey"))
 	out.PublicKey = value3
 	return &out
 }
@@ -348,7 +347,7 @@ type CredentialData struct {
 	Id string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -358,15 +357,13 @@ func (_this *CredentialData) JSValue() js.Value {
 }
 
 // CredentialDataFromJS is allocating a new
-// CredentialData object and copy all values from
-// input javascript object
-func CredentialDataFromJS(value js.Wrapper) *CredentialData {
-	input := value.JSValue()
+// CredentialData object and copy all values in the value javascript object.
+func CredentialDataFromJS(value js.Value) *CredentialData {
 	var out CredentialData
 	var (
 		value0 string // javascript: USVString {id Id id}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
 	return &out
 }
@@ -380,7 +377,7 @@ type CredentialRequestOptions struct {
 	PublicKey *PublicKeyCredentialRequestOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -398,10 +395,8 @@ func (_this *CredentialRequestOptions) JSValue() js.Value {
 }
 
 // CredentialRequestOptionsFromJS is allocating a new
-// CredentialRequestOptions object and copy all values from
-// input javascript object
-func CredentialRequestOptionsFromJS(value js.Wrapper) *CredentialRequestOptions {
-	input := value.JSValue()
+// CredentialRequestOptions object and copy all values in the value javascript object.
+func CredentialRequestOptionsFromJS(value js.Value) *CredentialRequestOptions {
 	var out CredentialRequestOptions
 	var (
 		value0 CredentialMediationRequirement     // javascript: CredentialMediationRequirement {mediation Mediation mediation}
@@ -410,15 +405,15 @@ func CredentialRequestOptionsFromJS(value js.Wrapper) *CredentialRequestOptions 
 		value3 *FederatedCredentialRequestOptions // javascript: FederatedCredentialRequestOptions {federated Federated federated}
 		value4 *PublicKeyCredentialRequestOptions // javascript: PublicKeyCredentialRequestOptions {publicKey PublicKey publicKey}
 	)
-	value0 = CredentialMediationRequirementFromJS(input.Get("mediation"))
+	value0 = CredentialMediationRequirementFromJS(value.Get("mediation"))
 	out.Mediation = value0
-	value1 = domcore.AbortSignalFromJS(input.Get("signal"))
+	value1 = domcore.AbortSignalFromJS(value.Get("signal"))
 	out.Signal = value1
-	value2 = (input.Get("password")).Bool()
+	value2 = (value.Get("password")).Bool()
 	out.Password = value2
-	value3 = FederatedCredentialRequestOptionsFromJS(input.Get("federated"))
+	value3 = FederatedCredentialRequestOptionsFromJS(value.Get("federated"))
 	out.Federated = value3
-	value4 = PublicKeyCredentialRequestOptionsFromJS(input.Get("publicKey"))
+	value4 = PublicKeyCredentialRequestOptionsFromJS(value.Get("publicKey"))
 	out.PublicKey = value4
 	return &out
 }
@@ -433,7 +428,7 @@ type FederatedCredentialInit struct {
 	Protocol string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FederatedCredentialInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -453,10 +448,8 @@ func (_this *FederatedCredentialInit) JSValue() js.Value {
 }
 
 // FederatedCredentialInitFromJS is allocating a new
-// FederatedCredentialInit object and copy all values from
-// input javascript object
-func FederatedCredentialInitFromJS(value js.Wrapper) *FederatedCredentialInit {
-	input := value.JSValue()
+// FederatedCredentialInit object and copy all values in the value javascript object.
+func FederatedCredentialInitFromJS(value js.Value) *FederatedCredentialInit {
 	var out FederatedCredentialInit
 	var (
 		value0 string // javascript: USVString {id Id id}
@@ -466,17 +459,17 @@ func FederatedCredentialInitFromJS(value js.Wrapper) *FederatedCredentialInit {
 		value4 string // javascript: USVString {provider Provider provider}
 		value5 string // javascript: DOMString {protocol Protocol protocol}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("iconURL")).String()
+	value2 = (value.Get("iconURL")).String()
 	out.IconURL = value2
-	value3 = (input.Get("origin")).String()
+	value3 = (value.Get("origin")).String()
 	out.Origin = value3
-	value4 = (input.Get("provider")).String()
+	value4 = (value.Get("provider")).String()
 	out.Provider = value4
-	value5 = (input.Get("protocol")).String()
+	value5 = (value.Get("protocol")).String()
 	out.Protocol = value5
 	return &out
 }
@@ -487,7 +480,7 @@ type FederatedCredentialRequestOptions struct {
 	Protocols []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FederatedCredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -507,30 +500,28 @@ func (_this *FederatedCredentialRequestOptions) JSValue() js.Value {
 }
 
 // FederatedCredentialRequestOptionsFromJS is allocating a new
-// FederatedCredentialRequestOptions object and copy all values from
-// input javascript object
-func FederatedCredentialRequestOptionsFromJS(value js.Wrapper) *FederatedCredentialRequestOptions {
-	input := value.JSValue()
+// FederatedCredentialRequestOptions object and copy all values in the value javascript object.
+func FederatedCredentialRequestOptionsFromJS(value js.Value) *FederatedCredentialRequestOptions {
 	var out FederatedCredentialRequestOptions
 	var (
 		value0 []string // javascript: sequence<USVString> {providers Providers providers}
 		value1 []string // javascript: sequence<DOMString> {protocols Protocols protocols}
 	)
-	__length0 := input.Get("providers").Length()
+	__length0 := value.Get("providers").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("providers").Index(__idx0)
+		__seq_in0 := value.Get("providers").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Providers = value0
-	__length1 := input.Get("protocols").Length()
+	__length1 := value.Get("protocols").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("protocols").Index(__idx1)
+		__seq_in1 := value.Get("protocols").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
@@ -548,7 +539,7 @@ type PasswordCredentialData struct {
 	Password string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PasswordCredentialData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -566,10 +557,8 @@ func (_this *PasswordCredentialData) JSValue() js.Value {
 }
 
 // PasswordCredentialDataFromJS is allocating a new
-// PasswordCredentialData object and copy all values from
-// input javascript object
-func PasswordCredentialDataFromJS(value js.Wrapper) *PasswordCredentialData {
-	input := value.JSValue()
+// PasswordCredentialData object and copy all values in the value javascript object.
+func PasswordCredentialDataFromJS(value js.Value) *PasswordCredentialData {
 	var out PasswordCredentialData
 	var (
 		value0 string // javascript: USVString {id Id id}
@@ -578,15 +567,15 @@ func PasswordCredentialDataFromJS(value js.Wrapper) *PasswordCredentialData {
 		value3 string // javascript: USVString {origin Origin origin}
 		value4 string // javascript: USVString {password Password password}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("iconURL")).String()
+	value2 = (value.Get("iconURL")).String()
 	out.IconURL = value2
-	value3 = (input.Get("origin")).String()
+	value3 = (value.Get("origin")).String()
 	out.Origin = value3
-	value4 = (input.Get("password")).String()
+	value4 = (value.Get("password")).String()
 	out.Password = value4
 	return &out
 }
@@ -604,7 +593,7 @@ type PublicKeyCredentialCreationOptions struct {
 	Extensions             *authentication.AuthenticationExtensionsClientInputs
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -638,10 +627,8 @@ func (_this *PublicKeyCredentialCreationOptions) JSValue() js.Value {
 }
 
 // PublicKeyCredentialCreationOptionsFromJS is allocating a new
-// PublicKeyCredentialCreationOptions object and copy all values from
-// input javascript object
-func PublicKeyCredentialCreationOptionsFromJS(value js.Wrapper) *PublicKeyCredentialCreationOptions {
-	input := value.JSValue()
+// PublicKeyCredentialCreationOptions object and copy all values in the value javascript object.
+func PublicKeyCredentialCreationOptionsFromJS(value js.Value) *PublicKeyCredentialCreationOptions {
 	var out PublicKeyCredentialCreationOptions
 	var (
 		value0 *PublicKeyCredentialRpEntity                         // javascript: PublicKeyCredentialRpEntity {rp Rp rp}
@@ -654,39 +641,39 @@ func PublicKeyCredentialCreationOptionsFromJS(value js.Wrapper) *PublicKeyCreden
 		value7 authentication.AttestationConveyancePreference       // javascript: AttestationConveyancePreference {attestation Attestation attestation}
 		value8 *authentication.AuthenticationExtensionsClientInputs // javascript: AuthenticationExtensionsClientInputs {extensions Extensions extensions}
 	)
-	value0 = PublicKeyCredentialRpEntityFromJS(input.Get("rp"))
+	value0 = PublicKeyCredentialRpEntityFromJS(value.Get("rp"))
 	out.Rp = value0
-	value1 = PublicKeyCredentialUserEntityFromJS(input.Get("user"))
+	value1 = PublicKeyCredentialUserEntityFromJS(value.Get("user"))
 	out.User = value1
-	value2 = UnionFromJS(input.Get("challenge"))
+	value2 = UnionFromJS(value.Get("challenge"))
 	out.Challenge = value2
-	__length3 := input.Get("pubKeyCredParams").Length()
+	__length3 := value.Get("pubKeyCredParams").Length()
 	__array3 := make([]*PublicKeyCredentialParameters, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *PublicKeyCredentialParameters
-		__seq_in3 := input.Get("pubKeyCredParams").Index(__idx3)
+		__seq_in3 := value.Get("pubKeyCredParams").Index(__idx3)
 		__seq_out3 = PublicKeyCredentialParametersFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.PubKeyCredParams = value3
-	value4 = (uint)((input.Get("timeout")).Int())
+	value4 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value4
-	__length5 := input.Get("excludeCredentials").Length()
+	__length5 := value.Get("excludeCredentials").Length()
 	__array5 := make([]*PublicKeyCredentialDescriptor, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *PublicKeyCredentialDescriptor
-		__seq_in5 := input.Get("excludeCredentials").Index(__idx5)
+		__seq_in5 := value.Get("excludeCredentials").Index(__idx5)
 		__seq_out5 = PublicKeyCredentialDescriptorFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.ExcludeCredentials = value5
-	value6 = authentication.SelectionCriteriaFromJS(input.Get("authenticatorSelection"))
+	value6 = authentication.SelectionCriteriaFromJS(value.Get("authenticatorSelection"))
 	out.AuthenticatorSelection = value6
-	value7 = authentication.AttestationConveyancePreferenceFromJS(input.Get("attestation"))
+	value7 = authentication.AttestationConveyancePreferenceFromJS(value.Get("attestation"))
 	out.Attestation = value7
-	value8 = authentication.AuthenticationExtensionsClientInputsFromJS(input.Get("extensions"))
+	value8 = authentication.AuthenticationExtensionsClientInputsFromJS(value.Get("extensions"))
 	out.Extensions = value8
 	return &out
 }
@@ -698,7 +685,7 @@ type PublicKeyCredentialDescriptor struct {
 	Transports []authentication.Transport
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -716,25 +703,23 @@ func (_this *PublicKeyCredentialDescriptor) JSValue() js.Value {
 }
 
 // PublicKeyCredentialDescriptorFromJS is allocating a new
-// PublicKeyCredentialDescriptor object and copy all values from
-// input javascript object
-func PublicKeyCredentialDescriptorFromJS(value js.Wrapper) *PublicKeyCredentialDescriptor {
-	input := value.JSValue()
+// PublicKeyCredentialDescriptor object and copy all values in the value javascript object.
+func PublicKeyCredentialDescriptorFromJS(value js.Value) *PublicKeyCredentialDescriptor {
 	var out PublicKeyCredentialDescriptor
 	var (
 		value0 PublicKeyCredentialType    // javascript: PublicKeyCredentialType {type Type _type}
 		value1 *Union                     // javascript: Union {id Id id}
 		value2 []authentication.Transport // javascript: sequence<AuthenticatorTransport> {transports Transports transports}
 	)
-	value0 = PublicKeyCredentialTypeFromJS(input.Get("type"))
+	value0 = PublicKeyCredentialTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = UnionFromJS(input.Get("id"))
+	value1 = UnionFromJS(value.Get("id"))
 	out.Id = value1
-	__length2 := input.Get("transports").Length()
+	__length2 := value.Get("transports").Length()
 	__array2 := make([]authentication.Transport, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 authentication.Transport
-		__seq_in2 := input.Get("transports").Index(__idx2)
+		__seq_in2 := value.Get("transports").Index(__idx2)
 		__seq_out2 = authentication.TransportFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -749,7 +734,7 @@ type PublicKeyCredentialEntity struct {
 	Icon string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -761,18 +746,16 @@ func (_this *PublicKeyCredentialEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialEntityFromJS is allocating a new
-// PublicKeyCredentialEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialEntityFromJS(value js.Wrapper) *PublicKeyCredentialEntity {
-	input := value.JSValue()
+// PublicKeyCredentialEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialEntityFromJS(value js.Value) *PublicKeyCredentialEntity {
 	var out PublicKeyCredentialEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: USVString {icon Icon icon}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
 	return &out
 }
@@ -783,7 +766,7 @@ type PublicKeyCredentialParameters struct {
 	Alg  int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -795,18 +778,16 @@ func (_this *PublicKeyCredentialParameters) JSValue() js.Value {
 }
 
 // PublicKeyCredentialParametersFromJS is allocating a new
-// PublicKeyCredentialParameters object and copy all values from
-// input javascript object
-func PublicKeyCredentialParametersFromJS(value js.Wrapper) *PublicKeyCredentialParameters {
-	input := value.JSValue()
+// PublicKeyCredentialParameters object and copy all values in the value javascript object.
+func PublicKeyCredentialParametersFromJS(value js.Value) *PublicKeyCredentialParameters {
 	var out PublicKeyCredentialParameters
 	var (
 		value0 PublicKeyCredentialType // javascript: PublicKeyCredentialType {type Type _type}
 		value1 int                     // javascript: long {alg Alg alg}
 	)
-	value0 = PublicKeyCredentialTypeFromJS(input.Get("type"))
+	value0 = PublicKeyCredentialTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = (input.Get("alg")).Int()
+	value1 = (value.Get("alg")).Int()
 	out.Alg = value1
 	return &out
 }
@@ -821,7 +802,7 @@ type PublicKeyCredentialRequestOptions struct {
 	Extensions       *authentication.AuthenticationExtensionsClientInputs
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -845,10 +826,8 @@ func (_this *PublicKeyCredentialRequestOptions) JSValue() js.Value {
 }
 
 // PublicKeyCredentialRequestOptionsFromJS is allocating a new
-// PublicKeyCredentialRequestOptions object and copy all values from
-// input javascript object
-func PublicKeyCredentialRequestOptionsFromJS(value js.Wrapper) *PublicKeyCredentialRequestOptions {
-	input := value.JSValue()
+// PublicKeyCredentialRequestOptions object and copy all values in the value javascript object.
+func PublicKeyCredentialRequestOptionsFromJS(value js.Value) *PublicKeyCredentialRequestOptions {
 	var out PublicKeyCredentialRequestOptions
 	var (
 		value0 *Union                                               // javascript: Union {challenge Challenge challenge}
@@ -858,25 +837,25 @@ func PublicKeyCredentialRequestOptionsFromJS(value js.Wrapper) *PublicKeyCredent
 		value4 authentication.UserVerificationRequirement           // javascript: UserVerificationRequirement {userVerification UserVerification userVerification}
 		value5 *authentication.AuthenticationExtensionsClientInputs // javascript: AuthenticationExtensionsClientInputs {extensions Extensions extensions}
 	)
-	value0 = UnionFromJS(input.Get("challenge"))
+	value0 = UnionFromJS(value.Get("challenge"))
 	out.Challenge = value0
-	value1 = (uint)((input.Get("timeout")).Int())
+	value1 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value1
-	value2 = (input.Get("rpId")).String()
+	value2 = (value.Get("rpId")).String()
 	out.RpId = value2
-	__length3 := input.Get("allowCredentials").Length()
+	__length3 := value.Get("allowCredentials").Length()
 	__array3 := make([]*PublicKeyCredentialDescriptor, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *PublicKeyCredentialDescriptor
-		__seq_in3 := input.Get("allowCredentials").Index(__idx3)
+		__seq_in3 := value.Get("allowCredentials").Index(__idx3)
 		__seq_out3 = PublicKeyCredentialDescriptorFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.AllowCredentials = value3
-	value4 = authentication.UserVerificationRequirementFromJS(input.Get("userVerification"))
+	value4 = authentication.UserVerificationRequirementFromJS(value.Get("userVerification"))
 	out.UserVerification = value4
-	value5 = authentication.AuthenticationExtensionsClientInputsFromJS(input.Get("extensions"))
+	value5 = authentication.AuthenticationExtensionsClientInputsFromJS(value.Get("extensions"))
 	out.Extensions = value5
 	return &out
 }
@@ -888,7 +867,7 @@ type PublicKeyCredentialRpEntity struct {
 	Id   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialRpEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -902,21 +881,19 @@ func (_this *PublicKeyCredentialRpEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialRpEntityFromJS is allocating a new
-// PublicKeyCredentialRpEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialRpEntityFromJS(value js.Wrapper) *PublicKeyCredentialRpEntity {
-	input := value.JSValue()
+// PublicKeyCredentialRpEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialRpEntityFromJS(value js.Value) *PublicKeyCredentialRpEntity {
 	var out PublicKeyCredentialRpEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: USVString {icon Icon icon}
 		value2 string // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
 	return &out
 }
@@ -929,7 +906,7 @@ type PublicKeyCredentialUserEntity struct {
 	DisplayName string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialUserEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -945,10 +922,8 @@ func (_this *PublicKeyCredentialUserEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialUserEntityFromJS is allocating a new
-// PublicKeyCredentialUserEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialUserEntityFromJS(value js.Wrapper) *PublicKeyCredentialUserEntity {
-	input := value.JSValue()
+// PublicKeyCredentialUserEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialUserEntityFromJS(value js.Value) *PublicKeyCredentialUserEntity {
 	var out PublicKeyCredentialUserEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -956,13 +931,13 @@ func PublicKeyCredentialUserEntityFromJS(value js.Wrapper) *PublicKeyCredentialU
 		value2 *Union // javascript: Union {id Id id}
 		value3 string // javascript: DOMString {displayName DisplayName displayName}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
-	value2 = UnionFromJS(input.Get("id"))
+	value2 = UnionFromJS(value.Get("id"))
 	out.Id = value2
-	value3 = (input.Get("displayName")).String()
+	value3 = (value.Get("displayName")).String()
 	out.DisplayName = value3
 	return &out
 }
@@ -977,15 +952,19 @@ func (_this *Credential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CredentialFromJS is casting a js.Wrapper into Credential.
-func CredentialFromJS(value js.Wrapper) *Credential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CredentialFromJS is casting a js.Value into Credential.
+func CredentialFromJS(value js.Value) *Credential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Credential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CredentialFromJS is casting from something that holds a js.Value into Credential.
+func CredentialFromWrapper(input core.Wrapper) *Credential {
+	return CredentialFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1016,15 +995,19 @@ func (_this *CredentialsContainer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CredentialsContainerFromJS is casting a js.Wrapper into CredentialsContainer.
-func CredentialsContainerFromJS(value js.Wrapper) *CredentialsContainer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CredentialsContainerFromJS is casting a js.Value into CredentialsContainer.
+func CredentialsContainerFromJS(value js.Value) *CredentialsContainer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CredentialsContainer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CredentialsContainerFromJS is casting from something that holds a js.Value into CredentialsContainer.
+func CredentialsContainerFromWrapper(input core.Wrapper) *CredentialsContainer {
+	return CredentialsContainerFromJS(input.JSValue())
 }
 
 func (_this *CredentialsContainer) Get(options *CredentialRequestOptions) (_result *PromiseNilCredential) {
@@ -1101,15 +1084,19 @@ type FederatedCredential struct {
 	Credential
 }
 
-// FederatedCredentialFromJS is casting a js.Wrapper into FederatedCredential.
-func FederatedCredentialFromJS(value js.Wrapper) *FederatedCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FederatedCredentialFromJS is casting a js.Value into FederatedCredential.
+func FederatedCredentialFromJS(value js.Value) *FederatedCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FederatedCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FederatedCredentialFromJS is casting from something that holds a js.Value into FederatedCredential.
+func FederatedCredentialFromWrapper(input core.Wrapper) *FederatedCredential {
+	return FederatedCredentialFromJS(input.JSValue())
 }
 
 func NewFederatedCredential(data *FederatedCredentialInit) (_result *FederatedCredential) {
@@ -1174,15 +1161,19 @@ type PasswordCredential struct {
 	Credential
 }
 
-// PasswordCredentialFromJS is casting a js.Wrapper into PasswordCredential.
-func PasswordCredentialFromJS(value js.Wrapper) *PasswordCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PasswordCredentialFromJS is casting a js.Value into PasswordCredential.
+func PasswordCredentialFromJS(value js.Value) *PasswordCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PasswordCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PasswordCredentialFromJS is casting from something that holds a js.Value into PasswordCredential.
+func PasswordCredentialFromWrapper(input core.Wrapper) *PasswordCredential {
+	return PasswordCredentialFromJS(input.JSValue())
 }
 
 func NewPasswordCredential(data *PasswordCredentialData) (_result *PasswordCredential) {
@@ -1240,15 +1231,19 @@ func (_this *PromiseCredential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCredentialFromJS is casting a js.Wrapper into PromiseCredential.
-func PromiseCredentialFromJS(value js.Wrapper) *PromiseCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCredentialFromJS is casting a js.Value into PromiseCredential.
+func PromiseCredentialFromJS(value js.Value) *PromiseCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCredentialFromJS is casting from something that holds a js.Value into PromiseCredential.
+func PromiseCredentialFromWrapper(input core.Wrapper) *PromiseCredential {
+	return PromiseCredentialFromJS(input.JSValue())
 }
 
 func (_this *PromiseCredential) Then(onFulfilled *PromiseCredentialOnFulfilled, onRejected *PromiseCredentialOnRejected) (_result *PromiseCredential) {
@@ -1345,15 +1340,19 @@ func (_this *PromiseNilCredential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilCredentialFromJS is casting a js.Wrapper into PromiseNilCredential.
-func PromiseNilCredentialFromJS(value js.Wrapper) *PromiseNilCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilCredentialFromJS is casting a js.Value into PromiseNilCredential.
+func PromiseNilCredentialFromJS(value js.Value) *PromiseNilCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilCredentialFromJS is casting from something that holds a js.Value into PromiseNilCredential.
+func PromiseNilCredentialFromWrapper(input core.Wrapper) *PromiseNilCredential {
+	return PromiseNilCredentialFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilCredential) Then(onFulfilled *PromiseNilCredentialOnFulfilled, onRejected *PromiseNilCredentialOnRejected) (_result *PromiseNilCredential) {
@@ -1445,15 +1444,19 @@ type PublicKeyCredential struct {
 	Credential
 }
 
-// PublicKeyCredentialFromJS is casting a js.Wrapper into PublicKeyCredential.
-func PublicKeyCredentialFromJS(value js.Wrapper) *PublicKeyCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PublicKeyCredentialFromJS is casting a js.Value into PublicKeyCredential.
+func PublicKeyCredentialFromJS(value js.Value) *PublicKeyCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PublicKeyCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PublicKeyCredentialFromJS is casting from something that holds a js.Value into PublicKeyCredential.
+func PublicKeyCredentialFromWrapper(input core.Wrapper) *PublicKeyCredential {
+	return PublicKeyCredentialFromJS(input.JSValue())
 }
 
 func IsUserVerifyingPlatformAuthenticatorAvailable() (_result *javascript.PromiseBool) {

--- a/crypto/credential/credential_js.go
+++ b/crypto/credential/credential_js.go
@@ -5,6 +5,7 @@ package credential
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto/authentication"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
@@ -303,7 +304,7 @@ type CredentialCreationOptions struct {
 	PublicKey *PublicKeyCredentialCreationOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -319,10 +320,8 @@ func (_this *CredentialCreationOptions) JSValue() js.Value {
 }
 
 // CredentialCreationOptionsFromJS is allocating a new
-// CredentialCreationOptions object and copy all values from
-// input javascript object
-func CredentialCreationOptionsFromJS(value js.Wrapper) *CredentialCreationOptions {
-	input := value.JSValue()
+// CredentialCreationOptions object and copy all values in the value javascript object.
+func CredentialCreationOptionsFromJS(value js.Value) *CredentialCreationOptions {
 	var out CredentialCreationOptions
 	var (
 		value0 *domcore.AbortSignal                // javascript: AbortSignal {signal Signal signal}
@@ -330,13 +329,13 @@ func CredentialCreationOptionsFromJS(value js.Wrapper) *CredentialCreationOption
 		value2 *FederatedCredentialInit            // javascript: FederatedCredentialInit {federated Federated federated}
 		value3 *PublicKeyCredentialCreationOptions // javascript: PublicKeyCredentialCreationOptions {publicKey PublicKey publicKey}
 	)
-	value0 = domcore.AbortSignalFromJS(input.Get("signal"))
+	value0 = domcore.AbortSignalFromJS(value.Get("signal"))
 	out.Signal = value0
-	value1 = UnionFromJS(input.Get("password"))
+	value1 = UnionFromJS(value.Get("password"))
 	out.Password = value1
-	value2 = FederatedCredentialInitFromJS(input.Get("federated"))
+	value2 = FederatedCredentialInitFromJS(value.Get("federated"))
 	out.Federated = value2
-	value3 = PublicKeyCredentialCreationOptionsFromJS(input.Get("publicKey"))
+	value3 = PublicKeyCredentialCreationOptionsFromJS(value.Get("publicKey"))
 	out.PublicKey = value3
 	return &out
 }
@@ -346,7 +345,7 @@ type CredentialData struct {
 	Id string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -356,15 +355,13 @@ func (_this *CredentialData) JSValue() js.Value {
 }
 
 // CredentialDataFromJS is allocating a new
-// CredentialData object and copy all values from
-// input javascript object
-func CredentialDataFromJS(value js.Wrapper) *CredentialData {
-	input := value.JSValue()
+// CredentialData object and copy all values in the value javascript object.
+func CredentialDataFromJS(value js.Value) *CredentialData {
 	var out CredentialData
 	var (
 		value0 string // javascript: USVString {id Id id}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
 	return &out
 }
@@ -378,7 +375,7 @@ type CredentialRequestOptions struct {
 	PublicKey *PublicKeyCredentialRequestOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -396,10 +393,8 @@ func (_this *CredentialRequestOptions) JSValue() js.Value {
 }
 
 // CredentialRequestOptionsFromJS is allocating a new
-// CredentialRequestOptions object and copy all values from
-// input javascript object
-func CredentialRequestOptionsFromJS(value js.Wrapper) *CredentialRequestOptions {
-	input := value.JSValue()
+// CredentialRequestOptions object and copy all values in the value javascript object.
+func CredentialRequestOptionsFromJS(value js.Value) *CredentialRequestOptions {
 	var out CredentialRequestOptions
 	var (
 		value0 CredentialMediationRequirement     // javascript: CredentialMediationRequirement {mediation Mediation mediation}
@@ -408,15 +403,15 @@ func CredentialRequestOptionsFromJS(value js.Wrapper) *CredentialRequestOptions 
 		value3 *FederatedCredentialRequestOptions // javascript: FederatedCredentialRequestOptions {federated Federated federated}
 		value4 *PublicKeyCredentialRequestOptions // javascript: PublicKeyCredentialRequestOptions {publicKey PublicKey publicKey}
 	)
-	value0 = CredentialMediationRequirementFromJS(input.Get("mediation"))
+	value0 = CredentialMediationRequirementFromJS(value.Get("mediation"))
 	out.Mediation = value0
-	value1 = domcore.AbortSignalFromJS(input.Get("signal"))
+	value1 = domcore.AbortSignalFromJS(value.Get("signal"))
 	out.Signal = value1
-	value2 = (input.Get("password")).Bool()
+	value2 = (value.Get("password")).Bool()
 	out.Password = value2
-	value3 = FederatedCredentialRequestOptionsFromJS(input.Get("federated"))
+	value3 = FederatedCredentialRequestOptionsFromJS(value.Get("federated"))
 	out.Federated = value3
-	value4 = PublicKeyCredentialRequestOptionsFromJS(input.Get("publicKey"))
+	value4 = PublicKeyCredentialRequestOptionsFromJS(value.Get("publicKey"))
 	out.PublicKey = value4
 	return &out
 }
@@ -431,7 +426,7 @@ type FederatedCredentialInit struct {
 	Protocol string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FederatedCredentialInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -451,10 +446,8 @@ func (_this *FederatedCredentialInit) JSValue() js.Value {
 }
 
 // FederatedCredentialInitFromJS is allocating a new
-// FederatedCredentialInit object and copy all values from
-// input javascript object
-func FederatedCredentialInitFromJS(value js.Wrapper) *FederatedCredentialInit {
-	input := value.JSValue()
+// FederatedCredentialInit object and copy all values in the value javascript object.
+func FederatedCredentialInitFromJS(value js.Value) *FederatedCredentialInit {
 	var out FederatedCredentialInit
 	var (
 		value0 string // javascript: USVString {id Id id}
@@ -464,17 +457,17 @@ func FederatedCredentialInitFromJS(value js.Wrapper) *FederatedCredentialInit {
 		value4 string // javascript: USVString {provider Provider provider}
 		value5 string // javascript: DOMString {protocol Protocol protocol}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("iconURL")).String()
+	value2 = (value.Get("iconURL")).String()
 	out.IconURL = value2
-	value3 = (input.Get("origin")).String()
+	value3 = (value.Get("origin")).String()
 	out.Origin = value3
-	value4 = (input.Get("provider")).String()
+	value4 = (value.Get("provider")).String()
 	out.Provider = value4
-	value5 = (input.Get("protocol")).String()
+	value5 = (value.Get("protocol")).String()
 	out.Protocol = value5
 	return &out
 }
@@ -485,7 +478,7 @@ type FederatedCredentialRequestOptions struct {
 	Protocols []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FederatedCredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -505,30 +498,28 @@ func (_this *FederatedCredentialRequestOptions) JSValue() js.Value {
 }
 
 // FederatedCredentialRequestOptionsFromJS is allocating a new
-// FederatedCredentialRequestOptions object and copy all values from
-// input javascript object
-func FederatedCredentialRequestOptionsFromJS(value js.Wrapper) *FederatedCredentialRequestOptions {
-	input := value.JSValue()
+// FederatedCredentialRequestOptions object and copy all values in the value javascript object.
+func FederatedCredentialRequestOptionsFromJS(value js.Value) *FederatedCredentialRequestOptions {
 	var out FederatedCredentialRequestOptions
 	var (
 		value0 []string // javascript: sequence<USVString> {providers Providers providers}
 		value1 []string // javascript: sequence<DOMString> {protocols Protocols protocols}
 	)
-	__length0 := input.Get("providers").Length()
+	__length0 := value.Get("providers").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("providers").Index(__idx0)
+		__seq_in0 := value.Get("providers").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Providers = value0
-	__length1 := input.Get("protocols").Length()
+	__length1 := value.Get("protocols").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("protocols").Index(__idx1)
+		__seq_in1 := value.Get("protocols").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
@@ -546,7 +537,7 @@ type PasswordCredentialData struct {
 	Password string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PasswordCredentialData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -564,10 +555,8 @@ func (_this *PasswordCredentialData) JSValue() js.Value {
 }
 
 // PasswordCredentialDataFromJS is allocating a new
-// PasswordCredentialData object and copy all values from
-// input javascript object
-func PasswordCredentialDataFromJS(value js.Wrapper) *PasswordCredentialData {
-	input := value.JSValue()
+// PasswordCredentialData object and copy all values in the value javascript object.
+func PasswordCredentialDataFromJS(value js.Value) *PasswordCredentialData {
 	var out PasswordCredentialData
 	var (
 		value0 string // javascript: USVString {id Id id}
@@ -576,15 +565,15 @@ func PasswordCredentialDataFromJS(value js.Wrapper) *PasswordCredentialData {
 		value3 string // javascript: USVString {origin Origin origin}
 		value4 string // javascript: USVString {password Password password}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("iconURL")).String()
+	value2 = (value.Get("iconURL")).String()
 	out.IconURL = value2
-	value3 = (input.Get("origin")).String()
+	value3 = (value.Get("origin")).String()
 	out.Origin = value3
-	value4 = (input.Get("password")).String()
+	value4 = (value.Get("password")).String()
 	out.Password = value4
 	return &out
 }
@@ -602,7 +591,7 @@ type PublicKeyCredentialCreationOptions struct {
 	Extensions             *authentication.AuthenticationExtensionsClientInputs
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -636,10 +625,8 @@ func (_this *PublicKeyCredentialCreationOptions) JSValue() js.Value {
 }
 
 // PublicKeyCredentialCreationOptionsFromJS is allocating a new
-// PublicKeyCredentialCreationOptions object and copy all values from
-// input javascript object
-func PublicKeyCredentialCreationOptionsFromJS(value js.Wrapper) *PublicKeyCredentialCreationOptions {
-	input := value.JSValue()
+// PublicKeyCredentialCreationOptions object and copy all values in the value javascript object.
+func PublicKeyCredentialCreationOptionsFromJS(value js.Value) *PublicKeyCredentialCreationOptions {
 	var out PublicKeyCredentialCreationOptions
 	var (
 		value0 *PublicKeyCredentialRpEntity                         // javascript: PublicKeyCredentialRpEntity {rp Rp rp}
@@ -652,39 +639,39 @@ func PublicKeyCredentialCreationOptionsFromJS(value js.Wrapper) *PublicKeyCreden
 		value7 authentication.AttestationConveyancePreference       // javascript: AttestationConveyancePreference {attestation Attestation attestation}
 		value8 *authentication.AuthenticationExtensionsClientInputs // javascript: AuthenticationExtensionsClientInputs {extensions Extensions extensions}
 	)
-	value0 = PublicKeyCredentialRpEntityFromJS(input.Get("rp"))
+	value0 = PublicKeyCredentialRpEntityFromJS(value.Get("rp"))
 	out.Rp = value0
-	value1 = PublicKeyCredentialUserEntityFromJS(input.Get("user"))
+	value1 = PublicKeyCredentialUserEntityFromJS(value.Get("user"))
 	out.User = value1
-	value2 = UnionFromJS(input.Get("challenge"))
+	value2 = UnionFromJS(value.Get("challenge"))
 	out.Challenge = value2
-	__length3 := input.Get("pubKeyCredParams").Length()
+	__length3 := value.Get("pubKeyCredParams").Length()
 	__array3 := make([]*PublicKeyCredentialParameters, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *PublicKeyCredentialParameters
-		__seq_in3 := input.Get("pubKeyCredParams").Index(__idx3)
+		__seq_in3 := value.Get("pubKeyCredParams").Index(__idx3)
 		__seq_out3 = PublicKeyCredentialParametersFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.PubKeyCredParams = value3
-	value4 = (uint)((input.Get("timeout")).Int())
+	value4 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value4
-	__length5 := input.Get("excludeCredentials").Length()
+	__length5 := value.Get("excludeCredentials").Length()
 	__array5 := make([]*PublicKeyCredentialDescriptor, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *PublicKeyCredentialDescriptor
-		__seq_in5 := input.Get("excludeCredentials").Index(__idx5)
+		__seq_in5 := value.Get("excludeCredentials").Index(__idx5)
 		__seq_out5 = PublicKeyCredentialDescriptorFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.ExcludeCredentials = value5
-	value6 = authentication.SelectionCriteriaFromJS(input.Get("authenticatorSelection"))
+	value6 = authentication.SelectionCriteriaFromJS(value.Get("authenticatorSelection"))
 	out.AuthenticatorSelection = value6
-	value7 = authentication.AttestationConveyancePreferenceFromJS(input.Get("attestation"))
+	value7 = authentication.AttestationConveyancePreferenceFromJS(value.Get("attestation"))
 	out.Attestation = value7
-	value8 = authentication.AuthenticationExtensionsClientInputsFromJS(input.Get("extensions"))
+	value8 = authentication.AuthenticationExtensionsClientInputsFromJS(value.Get("extensions"))
 	out.Extensions = value8
 	return &out
 }
@@ -696,7 +683,7 @@ type PublicKeyCredentialDescriptor struct {
 	Transports []authentication.Transport
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -714,25 +701,23 @@ func (_this *PublicKeyCredentialDescriptor) JSValue() js.Value {
 }
 
 // PublicKeyCredentialDescriptorFromJS is allocating a new
-// PublicKeyCredentialDescriptor object and copy all values from
-// input javascript object
-func PublicKeyCredentialDescriptorFromJS(value js.Wrapper) *PublicKeyCredentialDescriptor {
-	input := value.JSValue()
+// PublicKeyCredentialDescriptor object and copy all values in the value javascript object.
+func PublicKeyCredentialDescriptorFromJS(value js.Value) *PublicKeyCredentialDescriptor {
 	var out PublicKeyCredentialDescriptor
 	var (
 		value0 PublicKeyCredentialType    // javascript: PublicKeyCredentialType {type Type _type}
 		value1 *Union                     // javascript: Union {id Id id}
 		value2 []authentication.Transport // javascript: sequence<AuthenticatorTransport> {transports Transports transports}
 	)
-	value0 = PublicKeyCredentialTypeFromJS(input.Get("type"))
+	value0 = PublicKeyCredentialTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = UnionFromJS(input.Get("id"))
+	value1 = UnionFromJS(value.Get("id"))
 	out.Id = value1
-	__length2 := input.Get("transports").Length()
+	__length2 := value.Get("transports").Length()
 	__array2 := make([]authentication.Transport, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 authentication.Transport
-		__seq_in2 := input.Get("transports").Index(__idx2)
+		__seq_in2 := value.Get("transports").Index(__idx2)
 		__seq_out2 = authentication.TransportFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -747,7 +732,7 @@ type PublicKeyCredentialEntity struct {
 	Icon string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -759,18 +744,16 @@ func (_this *PublicKeyCredentialEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialEntityFromJS is allocating a new
-// PublicKeyCredentialEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialEntityFromJS(value js.Wrapper) *PublicKeyCredentialEntity {
-	input := value.JSValue()
+// PublicKeyCredentialEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialEntityFromJS(value js.Value) *PublicKeyCredentialEntity {
 	var out PublicKeyCredentialEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: USVString {icon Icon icon}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
 	return &out
 }
@@ -781,7 +764,7 @@ type PublicKeyCredentialParameters struct {
 	Alg  int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -793,18 +776,16 @@ func (_this *PublicKeyCredentialParameters) JSValue() js.Value {
 }
 
 // PublicKeyCredentialParametersFromJS is allocating a new
-// PublicKeyCredentialParameters object and copy all values from
-// input javascript object
-func PublicKeyCredentialParametersFromJS(value js.Wrapper) *PublicKeyCredentialParameters {
-	input := value.JSValue()
+// PublicKeyCredentialParameters object and copy all values in the value javascript object.
+func PublicKeyCredentialParametersFromJS(value js.Value) *PublicKeyCredentialParameters {
 	var out PublicKeyCredentialParameters
 	var (
 		value0 PublicKeyCredentialType // javascript: PublicKeyCredentialType {type Type _type}
 		value1 int                     // javascript: long {alg Alg alg}
 	)
-	value0 = PublicKeyCredentialTypeFromJS(input.Get("type"))
+	value0 = PublicKeyCredentialTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = (input.Get("alg")).Int()
+	value1 = (value.Get("alg")).Int()
 	out.Alg = value1
 	return &out
 }
@@ -819,7 +800,7 @@ type PublicKeyCredentialRequestOptions struct {
 	Extensions       *authentication.AuthenticationExtensionsClientInputs
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -843,10 +824,8 @@ func (_this *PublicKeyCredentialRequestOptions) JSValue() js.Value {
 }
 
 // PublicKeyCredentialRequestOptionsFromJS is allocating a new
-// PublicKeyCredentialRequestOptions object and copy all values from
-// input javascript object
-func PublicKeyCredentialRequestOptionsFromJS(value js.Wrapper) *PublicKeyCredentialRequestOptions {
-	input := value.JSValue()
+// PublicKeyCredentialRequestOptions object and copy all values in the value javascript object.
+func PublicKeyCredentialRequestOptionsFromJS(value js.Value) *PublicKeyCredentialRequestOptions {
 	var out PublicKeyCredentialRequestOptions
 	var (
 		value0 *Union                                               // javascript: Union {challenge Challenge challenge}
@@ -856,25 +835,25 @@ func PublicKeyCredentialRequestOptionsFromJS(value js.Wrapper) *PublicKeyCredent
 		value4 authentication.UserVerificationRequirement           // javascript: UserVerificationRequirement {userVerification UserVerification userVerification}
 		value5 *authentication.AuthenticationExtensionsClientInputs // javascript: AuthenticationExtensionsClientInputs {extensions Extensions extensions}
 	)
-	value0 = UnionFromJS(input.Get("challenge"))
+	value0 = UnionFromJS(value.Get("challenge"))
 	out.Challenge = value0
-	value1 = (uint)((input.Get("timeout")).Int())
+	value1 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value1
-	value2 = (input.Get("rpId")).String()
+	value2 = (value.Get("rpId")).String()
 	out.RpId = value2
-	__length3 := input.Get("allowCredentials").Length()
+	__length3 := value.Get("allowCredentials").Length()
 	__array3 := make([]*PublicKeyCredentialDescriptor, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *PublicKeyCredentialDescriptor
-		__seq_in3 := input.Get("allowCredentials").Index(__idx3)
+		__seq_in3 := value.Get("allowCredentials").Index(__idx3)
 		__seq_out3 = PublicKeyCredentialDescriptorFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.AllowCredentials = value3
-	value4 = authentication.UserVerificationRequirementFromJS(input.Get("userVerification"))
+	value4 = authentication.UserVerificationRequirementFromJS(value.Get("userVerification"))
 	out.UserVerification = value4
-	value5 = authentication.AuthenticationExtensionsClientInputsFromJS(input.Get("extensions"))
+	value5 = authentication.AuthenticationExtensionsClientInputsFromJS(value.Get("extensions"))
 	out.Extensions = value5
 	return &out
 }
@@ -886,7 +865,7 @@ type PublicKeyCredentialRpEntity struct {
 	Id   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialRpEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -900,21 +879,19 @@ func (_this *PublicKeyCredentialRpEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialRpEntityFromJS is allocating a new
-// PublicKeyCredentialRpEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialRpEntityFromJS(value js.Wrapper) *PublicKeyCredentialRpEntity {
-	input := value.JSValue()
+// PublicKeyCredentialRpEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialRpEntityFromJS(value js.Value) *PublicKeyCredentialRpEntity {
 	var out PublicKeyCredentialRpEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: USVString {icon Icon icon}
 		value2 string // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
 	return &out
 }
@@ -927,7 +904,7 @@ type PublicKeyCredentialUserEntity struct {
 	DisplayName string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PublicKeyCredentialUserEntity) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -943,10 +920,8 @@ func (_this *PublicKeyCredentialUserEntity) JSValue() js.Value {
 }
 
 // PublicKeyCredentialUserEntityFromJS is allocating a new
-// PublicKeyCredentialUserEntity object and copy all values from
-// input javascript object
-func PublicKeyCredentialUserEntityFromJS(value js.Wrapper) *PublicKeyCredentialUserEntity {
-	input := value.JSValue()
+// PublicKeyCredentialUserEntity object and copy all values in the value javascript object.
+func PublicKeyCredentialUserEntityFromJS(value js.Value) *PublicKeyCredentialUserEntity {
 	var out PublicKeyCredentialUserEntity
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -954,13 +929,13 @@ func PublicKeyCredentialUserEntityFromJS(value js.Wrapper) *PublicKeyCredentialU
 		value2 *Union // javascript: Union {id Id id}
 		value3 string // javascript: DOMString {displayName DisplayName displayName}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("icon")).String()
+	value1 = (value.Get("icon")).String()
 	out.Icon = value1
-	value2 = UnionFromJS(input.Get("id"))
+	value2 = UnionFromJS(value.Get("id"))
 	out.Id = value2
-	value3 = (input.Get("displayName")).String()
+	value3 = (value.Get("displayName")).String()
 	out.DisplayName = value3
 	return &out
 }
@@ -975,15 +950,19 @@ func (_this *Credential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CredentialFromJS is casting a js.Wrapper into Credential.
-func CredentialFromJS(value js.Wrapper) *Credential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CredentialFromJS is casting a js.Value into Credential.
+func CredentialFromJS(value js.Value) *Credential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Credential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CredentialFromJS is casting from something that holds a js.Value into Credential.
+func CredentialFromWrapper(input core.Wrapper) *Credential {
+	return CredentialFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1014,15 +993,19 @@ func (_this *CredentialsContainer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CredentialsContainerFromJS is casting a js.Wrapper into CredentialsContainer.
-func CredentialsContainerFromJS(value js.Wrapper) *CredentialsContainer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CredentialsContainerFromJS is casting a js.Value into CredentialsContainer.
+func CredentialsContainerFromJS(value js.Value) *CredentialsContainer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CredentialsContainer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CredentialsContainerFromJS is casting from something that holds a js.Value into CredentialsContainer.
+func CredentialsContainerFromWrapper(input core.Wrapper) *CredentialsContainer {
+	return CredentialsContainerFromJS(input.JSValue())
 }
 
 func (_this *CredentialsContainer) Get(options *CredentialRequestOptions) (_result *PromiseNilCredential) {
@@ -1099,15 +1082,19 @@ type FederatedCredential struct {
 	Credential
 }
 
-// FederatedCredentialFromJS is casting a js.Wrapper into FederatedCredential.
-func FederatedCredentialFromJS(value js.Wrapper) *FederatedCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FederatedCredentialFromJS is casting a js.Value into FederatedCredential.
+func FederatedCredentialFromJS(value js.Value) *FederatedCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FederatedCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FederatedCredentialFromJS is casting from something that holds a js.Value into FederatedCredential.
+func FederatedCredentialFromWrapper(input core.Wrapper) *FederatedCredential {
+	return FederatedCredentialFromJS(input.JSValue())
 }
 
 func NewFederatedCredential(data *FederatedCredentialInit) (_result *FederatedCredential) {
@@ -1172,15 +1159,19 @@ type PasswordCredential struct {
 	Credential
 }
 
-// PasswordCredentialFromJS is casting a js.Wrapper into PasswordCredential.
-func PasswordCredentialFromJS(value js.Wrapper) *PasswordCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PasswordCredentialFromJS is casting a js.Value into PasswordCredential.
+func PasswordCredentialFromJS(value js.Value) *PasswordCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PasswordCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PasswordCredentialFromJS is casting from something that holds a js.Value into PasswordCredential.
+func PasswordCredentialFromWrapper(input core.Wrapper) *PasswordCredential {
+	return PasswordCredentialFromJS(input.JSValue())
 }
 
 func NewPasswordCredential(data *PasswordCredentialData) (_result *PasswordCredential) {
@@ -1238,15 +1229,19 @@ func (_this *PromiseCredential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCredentialFromJS is casting a js.Wrapper into PromiseCredential.
-func PromiseCredentialFromJS(value js.Wrapper) *PromiseCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCredentialFromJS is casting a js.Value into PromiseCredential.
+func PromiseCredentialFromJS(value js.Value) *PromiseCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCredentialFromJS is casting from something that holds a js.Value into PromiseCredential.
+func PromiseCredentialFromWrapper(input core.Wrapper) *PromiseCredential {
+	return PromiseCredentialFromJS(input.JSValue())
 }
 
 func (_this *PromiseCredential) Then(onFulfilled *PromiseCredentialOnFulfilled, onRejected *PromiseCredentialOnRejected) (_result *PromiseCredential) {
@@ -1343,15 +1338,19 @@ func (_this *PromiseNilCredential) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilCredentialFromJS is casting a js.Wrapper into PromiseNilCredential.
-func PromiseNilCredentialFromJS(value js.Wrapper) *PromiseNilCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilCredentialFromJS is casting a js.Value into PromiseNilCredential.
+func PromiseNilCredentialFromJS(value js.Value) *PromiseNilCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilCredentialFromJS is casting from something that holds a js.Value into PromiseNilCredential.
+func PromiseNilCredentialFromWrapper(input core.Wrapper) *PromiseNilCredential {
+	return PromiseNilCredentialFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilCredential) Then(onFulfilled *PromiseNilCredentialOnFulfilled, onRejected *PromiseNilCredentialOnRejected) (_result *PromiseNilCredential) {
@@ -1443,15 +1442,19 @@ type PublicKeyCredential struct {
 	Credential
 }
 
-// PublicKeyCredentialFromJS is casting a js.Wrapper into PublicKeyCredential.
-func PublicKeyCredentialFromJS(value js.Wrapper) *PublicKeyCredential {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PublicKeyCredentialFromJS is casting a js.Value into PublicKeyCredential.
+func PublicKeyCredentialFromJS(value js.Value) *PublicKeyCredential {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PublicKeyCredential{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PublicKeyCredentialFromJS is casting from something that holds a js.Value into PublicKeyCredential.
+func PublicKeyCredentialFromWrapper(input core.Wrapper) *PublicKeyCredential {
+	return PublicKeyCredentialFromJS(input.JSValue())
 }
 
 func IsUserVerifyingPlatformAuthenticatorAvailable() (_result *javascript.PromiseBool) {

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -7,6 +7,7 @@ package crypto
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -263,7 +264,7 @@ type AesCbcParams struct {
 	Iv   *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesCbcParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -275,18 +276,16 @@ func (_this *AesCbcParams) JSValue() js.Value {
 }
 
 // AesCbcParamsFromJS is allocating a new
-// AesCbcParams object and copy all values from
-// input javascript object
-func AesCbcParamsFromJS(value js.Wrapper) *AesCbcParams {
-	input := value.JSValue()
+// AesCbcParams object and copy all values in the value javascript object.
+func AesCbcParamsFromJS(value js.Value) *AesCbcParams {
 	var out AesCbcParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {iv Iv iv}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("iv"))
+	value1 = UnionFromJS(value.Get("iv"))
 	out.Iv = value1
 	return &out
 }
@@ -298,7 +297,7 @@ type AesCtrParams struct {
 	Length  int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesCtrParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -312,21 +311,19 @@ func (_this *AesCtrParams) JSValue() js.Value {
 }
 
 // AesCtrParamsFromJS is allocating a new
-// AesCtrParams object and copy all values from
-// input javascript object
-func AesCtrParamsFromJS(value js.Wrapper) *AesCtrParams {
-	input := value.JSValue()
+// AesCtrParams object and copy all values in the value javascript object.
+func AesCtrParamsFromJS(value js.Value) *AesCtrParams {
 	var out AesCtrParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {counter Counter counter}
 		value2 int    // javascript: octet {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("counter"))
+	value1 = UnionFromJS(value.Get("counter"))
 	out.Counter = value1
-	value2 = (input.Get("length")).Int()
+	value2 = (value.Get("length")).Int()
 	out.Length = value2
 	return &out
 }
@@ -337,7 +334,7 @@ type AesDerivedKeyParams struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesDerivedKeyParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -349,18 +346,16 @@ func (_this *AesDerivedKeyParams) JSValue() js.Value {
 }
 
 // AesDerivedKeyParamsFromJS is allocating a new
-// AesDerivedKeyParams object and copy all values from
-// input javascript object
-func AesDerivedKeyParamsFromJS(value js.Wrapper) *AesDerivedKeyParams {
-	input := value.JSValue()
+// AesDerivedKeyParams object and copy all values in the value javascript object.
+func AesDerivedKeyParamsFromJS(value js.Value) *AesDerivedKeyParams {
 	var out AesDerivedKeyParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -373,7 +368,7 @@ type AesGcmParams struct {
 	TagLength      int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesGcmParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -389,10 +384,8 @@ func (_this *AesGcmParams) JSValue() js.Value {
 }
 
 // AesGcmParamsFromJS is allocating a new
-// AesGcmParams object and copy all values from
-// input javascript object
-func AesGcmParamsFromJS(value js.Wrapper) *AesGcmParams {
-	input := value.JSValue()
+// AesGcmParams object and copy all values in the value javascript object.
+func AesGcmParamsFromJS(value js.Value) *AesGcmParams {
 	var out AesGcmParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -400,13 +393,13 @@ func AesGcmParamsFromJS(value js.Wrapper) *AesGcmParams {
 		value2 *Union // javascript: Union {additionalData AdditionalData additionalData}
 		value3 int    // javascript: octet {tagLength TagLength tagLength}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("iv"))
+	value1 = UnionFromJS(value.Get("iv"))
 	out.Iv = value1
-	value2 = UnionFromJS(input.Get("additionalData"))
+	value2 = UnionFromJS(value.Get("additionalData"))
 	out.AdditionalData = value2
-	value3 = (input.Get("tagLength")).Int()
+	value3 = (value.Get("tagLength")).Int()
 	out.TagLength = value3
 	return &out
 }
@@ -417,7 +410,7 @@ type AesKeyAlgorithm struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -429,18 +422,16 @@ func (_this *AesKeyAlgorithm) JSValue() js.Value {
 }
 
 // AesKeyAlgorithmFromJS is allocating a new
-// AesKeyAlgorithm object and copy all values from
-// input javascript object
-func AesKeyAlgorithmFromJS(value js.Wrapper) *AesKeyAlgorithm {
-	input := value.JSValue()
+// AesKeyAlgorithm object and copy all values in the value javascript object.
+func AesKeyAlgorithmFromJS(value js.Value) *AesKeyAlgorithm {
 	var out AesKeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -451,7 +442,7 @@ type AesKeyGenParams struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -463,18 +454,16 @@ func (_this *AesKeyGenParams) JSValue() js.Value {
 }
 
 // AesKeyGenParamsFromJS is allocating a new
-// AesKeyGenParams object and copy all values from
-// input javascript object
-func AesKeyGenParamsFromJS(value js.Wrapper) *AesKeyGenParams {
-	input := value.JSValue()
+// AesKeyGenParams object and copy all values in the value javascript object.
+func AesKeyGenParamsFromJS(value js.Value) *AesKeyGenParams {
 	var out AesKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -484,7 +473,7 @@ type Algorithm struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Algorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -494,15 +483,13 @@ func (_this *Algorithm) JSValue() js.Value {
 }
 
 // AlgorithmFromJS is allocating a new
-// Algorithm object and copy all values from
-// input javascript object
-func AlgorithmFromJS(value js.Wrapper) *Algorithm {
-	input := value.JSValue()
+// Algorithm object and copy all values in the value javascript object.
+func AlgorithmFromJS(value js.Value) *Algorithm {
 	var out Algorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -513,7 +500,7 @@ type CryptoKeyPair struct {
 	PrivateKey *CryptoKey
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CryptoKeyPair) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -525,18 +512,16 @@ func (_this *CryptoKeyPair) JSValue() js.Value {
 }
 
 // CryptoKeyPairFromJS is allocating a new
-// CryptoKeyPair object and copy all values from
-// input javascript object
-func CryptoKeyPairFromJS(value js.Wrapper) *CryptoKeyPair {
-	input := value.JSValue()
+// CryptoKeyPair object and copy all values in the value javascript object.
+func CryptoKeyPairFromJS(value js.Value) *CryptoKeyPair {
 	var out CryptoKeyPair
 	var (
 		value0 *CryptoKey // javascript: CryptoKey {publicKey PublicKey publicKey}
 		value1 *CryptoKey // javascript: CryptoKey {privateKey PrivateKey privateKey}
 	)
-	value0 = CryptoKeyFromJS(input.Get("publicKey"))
+	value0 = CryptoKeyFromJS(value.Get("publicKey"))
 	out.PublicKey = value0
-	value1 = CryptoKeyFromJS(input.Get("privateKey"))
+	value1 = CryptoKeyFromJS(value.Get("privateKey"))
 	out.PrivateKey = value1
 	return &out
 }
@@ -547,7 +532,7 @@ type EcKeyAlgorithm struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -559,18 +544,16 @@ func (_this *EcKeyAlgorithm) JSValue() js.Value {
 }
 
 // EcKeyAlgorithmFromJS is allocating a new
-// EcKeyAlgorithm object and copy all values from
-// input javascript object
-func EcKeyAlgorithmFromJS(value js.Wrapper) *EcKeyAlgorithm {
-	input := value.JSValue()
+// EcKeyAlgorithm object and copy all values in the value javascript object.
+func EcKeyAlgorithmFromJS(value js.Value) *EcKeyAlgorithm {
 	var out EcKeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -581,7 +564,7 @@ type EcKeyGenParams struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -593,18 +576,16 @@ func (_this *EcKeyGenParams) JSValue() js.Value {
 }
 
 // EcKeyGenParamsFromJS is allocating a new
-// EcKeyGenParams object and copy all values from
-// input javascript object
-func EcKeyGenParamsFromJS(value js.Wrapper) *EcKeyGenParams {
-	input := value.JSValue()
+// EcKeyGenParams object and copy all values in the value javascript object.
+func EcKeyGenParamsFromJS(value js.Value) *EcKeyGenParams {
 	var out EcKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -615,7 +596,7 @@ type EcKeyImportParams struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -627,18 +608,16 @@ func (_this *EcKeyImportParams) JSValue() js.Value {
 }
 
 // EcKeyImportParamsFromJS is allocating a new
-// EcKeyImportParams object and copy all values from
-// input javascript object
-func EcKeyImportParamsFromJS(value js.Wrapper) *EcKeyImportParams {
-	input := value.JSValue()
+// EcKeyImportParams object and copy all values in the value javascript object.
+func EcKeyImportParamsFromJS(value js.Value) *EcKeyImportParams {
 	var out EcKeyImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -649,7 +628,7 @@ type EcdhKeyDeriveParams struct {
 	Public *CryptoKey
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcdhKeyDeriveParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -661,18 +640,16 @@ func (_this *EcdhKeyDeriveParams) JSValue() js.Value {
 }
 
 // EcdhKeyDeriveParamsFromJS is allocating a new
-// EcdhKeyDeriveParams object and copy all values from
-// input javascript object
-func EcdhKeyDeriveParamsFromJS(value js.Wrapper) *EcdhKeyDeriveParams {
-	input := value.JSValue()
+// EcdhKeyDeriveParams object and copy all values in the value javascript object.
+func EcdhKeyDeriveParamsFromJS(value js.Value) *EcdhKeyDeriveParams {
 	var out EcdhKeyDeriveParams
 	var (
 		value0 string     // javascript: DOMString {name Name name}
 		value1 *CryptoKey // javascript: CryptoKey {public Public public}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = CryptoKeyFromJS(input.Get("public"))
+	value1 = CryptoKeyFromJS(value.Get("public"))
 	out.Public = value1
 	return &out
 }
@@ -683,7 +660,7 @@ type EcdsaParams struct {
 	Hash *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcdsaParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -695,18 +672,16 @@ func (_this *EcdsaParams) JSValue() js.Value {
 }
 
 // EcdsaParamsFromJS is allocating a new
-// EcdsaParams object and copy all values from
-// input javascript object
-func EcdsaParamsFromJS(value js.Wrapper) *EcdsaParams {
-	input := value.JSValue()
+// EcdsaParams object and copy all values in the value javascript object.
+func EcdsaParamsFromJS(value js.Value) *EcdsaParams {
 	var out EcdsaParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
 	return &out
 }
@@ -719,7 +694,7 @@ type HkdfParams struct {
 	Info *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HkdfParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -735,10 +710,8 @@ func (_this *HkdfParams) JSValue() js.Value {
 }
 
 // HkdfParamsFromJS is allocating a new
-// HkdfParams object and copy all values from
-// input javascript object
-func HkdfParamsFromJS(value js.Wrapper) *HkdfParams {
-	input := value.JSValue()
+// HkdfParams object and copy all values in the value javascript object.
+func HkdfParamsFromJS(value js.Value) *HkdfParams {
 	var out HkdfParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -746,13 +719,13 @@ func HkdfParamsFromJS(value js.Wrapper) *HkdfParams {
 		value2 *Union // javascript: Union {salt Salt salt}
 		value3 *Union // javascript: Union {info Info info}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = UnionFromJS(input.Get("salt"))
+	value2 = UnionFromJS(value.Get("salt"))
 	out.Salt = value2
-	value3 = UnionFromJS(input.Get("info"))
+	value3 = UnionFromJS(value.Get("info"))
 	out.Info = value3
 	return &out
 }
@@ -764,7 +737,7 @@ type HmacImportParams struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -778,21 +751,19 @@ func (_this *HmacImportParams) JSValue() js.Value {
 }
 
 // HmacImportParamsFromJS is allocating a new
-// HmacImportParams object and copy all values from
-// input javascript object
-func HmacImportParamsFromJS(value js.Wrapper) *HmacImportParams {
-	input := value.JSValue()
+// HmacImportParams object and copy all values in the value javascript object.
+func HmacImportParamsFromJS(value js.Value) *HmacImportParams {
 	var out HmacImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 		value2 uint   // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -804,7 +775,7 @@ type HmacKeyAlgorithm struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -818,21 +789,19 @@ func (_this *HmacKeyAlgorithm) JSValue() js.Value {
 }
 
 // HmacKeyAlgorithmFromJS is allocating a new
-// HmacKeyAlgorithm object and copy all values from
-// input javascript object
-func HmacKeyAlgorithmFromJS(value js.Wrapper) *HmacKeyAlgorithm {
-	input := value.JSValue()
+// HmacKeyAlgorithm object and copy all values in the value javascript object.
+func HmacKeyAlgorithmFromJS(value js.Value) *HmacKeyAlgorithm {
 	var out HmacKeyAlgorithm
 	var (
 		value0 string        // javascript: DOMString {name Name name}
 		value1 *KeyAlgorithm // javascript: KeyAlgorithm {hash Hash hash}
 		value2 uint          // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = KeyAlgorithmFromJS(input.Get("hash"))
+	value1 = KeyAlgorithmFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -844,7 +813,7 @@ type HmacKeyGenParams struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -858,21 +827,19 @@ func (_this *HmacKeyGenParams) JSValue() js.Value {
 }
 
 // HmacKeyGenParamsFromJS is allocating a new
-// HmacKeyGenParams object and copy all values from
-// input javascript object
-func HmacKeyGenParamsFromJS(value js.Wrapper) *HmacKeyGenParams {
-	input := value.JSValue()
+// HmacKeyGenParams object and copy all values in the value javascript object.
+func HmacKeyGenParamsFromJS(value js.Value) *HmacKeyGenParams {
 	var out HmacKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 		value2 uint   // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -899,7 +866,7 @@ type JsonWebKey struct {
 	K      string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *JsonWebKey) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -951,10 +918,8 @@ func (_this *JsonWebKey) JSValue() js.Value {
 }
 
 // JsonWebKeyFromJS is allocating a new
-// JsonWebKey object and copy all values from
-// input javascript object
-func JsonWebKeyFromJS(value js.Wrapper) *JsonWebKey {
-	input := value.JSValue()
+// JsonWebKey object and copy all values in the value javascript object.
+func JsonWebKeyFromJS(value js.Value) *JsonWebKey {
 	var out JsonWebKey
 	var (
 		value0  string                // javascript: DOMString {kty Kty kty}
@@ -976,57 +941,57 @@ func JsonWebKeyFromJS(value js.Wrapper) *JsonWebKey {
 		value16 []*RsaOtherPrimesInfo // javascript: sequence<RsaOtherPrimesInfo> {oth Oth oth}
 		value17 string                // javascript: DOMString {k K k}
 	)
-	value0 = (input.Get("kty")).String()
+	value0 = (value.Get("kty")).String()
 	out.Kty = value0
-	value1 = (input.Get("use")).String()
+	value1 = (value.Get("use")).String()
 	out.Use = value1
-	__length2 := input.Get("key_ops").Length()
+	__length2 := value.Get("key_ops").Length()
 	__array2 := make([]string, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 string
-		__seq_in2 := input.Get("key_ops").Index(__idx2)
+		__seq_in2 := value.Get("key_ops").Index(__idx2)
 		__seq_out2 = (__seq_in2).String()
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.KeyOps = value2
-	value3 = (input.Get("alg")).String()
+	value3 = (value.Get("alg")).String()
 	out.Alg = value3
-	value4 = (input.Get("ext")).Bool()
+	value4 = (value.Get("ext")).Bool()
 	out.Ext = value4
-	value5 = (input.Get("crv")).String()
+	value5 = (value.Get("crv")).String()
 	out.Crv = value5
-	value6 = (input.Get("x")).String()
+	value6 = (value.Get("x")).String()
 	out.X = value6
-	value7 = (input.Get("y")).String()
+	value7 = (value.Get("y")).String()
 	out.Y = value7
-	value8 = (input.Get("d")).String()
+	value8 = (value.Get("d")).String()
 	out.D = value8
-	value9 = (input.Get("n")).String()
+	value9 = (value.Get("n")).String()
 	out.N = value9
-	value10 = (input.Get("e")).String()
+	value10 = (value.Get("e")).String()
 	out.E = value10
-	value11 = (input.Get("p")).String()
+	value11 = (value.Get("p")).String()
 	out.P = value11
-	value12 = (input.Get("q")).String()
+	value12 = (value.Get("q")).String()
 	out.Q = value12
-	value13 = (input.Get("dp")).String()
+	value13 = (value.Get("dp")).String()
 	out.Dp = value13
-	value14 = (input.Get("dq")).String()
+	value14 = (value.Get("dq")).String()
 	out.Dq = value14
-	value15 = (input.Get("qi")).String()
+	value15 = (value.Get("qi")).String()
 	out.Qi = value15
-	__length16 := input.Get("oth").Length()
+	__length16 := value.Get("oth").Length()
 	__array16 := make([]*RsaOtherPrimesInfo, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 *RsaOtherPrimesInfo
-		__seq_in16 := input.Get("oth").Index(__idx16)
+		__seq_in16 := value.Get("oth").Index(__idx16)
 		__seq_out16 = RsaOtherPrimesInfoFromJS(__seq_in16)
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.Oth = value16
-	value17 = (input.Get("k")).String()
+	value17 = (value.Get("k")).String()
 	out.K = value17
 	return &out
 }
@@ -1036,7 +1001,7 @@ type KeyAlgorithm struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1046,15 +1011,13 @@ func (_this *KeyAlgorithm) JSValue() js.Value {
 }
 
 // KeyAlgorithmFromJS is allocating a new
-// KeyAlgorithm object and copy all values from
-// input javascript object
-func KeyAlgorithmFromJS(value js.Wrapper) *KeyAlgorithm {
-	input := value.JSValue()
+// KeyAlgorithm object and copy all values in the value javascript object.
+func KeyAlgorithmFromJS(value js.Value) *KeyAlgorithm {
 	var out KeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -1067,7 +1030,7 @@ type Pbkdf2Params struct {
 	Hash       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Pbkdf2Params) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1083,10 +1046,8 @@ func (_this *Pbkdf2Params) JSValue() js.Value {
 }
 
 // Pbkdf2ParamsFromJS is allocating a new
-// Pbkdf2Params object and copy all values from
-// input javascript object
-func Pbkdf2ParamsFromJS(value js.Wrapper) *Pbkdf2Params {
-	input := value.JSValue()
+// Pbkdf2Params object and copy all values in the value javascript object.
+func Pbkdf2ParamsFromJS(value js.Value) *Pbkdf2Params {
 	var out Pbkdf2Params
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -1094,13 +1055,13 @@ func Pbkdf2ParamsFromJS(value js.Wrapper) *Pbkdf2Params {
 		value2 uint   // javascript: unsigned long {iterations Iterations iterations}
 		value3 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("salt"))
+	value1 = UnionFromJS(value.Get("salt"))
 	out.Salt = value1
-	value2 = (uint)((input.Get("iterations")).Int())
+	value2 = (uint)((value.Get("iterations")).Int())
 	out.Iterations = value2
-	value3 = UnionFromJS(input.Get("hash"))
+	value3 = UnionFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1111,7 +1072,7 @@ type RsaHashedImportParams struct {
 	Hash *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1123,18 +1084,16 @@ func (_this *RsaHashedImportParams) JSValue() js.Value {
 }
 
 // RsaHashedImportParamsFromJS is allocating a new
-// RsaHashedImportParams object and copy all values from
-// input javascript object
-func RsaHashedImportParamsFromJS(value js.Wrapper) *RsaHashedImportParams {
-	input := value.JSValue()
+// RsaHashedImportParams object and copy all values in the value javascript object.
+func RsaHashedImportParamsFromJS(value js.Value) *RsaHashedImportParams {
 	var out RsaHashedImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
 	return &out
 }
@@ -1147,7 +1106,7 @@ type RsaHashedKeyAlgorithm struct {
 	Hash           *KeyAlgorithm
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1163,10 +1122,8 @@ func (_this *RsaHashedKeyAlgorithm) JSValue() js.Value {
 }
 
 // RsaHashedKeyAlgorithmFromJS is allocating a new
-// RsaHashedKeyAlgorithm object and copy all values from
-// input javascript object
-func RsaHashedKeyAlgorithmFromJS(value js.Wrapper) *RsaHashedKeyAlgorithm {
-	input := value.JSValue()
+// RsaHashedKeyAlgorithm object and copy all values in the value javascript object.
+func RsaHashedKeyAlgorithmFromJS(value js.Value) *RsaHashedKeyAlgorithm {
 	var out RsaHashedKeyAlgorithm
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
@@ -1174,13 +1131,13 @@ func RsaHashedKeyAlgorithmFromJS(value js.Wrapper) *RsaHashedKeyAlgorithm {
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 		value3 *KeyAlgorithm          // javascript: KeyAlgorithm {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
-	value3 = KeyAlgorithmFromJS(input.Get("hash"))
+	value3 = KeyAlgorithmFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1193,7 +1150,7 @@ type RsaHashedKeyGenParams struct {
 	Hash           *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1209,10 +1166,8 @@ func (_this *RsaHashedKeyGenParams) JSValue() js.Value {
 }
 
 // RsaHashedKeyGenParamsFromJS is allocating a new
-// RsaHashedKeyGenParams object and copy all values from
-// input javascript object
-func RsaHashedKeyGenParamsFromJS(value js.Wrapper) *RsaHashedKeyGenParams {
-	input := value.JSValue()
+// RsaHashedKeyGenParams object and copy all values in the value javascript object.
+func RsaHashedKeyGenParamsFromJS(value js.Value) *RsaHashedKeyGenParams {
 	var out RsaHashedKeyGenParams
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
@@ -1220,13 +1175,13 @@ func RsaHashedKeyGenParamsFromJS(value js.Wrapper) *RsaHashedKeyGenParams {
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 		value3 *Union                 // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
-	value3 = UnionFromJS(input.Get("hash"))
+	value3 = UnionFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1238,7 +1193,7 @@ type RsaKeyAlgorithm struct {
 	PublicExponent *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1252,21 +1207,19 @@ func (_this *RsaKeyAlgorithm) JSValue() js.Value {
 }
 
 // RsaKeyAlgorithmFromJS is allocating a new
-// RsaKeyAlgorithm object and copy all values from
-// input javascript object
-func RsaKeyAlgorithmFromJS(value js.Wrapper) *RsaKeyAlgorithm {
-	input := value.JSValue()
+// RsaKeyAlgorithm object and copy all values in the value javascript object.
+func RsaKeyAlgorithmFromJS(value js.Value) *RsaKeyAlgorithm {
 	var out RsaKeyAlgorithm
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
 		value1 uint                   // javascript: unsigned long {modulusLength ModulusLength modulusLength}
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
 	return &out
 }
@@ -1278,7 +1231,7 @@ type RsaKeyGenParams struct {
 	PublicExponent *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1292,21 +1245,19 @@ func (_this *RsaKeyGenParams) JSValue() js.Value {
 }
 
 // RsaKeyGenParamsFromJS is allocating a new
-// RsaKeyGenParams object and copy all values from
-// input javascript object
-func RsaKeyGenParamsFromJS(value js.Wrapper) *RsaKeyGenParams {
-	input := value.JSValue()
+// RsaKeyGenParams object and copy all values in the value javascript object.
+func RsaKeyGenParamsFromJS(value js.Value) *RsaKeyGenParams {
 	var out RsaKeyGenParams
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
 		value1 uint                   // javascript: unsigned long {modulusLength ModulusLength modulusLength}
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
 	return &out
 }
@@ -1317,7 +1268,7 @@ type RsaOaepParams struct {
 	Label *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaOaepParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1329,18 +1280,16 @@ func (_this *RsaOaepParams) JSValue() js.Value {
 }
 
 // RsaOaepParamsFromJS is allocating a new
-// RsaOaepParams object and copy all values from
-// input javascript object
-func RsaOaepParamsFromJS(value js.Wrapper) *RsaOaepParams {
-	input := value.JSValue()
+// RsaOaepParams object and copy all values in the value javascript object.
+func RsaOaepParamsFromJS(value js.Value) *RsaOaepParams {
 	var out RsaOaepParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {label Label label}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("label"))
+	value1 = UnionFromJS(value.Get("label"))
 	out.Label = value1
 	return &out
 }
@@ -1352,7 +1301,7 @@ type RsaOtherPrimesInfo struct {
 	T string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaOtherPrimesInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1366,21 +1315,19 @@ func (_this *RsaOtherPrimesInfo) JSValue() js.Value {
 }
 
 // RsaOtherPrimesInfoFromJS is allocating a new
-// RsaOtherPrimesInfo object and copy all values from
-// input javascript object
-func RsaOtherPrimesInfoFromJS(value js.Wrapper) *RsaOtherPrimesInfo {
-	input := value.JSValue()
+// RsaOtherPrimesInfo object and copy all values in the value javascript object.
+func RsaOtherPrimesInfoFromJS(value js.Value) *RsaOtherPrimesInfo {
 	var out RsaOtherPrimesInfo
 	var (
 		value0 string // javascript: DOMString {r R r}
 		value1 string // javascript: DOMString {d D d}
 		value2 string // javascript: DOMString {t T t}
 	)
-	value0 = (input.Get("r")).String()
+	value0 = (value.Get("r")).String()
 	out.R = value0
-	value1 = (input.Get("d")).String()
+	value1 = (value.Get("d")).String()
 	out.D = value1
-	value2 = (input.Get("t")).String()
+	value2 = (value.Get("t")).String()
 	out.T = value2
 	return &out
 }
@@ -1391,7 +1338,7 @@ type RsaPssParams struct {
 	SaltLength uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaPssParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1403,18 +1350,16 @@ func (_this *RsaPssParams) JSValue() js.Value {
 }
 
 // RsaPssParamsFromJS is allocating a new
-// RsaPssParams object and copy all values from
-// input javascript object
-func RsaPssParamsFromJS(value js.Wrapper) *RsaPssParams {
-	input := value.JSValue()
+// RsaPssParams object and copy all values in the value javascript object.
+func RsaPssParamsFromJS(value js.Value) *RsaPssParams {
 	var out RsaPssParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 uint   // javascript: unsigned long {saltLength SaltLength saltLength}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("saltLength")).Int())
+	value1 = (uint)((value.Get("saltLength")).Int())
 	out.SaltLength = value1
 	return &out
 }
@@ -1429,15 +1374,19 @@ func (_this *Crypto) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CryptoFromJS is casting a js.Wrapper into Crypto.
-func CryptoFromJS(value js.Wrapper) *Crypto {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CryptoFromJS is casting a js.Value into Crypto.
+func CryptoFromJS(value js.Value) *Crypto {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Crypto{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CryptoFromJS is casting from something that holds a js.Value into Crypto.
+func CryptoFromWrapper(input core.Wrapper) *Crypto {
+	return CryptoFromJS(input.JSValue())
 }
 
 // Subtle returning attribute 'subtle' with
@@ -1476,15 +1425,19 @@ func (_this *CryptoKey) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CryptoKeyFromJS is casting a js.Wrapper into CryptoKey.
-func CryptoKeyFromJS(value js.Wrapper) *CryptoKey {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CryptoKeyFromJS is casting a js.Value into CryptoKey.
+func CryptoKeyFromJS(value js.Value) *CryptoKey {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CryptoKey{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CryptoKeyFromJS is casting from something that holds a js.Value into CryptoKey.
+func CryptoKeyFromWrapper(input core.Wrapper) *CryptoKey {
+	return CryptoKeyFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -1533,15 +1486,19 @@ func (_this *PromiseCryptoKey) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCryptoKeyFromJS is casting a js.Wrapper into PromiseCryptoKey.
-func PromiseCryptoKeyFromJS(value js.Wrapper) *PromiseCryptoKey {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCryptoKeyFromJS is casting a js.Value into PromiseCryptoKey.
+func PromiseCryptoKeyFromJS(value js.Value) *PromiseCryptoKey {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCryptoKey{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCryptoKeyFromJS is casting from something that holds a js.Value into PromiseCryptoKey.
+func PromiseCryptoKeyFromWrapper(input core.Wrapper) *PromiseCryptoKey {
+	return PromiseCryptoKeyFromJS(input.JSValue())
 }
 
 func (_this *PromiseCryptoKey) Then(onFulfilled *PromiseCryptoKeyOnFulfilled, onRejected *PromiseCryptoKeyOnRejected) (_result *PromiseCryptoKey) {
@@ -1638,15 +1595,19 @@ func (_this *SubtleCrypto) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubtleCryptoFromJS is casting a js.Wrapper into SubtleCrypto.
-func SubtleCryptoFromJS(value js.Wrapper) *SubtleCrypto {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubtleCryptoFromJS is casting a js.Value into SubtleCrypto.
+func SubtleCryptoFromJS(value js.Value) *SubtleCrypto {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubtleCrypto{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubtleCryptoFromJS is casting from something that holds a js.Value into SubtleCrypto.
+func SubtleCryptoFromWrapper(input core.Wrapper) *SubtleCrypto {
+	return SubtleCryptoFromJS(input.JSValue())
 }
 
 func (_this *SubtleCrypto) Encrypt(algorithm *Union, key *CryptoKey, data *Union) (_result *javascript.Promise) {

--- a/crypto/crypto_js.go
+++ b/crypto/crypto_js.go
@@ -5,6 +5,7 @@ package crypto
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -261,7 +262,7 @@ type AesCbcParams struct {
 	Iv   *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesCbcParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -273,18 +274,16 @@ func (_this *AesCbcParams) JSValue() js.Value {
 }
 
 // AesCbcParamsFromJS is allocating a new
-// AesCbcParams object and copy all values from
-// input javascript object
-func AesCbcParamsFromJS(value js.Wrapper) *AesCbcParams {
-	input := value.JSValue()
+// AesCbcParams object and copy all values in the value javascript object.
+func AesCbcParamsFromJS(value js.Value) *AesCbcParams {
 	var out AesCbcParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {iv Iv iv}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("iv"))
+	value1 = UnionFromJS(value.Get("iv"))
 	out.Iv = value1
 	return &out
 }
@@ -296,7 +295,7 @@ type AesCtrParams struct {
 	Length  int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesCtrParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -310,21 +309,19 @@ func (_this *AesCtrParams) JSValue() js.Value {
 }
 
 // AesCtrParamsFromJS is allocating a new
-// AesCtrParams object and copy all values from
-// input javascript object
-func AesCtrParamsFromJS(value js.Wrapper) *AesCtrParams {
-	input := value.JSValue()
+// AesCtrParams object and copy all values in the value javascript object.
+func AesCtrParamsFromJS(value js.Value) *AesCtrParams {
 	var out AesCtrParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {counter Counter counter}
 		value2 int    // javascript: octet {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("counter"))
+	value1 = UnionFromJS(value.Get("counter"))
 	out.Counter = value1
-	value2 = (input.Get("length")).Int()
+	value2 = (value.Get("length")).Int()
 	out.Length = value2
 	return &out
 }
@@ -335,7 +332,7 @@ type AesDerivedKeyParams struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesDerivedKeyParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -347,18 +344,16 @@ func (_this *AesDerivedKeyParams) JSValue() js.Value {
 }
 
 // AesDerivedKeyParamsFromJS is allocating a new
-// AesDerivedKeyParams object and copy all values from
-// input javascript object
-func AesDerivedKeyParamsFromJS(value js.Wrapper) *AesDerivedKeyParams {
-	input := value.JSValue()
+// AesDerivedKeyParams object and copy all values in the value javascript object.
+func AesDerivedKeyParamsFromJS(value js.Value) *AesDerivedKeyParams {
 	var out AesDerivedKeyParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -371,7 +366,7 @@ type AesGcmParams struct {
 	TagLength      int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesGcmParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -387,10 +382,8 @@ func (_this *AesGcmParams) JSValue() js.Value {
 }
 
 // AesGcmParamsFromJS is allocating a new
-// AesGcmParams object and copy all values from
-// input javascript object
-func AesGcmParamsFromJS(value js.Wrapper) *AesGcmParams {
-	input := value.JSValue()
+// AesGcmParams object and copy all values in the value javascript object.
+func AesGcmParamsFromJS(value js.Value) *AesGcmParams {
 	var out AesGcmParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -398,13 +391,13 @@ func AesGcmParamsFromJS(value js.Wrapper) *AesGcmParams {
 		value2 *Union // javascript: Union {additionalData AdditionalData additionalData}
 		value3 int    // javascript: octet {tagLength TagLength tagLength}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("iv"))
+	value1 = UnionFromJS(value.Get("iv"))
 	out.Iv = value1
-	value2 = UnionFromJS(input.Get("additionalData"))
+	value2 = UnionFromJS(value.Get("additionalData"))
 	out.AdditionalData = value2
-	value3 = (input.Get("tagLength")).Int()
+	value3 = (value.Get("tagLength")).Int()
 	out.TagLength = value3
 	return &out
 }
@@ -415,7 +408,7 @@ type AesKeyAlgorithm struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -427,18 +420,16 @@ func (_this *AesKeyAlgorithm) JSValue() js.Value {
 }
 
 // AesKeyAlgorithmFromJS is allocating a new
-// AesKeyAlgorithm object and copy all values from
-// input javascript object
-func AesKeyAlgorithmFromJS(value js.Wrapper) *AesKeyAlgorithm {
-	input := value.JSValue()
+// AesKeyAlgorithm object and copy all values in the value javascript object.
+func AesKeyAlgorithmFromJS(value js.Value) *AesKeyAlgorithm {
 	var out AesKeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -449,7 +440,7 @@ type AesKeyGenParams struct {
 	Length int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AesKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -461,18 +452,16 @@ func (_this *AesKeyGenParams) JSValue() js.Value {
 }
 
 // AesKeyGenParamsFromJS is allocating a new
-// AesKeyGenParams object and copy all values from
-// input javascript object
-func AesKeyGenParamsFromJS(value js.Wrapper) *AesKeyGenParams {
-	input := value.JSValue()
+// AesKeyGenParams object and copy all values in the value javascript object.
+func AesKeyGenParamsFromJS(value js.Value) *AesKeyGenParams {
 	var out AesKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned short {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("length")).Int()
+	value1 = (value.Get("length")).Int()
 	out.Length = value1
 	return &out
 }
@@ -482,7 +471,7 @@ type Algorithm struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Algorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -492,15 +481,13 @@ func (_this *Algorithm) JSValue() js.Value {
 }
 
 // AlgorithmFromJS is allocating a new
-// Algorithm object and copy all values from
-// input javascript object
-func AlgorithmFromJS(value js.Wrapper) *Algorithm {
-	input := value.JSValue()
+// Algorithm object and copy all values in the value javascript object.
+func AlgorithmFromJS(value js.Value) *Algorithm {
 	var out Algorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -511,7 +498,7 @@ type CryptoKeyPair struct {
 	PrivateKey *CryptoKey
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CryptoKeyPair) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -523,18 +510,16 @@ func (_this *CryptoKeyPair) JSValue() js.Value {
 }
 
 // CryptoKeyPairFromJS is allocating a new
-// CryptoKeyPair object and copy all values from
-// input javascript object
-func CryptoKeyPairFromJS(value js.Wrapper) *CryptoKeyPair {
-	input := value.JSValue()
+// CryptoKeyPair object and copy all values in the value javascript object.
+func CryptoKeyPairFromJS(value js.Value) *CryptoKeyPair {
 	var out CryptoKeyPair
 	var (
 		value0 *CryptoKey // javascript: CryptoKey {publicKey PublicKey publicKey}
 		value1 *CryptoKey // javascript: CryptoKey {privateKey PrivateKey privateKey}
 	)
-	value0 = CryptoKeyFromJS(input.Get("publicKey"))
+	value0 = CryptoKeyFromJS(value.Get("publicKey"))
 	out.PublicKey = value0
-	value1 = CryptoKeyFromJS(input.Get("privateKey"))
+	value1 = CryptoKeyFromJS(value.Get("privateKey"))
 	out.PrivateKey = value1
 	return &out
 }
@@ -545,7 +530,7 @@ type EcKeyAlgorithm struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -557,18 +542,16 @@ func (_this *EcKeyAlgorithm) JSValue() js.Value {
 }
 
 // EcKeyAlgorithmFromJS is allocating a new
-// EcKeyAlgorithm object and copy all values from
-// input javascript object
-func EcKeyAlgorithmFromJS(value js.Wrapper) *EcKeyAlgorithm {
-	input := value.JSValue()
+// EcKeyAlgorithm object and copy all values in the value javascript object.
+func EcKeyAlgorithmFromJS(value js.Value) *EcKeyAlgorithm {
 	var out EcKeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -579,7 +562,7 @@ type EcKeyGenParams struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -591,18 +574,16 @@ func (_this *EcKeyGenParams) JSValue() js.Value {
 }
 
 // EcKeyGenParamsFromJS is allocating a new
-// EcKeyGenParams object and copy all values from
-// input javascript object
-func EcKeyGenParamsFromJS(value js.Wrapper) *EcKeyGenParams {
-	input := value.JSValue()
+// EcKeyGenParams object and copy all values in the value javascript object.
+func EcKeyGenParamsFromJS(value js.Value) *EcKeyGenParams {
 	var out EcKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -613,7 +594,7 @@ type EcKeyImportParams struct {
 	NamedCurve string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcKeyImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -625,18 +606,16 @@ func (_this *EcKeyImportParams) JSValue() js.Value {
 }
 
 // EcKeyImportParamsFromJS is allocating a new
-// EcKeyImportParams object and copy all values from
-// input javascript object
-func EcKeyImportParamsFromJS(value js.Wrapper) *EcKeyImportParams {
-	input := value.JSValue()
+// EcKeyImportParams object and copy all values in the value javascript object.
+func EcKeyImportParamsFromJS(value js.Value) *EcKeyImportParams {
 	var out EcKeyImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {namedCurve NamedCurve namedCurve}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("namedCurve")).String()
+	value1 = (value.Get("namedCurve")).String()
 	out.NamedCurve = value1
 	return &out
 }
@@ -647,7 +626,7 @@ type EcdhKeyDeriveParams struct {
 	Public *CryptoKey
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcdhKeyDeriveParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -659,18 +638,16 @@ func (_this *EcdhKeyDeriveParams) JSValue() js.Value {
 }
 
 // EcdhKeyDeriveParamsFromJS is allocating a new
-// EcdhKeyDeriveParams object and copy all values from
-// input javascript object
-func EcdhKeyDeriveParamsFromJS(value js.Wrapper) *EcdhKeyDeriveParams {
-	input := value.JSValue()
+// EcdhKeyDeriveParams object and copy all values in the value javascript object.
+func EcdhKeyDeriveParamsFromJS(value js.Value) *EcdhKeyDeriveParams {
 	var out EcdhKeyDeriveParams
 	var (
 		value0 string     // javascript: DOMString {name Name name}
 		value1 *CryptoKey // javascript: CryptoKey {public Public public}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = CryptoKeyFromJS(input.Get("public"))
+	value1 = CryptoKeyFromJS(value.Get("public"))
 	out.Public = value1
 	return &out
 }
@@ -681,7 +658,7 @@ type EcdsaParams struct {
 	Hash *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EcdsaParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -693,18 +670,16 @@ func (_this *EcdsaParams) JSValue() js.Value {
 }
 
 // EcdsaParamsFromJS is allocating a new
-// EcdsaParams object and copy all values from
-// input javascript object
-func EcdsaParamsFromJS(value js.Wrapper) *EcdsaParams {
-	input := value.JSValue()
+// EcdsaParams object and copy all values in the value javascript object.
+func EcdsaParamsFromJS(value js.Value) *EcdsaParams {
 	var out EcdsaParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
 	return &out
 }
@@ -717,7 +692,7 @@ type HkdfParams struct {
 	Info *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HkdfParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -733,10 +708,8 @@ func (_this *HkdfParams) JSValue() js.Value {
 }
 
 // HkdfParamsFromJS is allocating a new
-// HkdfParams object and copy all values from
-// input javascript object
-func HkdfParamsFromJS(value js.Wrapper) *HkdfParams {
-	input := value.JSValue()
+// HkdfParams object and copy all values in the value javascript object.
+func HkdfParamsFromJS(value js.Value) *HkdfParams {
 	var out HkdfParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -744,13 +717,13 @@ func HkdfParamsFromJS(value js.Wrapper) *HkdfParams {
 		value2 *Union // javascript: Union {salt Salt salt}
 		value3 *Union // javascript: Union {info Info info}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = UnionFromJS(input.Get("salt"))
+	value2 = UnionFromJS(value.Get("salt"))
 	out.Salt = value2
-	value3 = UnionFromJS(input.Get("info"))
+	value3 = UnionFromJS(value.Get("info"))
 	out.Info = value3
 	return &out
 }
@@ -762,7 +735,7 @@ type HmacImportParams struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -776,21 +749,19 @@ func (_this *HmacImportParams) JSValue() js.Value {
 }
 
 // HmacImportParamsFromJS is allocating a new
-// HmacImportParams object and copy all values from
-// input javascript object
-func HmacImportParamsFromJS(value js.Wrapper) *HmacImportParams {
-	input := value.JSValue()
+// HmacImportParams object and copy all values in the value javascript object.
+func HmacImportParamsFromJS(value js.Value) *HmacImportParams {
 	var out HmacImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 		value2 uint   // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -802,7 +773,7 @@ type HmacKeyAlgorithm struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -816,21 +787,19 @@ func (_this *HmacKeyAlgorithm) JSValue() js.Value {
 }
 
 // HmacKeyAlgorithmFromJS is allocating a new
-// HmacKeyAlgorithm object and copy all values from
-// input javascript object
-func HmacKeyAlgorithmFromJS(value js.Wrapper) *HmacKeyAlgorithm {
-	input := value.JSValue()
+// HmacKeyAlgorithm object and copy all values in the value javascript object.
+func HmacKeyAlgorithmFromJS(value js.Value) *HmacKeyAlgorithm {
 	var out HmacKeyAlgorithm
 	var (
 		value0 string        // javascript: DOMString {name Name name}
 		value1 *KeyAlgorithm // javascript: KeyAlgorithm {hash Hash hash}
 		value2 uint          // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = KeyAlgorithmFromJS(input.Get("hash"))
+	value1 = KeyAlgorithmFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -842,7 +811,7 @@ type HmacKeyGenParams struct {
 	Length uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HmacKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -856,21 +825,19 @@ func (_this *HmacKeyGenParams) JSValue() js.Value {
 }
 
 // HmacKeyGenParamsFromJS is allocating a new
-// HmacKeyGenParams object and copy all values from
-// input javascript object
-func HmacKeyGenParamsFromJS(value js.Wrapper) *HmacKeyGenParams {
-	input := value.JSValue()
+// HmacKeyGenParams object and copy all values in the value javascript object.
+func HmacKeyGenParamsFromJS(value js.Value) *HmacKeyGenParams {
 	var out HmacKeyGenParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 		value2 uint   // javascript: unsigned long {length Length length}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
-	value2 = (uint)((input.Get("length")).Int())
+	value2 = (uint)((value.Get("length")).Int())
 	out.Length = value2
 	return &out
 }
@@ -897,7 +864,7 @@ type JsonWebKey struct {
 	K      string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *JsonWebKey) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -949,10 +916,8 @@ func (_this *JsonWebKey) JSValue() js.Value {
 }
 
 // JsonWebKeyFromJS is allocating a new
-// JsonWebKey object and copy all values from
-// input javascript object
-func JsonWebKeyFromJS(value js.Wrapper) *JsonWebKey {
-	input := value.JSValue()
+// JsonWebKey object and copy all values in the value javascript object.
+func JsonWebKeyFromJS(value js.Value) *JsonWebKey {
 	var out JsonWebKey
 	var (
 		value0  string                // javascript: DOMString {kty Kty kty}
@@ -974,57 +939,57 @@ func JsonWebKeyFromJS(value js.Wrapper) *JsonWebKey {
 		value16 []*RsaOtherPrimesInfo // javascript: sequence<RsaOtherPrimesInfo> {oth Oth oth}
 		value17 string                // javascript: DOMString {k K k}
 	)
-	value0 = (input.Get("kty")).String()
+	value0 = (value.Get("kty")).String()
 	out.Kty = value0
-	value1 = (input.Get("use")).String()
+	value1 = (value.Get("use")).String()
 	out.Use = value1
-	__length2 := input.Get("key_ops").Length()
+	__length2 := value.Get("key_ops").Length()
 	__array2 := make([]string, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 string
-		__seq_in2 := input.Get("key_ops").Index(__idx2)
+		__seq_in2 := value.Get("key_ops").Index(__idx2)
 		__seq_out2 = (__seq_in2).String()
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.KeyOps = value2
-	value3 = (input.Get("alg")).String()
+	value3 = (value.Get("alg")).String()
 	out.Alg = value3
-	value4 = (input.Get("ext")).Bool()
+	value4 = (value.Get("ext")).Bool()
 	out.Ext = value4
-	value5 = (input.Get("crv")).String()
+	value5 = (value.Get("crv")).String()
 	out.Crv = value5
-	value6 = (input.Get("x")).String()
+	value6 = (value.Get("x")).String()
 	out.X = value6
-	value7 = (input.Get("y")).String()
+	value7 = (value.Get("y")).String()
 	out.Y = value7
-	value8 = (input.Get("d")).String()
+	value8 = (value.Get("d")).String()
 	out.D = value8
-	value9 = (input.Get("n")).String()
+	value9 = (value.Get("n")).String()
 	out.N = value9
-	value10 = (input.Get("e")).String()
+	value10 = (value.Get("e")).String()
 	out.E = value10
-	value11 = (input.Get("p")).String()
+	value11 = (value.Get("p")).String()
 	out.P = value11
-	value12 = (input.Get("q")).String()
+	value12 = (value.Get("q")).String()
 	out.Q = value12
-	value13 = (input.Get("dp")).String()
+	value13 = (value.Get("dp")).String()
 	out.Dp = value13
-	value14 = (input.Get("dq")).String()
+	value14 = (value.Get("dq")).String()
 	out.Dq = value14
-	value15 = (input.Get("qi")).String()
+	value15 = (value.Get("qi")).String()
 	out.Qi = value15
-	__length16 := input.Get("oth").Length()
+	__length16 := value.Get("oth").Length()
 	__array16 := make([]*RsaOtherPrimesInfo, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 *RsaOtherPrimesInfo
-		__seq_in16 := input.Get("oth").Index(__idx16)
+		__seq_in16 := value.Get("oth").Index(__idx16)
 		__seq_out16 = RsaOtherPrimesInfoFromJS(__seq_in16)
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.Oth = value16
-	value17 = (input.Get("k")).String()
+	value17 = (value.Get("k")).String()
 	out.K = value17
 	return &out
 }
@@ -1034,7 +999,7 @@ type KeyAlgorithm struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1044,15 +1009,13 @@ func (_this *KeyAlgorithm) JSValue() js.Value {
 }
 
 // KeyAlgorithmFromJS is allocating a new
-// KeyAlgorithm object and copy all values from
-// input javascript object
-func KeyAlgorithmFromJS(value js.Wrapper) *KeyAlgorithm {
-	input := value.JSValue()
+// KeyAlgorithm object and copy all values in the value javascript object.
+func KeyAlgorithmFromJS(value js.Value) *KeyAlgorithm {
 	var out KeyAlgorithm
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -1065,7 +1028,7 @@ type Pbkdf2Params struct {
 	Hash       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Pbkdf2Params) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1081,10 +1044,8 @@ func (_this *Pbkdf2Params) JSValue() js.Value {
 }
 
 // Pbkdf2ParamsFromJS is allocating a new
-// Pbkdf2Params object and copy all values from
-// input javascript object
-func Pbkdf2ParamsFromJS(value js.Wrapper) *Pbkdf2Params {
-	input := value.JSValue()
+// Pbkdf2Params object and copy all values in the value javascript object.
+func Pbkdf2ParamsFromJS(value js.Value) *Pbkdf2Params {
 	var out Pbkdf2Params
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -1092,13 +1053,13 @@ func Pbkdf2ParamsFromJS(value js.Wrapper) *Pbkdf2Params {
 		value2 uint   // javascript: unsigned long {iterations Iterations iterations}
 		value3 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("salt"))
+	value1 = UnionFromJS(value.Get("salt"))
 	out.Salt = value1
-	value2 = (uint)((input.Get("iterations")).Int())
+	value2 = (uint)((value.Get("iterations")).Int())
 	out.Iterations = value2
-	value3 = UnionFromJS(input.Get("hash"))
+	value3 = UnionFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1109,7 +1070,7 @@ type RsaHashedImportParams struct {
 	Hash *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedImportParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1121,18 +1082,16 @@ func (_this *RsaHashedImportParams) JSValue() js.Value {
 }
 
 // RsaHashedImportParamsFromJS is allocating a new
-// RsaHashedImportParams object and copy all values from
-// input javascript object
-func RsaHashedImportParamsFromJS(value js.Wrapper) *RsaHashedImportParams {
-	input := value.JSValue()
+// RsaHashedImportParams object and copy all values in the value javascript object.
+func RsaHashedImportParamsFromJS(value js.Value) *RsaHashedImportParams {
 	var out RsaHashedImportParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("hash"))
+	value1 = UnionFromJS(value.Get("hash"))
 	out.Hash = value1
 	return &out
 }
@@ -1145,7 +1104,7 @@ type RsaHashedKeyAlgorithm struct {
 	Hash           *KeyAlgorithm
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1161,10 +1120,8 @@ func (_this *RsaHashedKeyAlgorithm) JSValue() js.Value {
 }
 
 // RsaHashedKeyAlgorithmFromJS is allocating a new
-// RsaHashedKeyAlgorithm object and copy all values from
-// input javascript object
-func RsaHashedKeyAlgorithmFromJS(value js.Wrapper) *RsaHashedKeyAlgorithm {
-	input := value.JSValue()
+// RsaHashedKeyAlgorithm object and copy all values in the value javascript object.
+func RsaHashedKeyAlgorithmFromJS(value js.Value) *RsaHashedKeyAlgorithm {
 	var out RsaHashedKeyAlgorithm
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
@@ -1172,13 +1129,13 @@ func RsaHashedKeyAlgorithmFromJS(value js.Wrapper) *RsaHashedKeyAlgorithm {
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 		value3 *KeyAlgorithm          // javascript: KeyAlgorithm {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
-	value3 = KeyAlgorithmFromJS(input.Get("hash"))
+	value3 = KeyAlgorithmFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1191,7 +1148,7 @@ type RsaHashedKeyGenParams struct {
 	Hash           *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaHashedKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1207,10 +1164,8 @@ func (_this *RsaHashedKeyGenParams) JSValue() js.Value {
 }
 
 // RsaHashedKeyGenParamsFromJS is allocating a new
-// RsaHashedKeyGenParams object and copy all values from
-// input javascript object
-func RsaHashedKeyGenParamsFromJS(value js.Wrapper) *RsaHashedKeyGenParams {
-	input := value.JSValue()
+// RsaHashedKeyGenParams object and copy all values in the value javascript object.
+func RsaHashedKeyGenParamsFromJS(value js.Value) *RsaHashedKeyGenParams {
 	var out RsaHashedKeyGenParams
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
@@ -1218,13 +1173,13 @@ func RsaHashedKeyGenParamsFromJS(value js.Wrapper) *RsaHashedKeyGenParams {
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 		value3 *Union                 // javascript: Union {hash Hash hash}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
-	value3 = UnionFromJS(input.Get("hash"))
+	value3 = UnionFromJS(value.Get("hash"))
 	out.Hash = value3
 	return &out
 }
@@ -1236,7 +1191,7 @@ type RsaKeyAlgorithm struct {
 	PublicExponent *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaKeyAlgorithm) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1250,21 +1205,19 @@ func (_this *RsaKeyAlgorithm) JSValue() js.Value {
 }
 
 // RsaKeyAlgorithmFromJS is allocating a new
-// RsaKeyAlgorithm object and copy all values from
-// input javascript object
-func RsaKeyAlgorithmFromJS(value js.Wrapper) *RsaKeyAlgorithm {
-	input := value.JSValue()
+// RsaKeyAlgorithm object and copy all values in the value javascript object.
+func RsaKeyAlgorithmFromJS(value js.Value) *RsaKeyAlgorithm {
 	var out RsaKeyAlgorithm
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
 		value1 uint                   // javascript: unsigned long {modulusLength ModulusLength modulusLength}
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
 	return &out
 }
@@ -1276,7 +1229,7 @@ type RsaKeyGenParams struct {
 	PublicExponent *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaKeyGenParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1290,21 +1243,19 @@ func (_this *RsaKeyGenParams) JSValue() js.Value {
 }
 
 // RsaKeyGenParamsFromJS is allocating a new
-// RsaKeyGenParams object and copy all values from
-// input javascript object
-func RsaKeyGenParamsFromJS(value js.Wrapper) *RsaKeyGenParams {
-	input := value.JSValue()
+// RsaKeyGenParams object and copy all values in the value javascript object.
+func RsaKeyGenParamsFromJS(value js.Value) *RsaKeyGenParams {
 	var out RsaKeyGenParams
 	var (
 		value0 string                 // javascript: DOMString {name Name name}
 		value1 uint                   // javascript: unsigned long {modulusLength ModulusLength modulusLength}
 		value2 *javascript.Uint8Array // javascript: Uint8Array {publicExponent PublicExponent publicExponent}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("modulusLength")).Int())
+	value1 = (uint)((value.Get("modulusLength")).Int())
 	out.ModulusLength = value1
-	value2 = javascript.Uint8ArrayFromJS(input.Get("publicExponent"))
+	value2 = javascript.Uint8ArrayFromJS(value.Get("publicExponent"))
 	out.PublicExponent = value2
 	return &out
 }
@@ -1315,7 +1266,7 @@ type RsaOaepParams struct {
 	Label *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaOaepParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1327,18 +1278,16 @@ func (_this *RsaOaepParams) JSValue() js.Value {
 }
 
 // RsaOaepParamsFromJS is allocating a new
-// RsaOaepParams object and copy all values from
-// input javascript object
-func RsaOaepParamsFromJS(value js.Wrapper) *RsaOaepParams {
-	input := value.JSValue()
+// RsaOaepParams object and copy all values in the value javascript object.
+func RsaOaepParamsFromJS(value js.Value) *RsaOaepParams {
 	var out RsaOaepParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 *Union // javascript: Union {label Label label}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = UnionFromJS(input.Get("label"))
+	value1 = UnionFromJS(value.Get("label"))
 	out.Label = value1
 	return &out
 }
@@ -1350,7 +1299,7 @@ type RsaOtherPrimesInfo struct {
 	T string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaOtherPrimesInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1364,21 +1313,19 @@ func (_this *RsaOtherPrimesInfo) JSValue() js.Value {
 }
 
 // RsaOtherPrimesInfoFromJS is allocating a new
-// RsaOtherPrimesInfo object and copy all values from
-// input javascript object
-func RsaOtherPrimesInfoFromJS(value js.Wrapper) *RsaOtherPrimesInfo {
-	input := value.JSValue()
+// RsaOtherPrimesInfo object and copy all values in the value javascript object.
+func RsaOtherPrimesInfoFromJS(value js.Value) *RsaOtherPrimesInfo {
 	var out RsaOtherPrimesInfo
 	var (
 		value0 string // javascript: DOMString {r R r}
 		value1 string // javascript: DOMString {d D d}
 		value2 string // javascript: DOMString {t T t}
 	)
-	value0 = (input.Get("r")).String()
+	value0 = (value.Get("r")).String()
 	out.R = value0
-	value1 = (input.Get("d")).String()
+	value1 = (value.Get("d")).String()
 	out.D = value1
-	value2 = (input.Get("t")).String()
+	value2 = (value.Get("t")).String()
 	out.T = value2
 	return &out
 }
@@ -1389,7 +1336,7 @@ type RsaPssParams struct {
 	SaltLength uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RsaPssParams) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1401,18 +1348,16 @@ func (_this *RsaPssParams) JSValue() js.Value {
 }
 
 // RsaPssParamsFromJS is allocating a new
-// RsaPssParams object and copy all values from
-// input javascript object
-func RsaPssParamsFromJS(value js.Wrapper) *RsaPssParams {
-	input := value.JSValue()
+// RsaPssParams object and copy all values in the value javascript object.
+func RsaPssParamsFromJS(value js.Value) *RsaPssParams {
 	var out RsaPssParams
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 uint   // javascript: unsigned long {saltLength SaltLength saltLength}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (uint)((input.Get("saltLength")).Int())
+	value1 = (uint)((value.Get("saltLength")).Int())
 	out.SaltLength = value1
 	return &out
 }
@@ -1427,15 +1372,19 @@ func (_this *Crypto) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CryptoFromJS is casting a js.Wrapper into Crypto.
-func CryptoFromJS(value js.Wrapper) *Crypto {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CryptoFromJS is casting a js.Value into Crypto.
+func CryptoFromJS(value js.Value) *Crypto {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Crypto{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CryptoFromJS is casting from something that holds a js.Value into Crypto.
+func CryptoFromWrapper(input core.Wrapper) *Crypto {
+	return CryptoFromJS(input.JSValue())
 }
 
 // Subtle returning attribute 'subtle' with
@@ -1474,15 +1423,19 @@ func (_this *CryptoKey) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CryptoKeyFromJS is casting a js.Wrapper into CryptoKey.
-func CryptoKeyFromJS(value js.Wrapper) *CryptoKey {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CryptoKeyFromJS is casting a js.Value into CryptoKey.
+func CryptoKeyFromJS(value js.Value) *CryptoKey {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CryptoKey{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CryptoKeyFromJS is casting from something that holds a js.Value into CryptoKey.
+func CryptoKeyFromWrapper(input core.Wrapper) *CryptoKey {
+	return CryptoKeyFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -1531,15 +1484,19 @@ func (_this *PromiseCryptoKey) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCryptoKeyFromJS is casting a js.Wrapper into PromiseCryptoKey.
-func PromiseCryptoKeyFromJS(value js.Wrapper) *PromiseCryptoKey {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCryptoKeyFromJS is casting a js.Value into PromiseCryptoKey.
+func PromiseCryptoKeyFromJS(value js.Value) *PromiseCryptoKey {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCryptoKey{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCryptoKeyFromJS is casting from something that holds a js.Value into PromiseCryptoKey.
+func PromiseCryptoKeyFromWrapper(input core.Wrapper) *PromiseCryptoKey {
+	return PromiseCryptoKeyFromJS(input.JSValue())
 }
 
 func (_this *PromiseCryptoKey) Then(onFulfilled *PromiseCryptoKeyOnFulfilled, onRejected *PromiseCryptoKeyOnRejected) (_result *PromiseCryptoKey) {
@@ -1636,15 +1593,19 @@ func (_this *SubtleCrypto) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubtleCryptoFromJS is casting a js.Wrapper into SubtleCrypto.
-func SubtleCryptoFromJS(value js.Wrapper) *SubtleCrypto {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubtleCryptoFromJS is casting a js.Value into SubtleCrypto.
+func SubtleCryptoFromJS(value js.Value) *SubtleCrypto {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubtleCrypto{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubtleCryptoFromJS is casting from something that holds a js.Value into SubtleCrypto.
+func SubtleCryptoFromWrapper(input core.Wrapper) *SubtleCrypto {
+	return SubtleCryptoFromJS(input.JSValue())
 }
 
 func (_this *SubtleCrypto) Encrypt(algorithm *Union, key *CryptoKey, data *Union) (_result *javascript.Promise) {

--- a/csp/csp.go
+++ b/csp/csp.go
@@ -7,6 +7,7 @@ package csp
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -96,7 +97,7 @@ type SecurityPolicyViolationEventInit struct {
 	Colno              uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SecurityPolicyViolationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -132,10 +133,8 @@ func (_this *SecurityPolicyViolationEventInit) JSValue() js.Value {
 }
 
 // SecurityPolicyViolationEventInitFromJS is allocating a new
-// SecurityPolicyViolationEventInit object and copy all values from
-// input javascript object
-func SecurityPolicyViolationEventInitFromJS(value js.Wrapper) *SecurityPolicyViolationEventInit {
-	input := value.JSValue()
+// SecurityPolicyViolationEventInit object and copy all values in the value javascript object.
+func SecurityPolicyViolationEventInitFromJS(value js.Value) *SecurityPolicyViolationEventInit {
 	var out SecurityPolicyViolationEventInit
 	var (
 		value0  bool                                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -153,33 +152,33 @@ func SecurityPolicyViolationEventInitFromJS(value js.Wrapper) *SecurityPolicyVio
 		value12 uint                                    // javascript: unsigned long {lineno Lineno lineno}
 		value13 uint                                    // javascript: unsigned long {colno Colno colno}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("documentURL")).String()
+	value3 = (value.Get("documentURL")).String()
 	out.DocumentURL = value3
-	value4 = (input.Get("referrer")).String()
+	value4 = (value.Get("referrer")).String()
 	out.Referrer = value4
-	value5 = (input.Get("blockedURL")).String()
+	value5 = (value.Get("blockedURL")).String()
 	out.BlockedURL = value5
-	value6 = (input.Get("effectiveDirective")).String()
+	value6 = (value.Get("effectiveDirective")).String()
 	out.EffectiveDirective = value6
-	value7 = (input.Get("originalPolicy")).String()
+	value7 = (value.Get("originalPolicy")).String()
 	out.OriginalPolicy = value7
-	value8 = (input.Get("sourceFile")).String()
+	value8 = (value.Get("sourceFile")).String()
 	out.SourceFile = value8
-	value9 = (input.Get("sample")).String()
+	value9 = (value.Get("sample")).String()
 	out.Sample = value9
-	value10 = SecurityPolicyViolationEventDispositionFromJS(input.Get("disposition"))
+	value10 = SecurityPolicyViolationEventDispositionFromJS(value.Get("disposition"))
 	out.Disposition = value10
-	value11 = (input.Get("statusCode")).Int()
+	value11 = (value.Get("statusCode")).Int()
 	out.StatusCode = value11
-	value12 = (uint)((input.Get("lineno")).Int())
+	value12 = (uint)((value.Get("lineno")).Int())
 	out.Lineno = value12
-	value13 = (uint)((input.Get("colno")).Int())
+	value13 = (uint)((value.Get("colno")).Int())
 	out.Colno = value13
 	return &out
 }
@@ -189,15 +188,19 @@ type SecurityPolicyViolationEvent struct {
 	domcore.Event
 }
 
-// SecurityPolicyViolationEventFromJS is casting a js.Wrapper into SecurityPolicyViolationEvent.
-func SecurityPolicyViolationEventFromJS(value js.Wrapper) *SecurityPolicyViolationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SecurityPolicyViolationEventFromJS is casting a js.Value into SecurityPolicyViolationEvent.
+func SecurityPolicyViolationEventFromJS(value js.Value) *SecurityPolicyViolationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SecurityPolicyViolationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SecurityPolicyViolationEventFromJS is casting from something that holds a js.Value into SecurityPolicyViolationEvent.
+func SecurityPolicyViolationEventFromWrapper(input core.Wrapper) *SecurityPolicyViolationEvent {
+	return SecurityPolicyViolationEventFromJS(input.JSValue())
 }
 
 func NewSecurityPolicyViolationEvent(_type string, eventInitDict *SecurityPolicyViolationEventInit) (_result *SecurityPolicyViolationEvent) {

--- a/csp/csp_js.go
+++ b/csp/csp_js.go
@@ -5,6 +5,7 @@ package csp
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -94,7 +95,7 @@ type SecurityPolicyViolationEventInit struct {
 	Colno              uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SecurityPolicyViolationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -130,10 +131,8 @@ func (_this *SecurityPolicyViolationEventInit) JSValue() js.Value {
 }
 
 // SecurityPolicyViolationEventInitFromJS is allocating a new
-// SecurityPolicyViolationEventInit object and copy all values from
-// input javascript object
-func SecurityPolicyViolationEventInitFromJS(value js.Wrapper) *SecurityPolicyViolationEventInit {
-	input := value.JSValue()
+// SecurityPolicyViolationEventInit object and copy all values in the value javascript object.
+func SecurityPolicyViolationEventInitFromJS(value js.Value) *SecurityPolicyViolationEventInit {
 	var out SecurityPolicyViolationEventInit
 	var (
 		value0  bool                                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -151,33 +150,33 @@ func SecurityPolicyViolationEventInitFromJS(value js.Wrapper) *SecurityPolicyVio
 		value12 uint                                    // javascript: unsigned long {lineno Lineno lineno}
 		value13 uint                                    // javascript: unsigned long {colno Colno colno}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("documentURL")).String()
+	value3 = (value.Get("documentURL")).String()
 	out.DocumentURL = value3
-	value4 = (input.Get("referrer")).String()
+	value4 = (value.Get("referrer")).String()
 	out.Referrer = value4
-	value5 = (input.Get("blockedURL")).String()
+	value5 = (value.Get("blockedURL")).String()
 	out.BlockedURL = value5
-	value6 = (input.Get("effectiveDirective")).String()
+	value6 = (value.Get("effectiveDirective")).String()
 	out.EffectiveDirective = value6
-	value7 = (input.Get("originalPolicy")).String()
+	value7 = (value.Get("originalPolicy")).String()
 	out.OriginalPolicy = value7
-	value8 = (input.Get("sourceFile")).String()
+	value8 = (value.Get("sourceFile")).String()
 	out.SourceFile = value8
-	value9 = (input.Get("sample")).String()
+	value9 = (value.Get("sample")).String()
 	out.Sample = value9
-	value10 = SecurityPolicyViolationEventDispositionFromJS(input.Get("disposition"))
+	value10 = SecurityPolicyViolationEventDispositionFromJS(value.Get("disposition"))
 	out.Disposition = value10
-	value11 = (input.Get("statusCode")).Int()
+	value11 = (value.Get("statusCode")).Int()
 	out.StatusCode = value11
-	value12 = (uint)((input.Get("lineno")).Int())
+	value12 = (uint)((value.Get("lineno")).Int())
 	out.Lineno = value12
-	value13 = (uint)((input.Get("colno")).Int())
+	value13 = (uint)((value.Get("colno")).Int())
 	out.Colno = value13
 	return &out
 }
@@ -187,15 +186,19 @@ type SecurityPolicyViolationEvent struct {
 	domcore.Event
 }
 
-// SecurityPolicyViolationEventFromJS is casting a js.Wrapper into SecurityPolicyViolationEvent.
-func SecurityPolicyViolationEventFromJS(value js.Wrapper) *SecurityPolicyViolationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SecurityPolicyViolationEventFromJS is casting a js.Value into SecurityPolicyViolationEvent.
+func SecurityPolicyViolationEventFromJS(value js.Value) *SecurityPolicyViolationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SecurityPolicyViolationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SecurityPolicyViolationEventFromJS is casting from something that holds a js.Value into SecurityPolicyViolationEvent.
+func SecurityPolicyViolationEventFromWrapper(input core.Wrapper) *SecurityPolicyViolationEvent {
+	return SecurityPolicyViolationEventFromJS(input.JSValue())
 }
 
 func NewSecurityPolicyViolationEvent(_type string, eventInitDict *SecurityPolicyViolationEventInit) (_result *SecurityPolicyViolationEvent) {

--- a/css/animations/animations.go
+++ b/css/animations/animations.go
@@ -7,6 +7,7 @@ package animations
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
@@ -50,7 +51,7 @@ type AnimationEventInit struct {
 	PseudoElement string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnimationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -70,10 +71,8 @@ func (_this *AnimationEventInit) JSValue() js.Value {
 }
 
 // AnimationEventInitFromJS is allocating a new
-// AnimationEventInit object and copy all values from
-// input javascript object
-func AnimationEventInitFromJS(value js.Wrapper) *AnimationEventInit {
-	input := value.JSValue()
+// AnimationEventInit object and copy all values in the value javascript object.
+func AnimationEventInitFromJS(value js.Value) *AnimationEventInit {
 	var out AnimationEventInit
 	var (
 		value0 bool    // javascript: boolean {bubbles Bubbles bubbles}
@@ -83,17 +82,17 @@ func AnimationEventInitFromJS(value js.Wrapper) *AnimationEventInit {
 		value4 float64 // javascript: double {elapsedTime ElapsedTime elapsedTime}
 		value5 string  // javascript: DOMString {pseudoElement PseudoElement pseudoElement}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("animationName")).String()
+	value3 = (value.Get("animationName")).String()
 	out.AnimationName = value3
-	value4 = (input.Get("elapsedTime")).Float()
+	value4 = (value.Get("elapsedTime")).Float()
 	out.ElapsedTime = value4
-	value5 = (input.Get("pseudoElement")).String()
+	value5 = (value.Get("pseudoElement")).String()
 	out.PseudoElement = value5
 	return &out
 }
@@ -103,15 +102,19 @@ type AnimationEvent struct {
 	domcore.Event
 }
 
-// AnimationEventFromJS is casting a js.Wrapper into AnimationEvent.
-func AnimationEventFromJS(value js.Wrapper) *AnimationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationEventFromJS is casting a js.Value into AnimationEvent.
+func AnimationEventFromJS(value js.Value) *AnimationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationEventFromJS is casting from something that holds a js.Value into AnimationEvent.
+func AnimationEventFromWrapper(input core.Wrapper) *AnimationEvent {
+	return AnimationEventFromJS(input.JSValue())
 }
 
 func NewAnimationEvent(_type string, animationEventInitDict *AnimationEventInit) (_result *AnimationEvent) {
@@ -169,15 +172,19 @@ type CSSKeyframeRule struct {
 	cssom.CSSRule
 }
 
-// CSSKeyframeRuleFromJS is casting a js.Wrapper into CSSKeyframeRule.
-func CSSKeyframeRuleFromJS(value js.Wrapper) *CSSKeyframeRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeyframeRuleFromJS is casting a js.Value into CSSKeyframeRule.
+func CSSKeyframeRuleFromJS(value js.Value) *CSSKeyframeRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeyframeRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeyframeRuleFromJS is casting from something that holds a js.Value into CSSKeyframeRule.
+func CSSKeyframeRuleFromWrapper(input core.Wrapper) *CSSKeyframeRule {
+	return CSSKeyframeRuleFromJS(input.JSValue())
 }
 
 // KeyText returning attribute 'keyText' with
@@ -210,15 +217,19 @@ type CSSKeyframesRule struct {
 	cssom.CSSRule
 }
 
-// CSSKeyframesRuleFromJS is casting a js.Wrapper into CSSKeyframesRule.
-func CSSKeyframesRuleFromJS(value js.Wrapper) *CSSKeyframesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeyframesRuleFromJS is casting a js.Value into CSSKeyframesRule.
+func CSSKeyframesRuleFromJS(value js.Value) *CSSKeyframesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeyframesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeyframesRuleFromJS is casting from something that holds a js.Value into CSSKeyframesRule.
+func CSSKeyframesRuleFromWrapper(input core.Wrapper) *CSSKeyframesRule {
+	return CSSKeyframesRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with

--- a/css/animations/animations_js.go
+++ b/css/animations/animations_js.go
@@ -5,6 +5,7 @@ package animations
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
@@ -48,7 +49,7 @@ type AnimationEventInit struct {
 	PseudoElement string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnimationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -68,10 +69,8 @@ func (_this *AnimationEventInit) JSValue() js.Value {
 }
 
 // AnimationEventInitFromJS is allocating a new
-// AnimationEventInit object and copy all values from
-// input javascript object
-func AnimationEventInitFromJS(value js.Wrapper) *AnimationEventInit {
-	input := value.JSValue()
+// AnimationEventInit object and copy all values in the value javascript object.
+func AnimationEventInitFromJS(value js.Value) *AnimationEventInit {
 	var out AnimationEventInit
 	var (
 		value0 bool    // javascript: boolean {bubbles Bubbles bubbles}
@@ -81,17 +80,17 @@ func AnimationEventInitFromJS(value js.Wrapper) *AnimationEventInit {
 		value4 float64 // javascript: double {elapsedTime ElapsedTime elapsedTime}
 		value5 string  // javascript: DOMString {pseudoElement PseudoElement pseudoElement}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("animationName")).String()
+	value3 = (value.Get("animationName")).String()
 	out.AnimationName = value3
-	value4 = (input.Get("elapsedTime")).Float()
+	value4 = (value.Get("elapsedTime")).Float()
 	out.ElapsedTime = value4
-	value5 = (input.Get("pseudoElement")).String()
+	value5 = (value.Get("pseudoElement")).String()
 	out.PseudoElement = value5
 	return &out
 }
@@ -101,15 +100,19 @@ type AnimationEvent struct {
 	domcore.Event
 }
 
-// AnimationEventFromJS is casting a js.Wrapper into AnimationEvent.
-func AnimationEventFromJS(value js.Wrapper) *AnimationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationEventFromJS is casting a js.Value into AnimationEvent.
+func AnimationEventFromJS(value js.Value) *AnimationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationEventFromJS is casting from something that holds a js.Value into AnimationEvent.
+func AnimationEventFromWrapper(input core.Wrapper) *AnimationEvent {
+	return AnimationEventFromJS(input.JSValue())
 }
 
 func NewAnimationEvent(_type string, animationEventInitDict *AnimationEventInit) (_result *AnimationEvent) {
@@ -167,15 +170,19 @@ type CSSKeyframeRule struct {
 	cssom.CSSRule
 }
 
-// CSSKeyframeRuleFromJS is casting a js.Wrapper into CSSKeyframeRule.
-func CSSKeyframeRuleFromJS(value js.Wrapper) *CSSKeyframeRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeyframeRuleFromJS is casting a js.Value into CSSKeyframeRule.
+func CSSKeyframeRuleFromJS(value js.Value) *CSSKeyframeRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeyframeRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeyframeRuleFromJS is casting from something that holds a js.Value into CSSKeyframeRule.
+func CSSKeyframeRuleFromWrapper(input core.Wrapper) *CSSKeyframeRule {
+	return CSSKeyframeRuleFromJS(input.JSValue())
 }
 
 // KeyText returning attribute 'keyText' with
@@ -208,15 +215,19 @@ type CSSKeyframesRule struct {
 	cssom.CSSRule
 }
 
-// CSSKeyframesRuleFromJS is casting a js.Wrapper into CSSKeyframesRule.
-func CSSKeyframesRuleFromJS(value js.Wrapper) *CSSKeyframesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeyframesRuleFromJS is casting a js.Value into CSSKeyframesRule.
+func CSSKeyframesRuleFromJS(value js.Value) *CSSKeyframesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeyframesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeyframesRuleFromJS is casting from something that holds a js.Value into CSSKeyframesRule.
+func CSSKeyframesRuleFromWrapper(input core.Wrapper) *CSSKeyframesRule {
+	return CSSKeyframesRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with

--- a/css/animations/webani/webani.go
+++ b/css/animations/webani/webani.go
@@ -7,6 +7,7 @@ package webani
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -312,7 +313,7 @@ type AnimationPlaybackEventInit struct {
 	TimelineTime *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnimationPlaybackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -342,10 +343,8 @@ func (_this *AnimationPlaybackEventInit) JSValue() js.Value {
 }
 
 // AnimationPlaybackEventInitFromJS is allocating a new
-// AnimationPlaybackEventInit object and copy all values from
-// input javascript object
-func AnimationPlaybackEventInitFromJS(value js.Wrapper) *AnimationPlaybackEventInit {
-	input := value.JSValue()
+// AnimationPlaybackEventInit object and copy all values in the value javascript object.
+func AnimationPlaybackEventInitFromJS(value js.Value) *AnimationPlaybackEventInit {
 	var out AnimationPlaybackEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -354,19 +353,19 @@ func AnimationPlaybackEventInitFromJS(value js.Wrapper) *AnimationPlaybackEventI
 		value3 *float64 // javascript: double {currentTime CurrentTime currentTime}
 		value4 *float64 // javascript: double {timelineTime TimelineTime timelineTime}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("currentTime").Type() != js.TypeNull && input.Get("currentTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("currentTime")).Float()
+	if value.Get("currentTime").Type() != js.TypeNull && value.Get("currentTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("currentTime")).Float()
 		value3 = &__tmp
 	}
 	out.CurrentTime = value3
-	if input.Get("timelineTime").Type() != js.TypeNull && input.Get("timelineTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("timelineTime")).Float()
+	if value.Get("timelineTime").Type() != js.TypeNull && value.Get("timelineTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("timelineTime")).Float()
 		value4 = &__tmp
 	}
 	out.TimelineTime = value4
@@ -381,7 +380,7 @@ type BaseComputedKeyframe struct {
 	Composite      CompositeOperationOrAuto
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BaseComputedKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -403,10 +402,8 @@ func (_this *BaseComputedKeyframe) JSValue() js.Value {
 }
 
 // BaseComputedKeyframeFromJS is allocating a new
-// BaseComputedKeyframe object and copy all values from
-// input javascript object
-func BaseComputedKeyframeFromJS(value js.Wrapper) *BaseComputedKeyframe {
-	input := value.JSValue()
+// BaseComputedKeyframe object and copy all values in the value javascript object.
+func BaseComputedKeyframeFromJS(value js.Value) *BaseComputedKeyframe {
 	var out BaseComputedKeyframe
 	var (
 		value0 *float64                 // javascript: double {offset Offset offset}
@@ -414,16 +411,16 @@ func BaseComputedKeyframeFromJS(value js.Wrapper) *BaseComputedKeyframe {
 		value2 string                   // javascript: DOMString {easing Easing easing}
 		value3 CompositeOperationOrAuto // javascript: CompositeOperationOrAuto {composite Composite composite}
 	)
-	if input.Get("offset").Type() != js.TypeNull && input.Get("offset").Type() != js.TypeUndefined {
-		__tmp := (input.Get("offset")).Float()
+	if value.Get("offset").Type() != js.TypeNull && value.Get("offset").Type() != js.TypeUndefined {
+		__tmp := (value.Get("offset")).Float()
 		value0 = &__tmp
 	}
 	out.Offset = value0
-	value1 = (input.Get("computedOffset")).Float()
+	value1 = (value.Get("computedOffset")).Float()
 	out.ComputedOffset = value1
-	value2 = (input.Get("easing")).String()
+	value2 = (value.Get("easing")).String()
 	out.Easing = value2
-	value3 = CompositeOperationOrAutoFromJS(input.Get("composite"))
+	value3 = CompositeOperationOrAutoFromJS(value.Get("composite"))
 	out.Composite = value3
 	return &out
 }
@@ -435,7 +432,7 @@ type BaseKeyframe struct {
 	Composite CompositeOperationOrAuto
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BaseKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -455,24 +452,22 @@ func (_this *BaseKeyframe) JSValue() js.Value {
 }
 
 // BaseKeyframeFromJS is allocating a new
-// BaseKeyframe object and copy all values from
-// input javascript object
-func BaseKeyframeFromJS(value js.Wrapper) *BaseKeyframe {
-	input := value.JSValue()
+// BaseKeyframe object and copy all values in the value javascript object.
+func BaseKeyframeFromJS(value js.Value) *BaseKeyframe {
 	var out BaseKeyframe
 	var (
 		value0 *float64                 // javascript: double {offset Offset offset}
 		value1 string                   // javascript: DOMString {easing Easing easing}
 		value2 CompositeOperationOrAuto // javascript: CompositeOperationOrAuto {composite Composite composite}
 	)
-	if input.Get("offset").Type() != js.TypeNull && input.Get("offset").Type() != js.TypeUndefined {
-		__tmp := (input.Get("offset")).Float()
+	if value.Get("offset").Type() != js.TypeNull && value.Get("offset").Type() != js.TypeUndefined {
+		__tmp := (value.Get("offset")).Float()
 		value0 = &__tmp
 	}
 	out.Offset = value0
-	value1 = (input.Get("easing")).String()
+	value1 = (value.Get("easing")).String()
 	out.Easing = value1
-	value2 = CompositeOperationOrAutoFromJS(input.Get("composite"))
+	value2 = CompositeOperationOrAutoFromJS(value.Get("composite"))
 	out.Composite = value2
 	return &out
 }
@@ -484,7 +479,7 @@ type BasePropertyIndexedKeyframe struct {
 	Composite *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasePropertyIndexedKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -498,21 +493,19 @@ func (_this *BasePropertyIndexedKeyframe) JSValue() js.Value {
 }
 
 // BasePropertyIndexedKeyframeFromJS is allocating a new
-// BasePropertyIndexedKeyframe object and copy all values from
-// input javascript object
-func BasePropertyIndexedKeyframeFromJS(value js.Wrapper) *BasePropertyIndexedKeyframe {
-	input := value.JSValue()
+// BasePropertyIndexedKeyframe object and copy all values in the value javascript object.
+func BasePropertyIndexedKeyframeFromJS(value js.Value) *BasePropertyIndexedKeyframe {
 	var out BasePropertyIndexedKeyframe
 	var (
 		value0 *Union // javascript: Union {offset Offset offset}
 		value1 *Union // javascript: Union {easing Easing easing}
 		value2 *Union // javascript: Union {composite Composite composite}
 	)
-	value0 = UnionFromJS(input.Get("offset"))
+	value0 = UnionFromJS(value.Get("offset"))
 	out.Offset = value0
-	value1 = UnionFromJS(input.Get("easing"))
+	value1 = UnionFromJS(value.Get("easing"))
 	out.Easing = value1
-	value2 = UnionFromJS(input.Get("composite"))
+	value2 = UnionFromJS(value.Get("composite"))
 	out.Composite = value2
 	return &out
 }
@@ -534,7 +527,7 @@ type ComputedEffectTiming struct {
 	CurrentIteration *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ComputedEffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -586,10 +579,8 @@ func (_this *ComputedEffectTiming) JSValue() js.Value {
 }
 
 // ComputedEffectTimingFromJS is allocating a new
-// ComputedEffectTiming object and copy all values from
-// input javascript object
-func ComputedEffectTimingFromJS(value js.Wrapper) *ComputedEffectTiming {
-	input := value.JSValue()
+// ComputedEffectTiming object and copy all values in the value javascript object.
+func ComputedEffectTimingFromJS(value js.Value) *ComputedEffectTiming {
 	var out ComputedEffectTiming
 	var (
 		value0  float64           // javascript: double {delay Delay delay}
@@ -606,38 +597,38 @@ func ComputedEffectTimingFromJS(value js.Wrapper) *ComputedEffectTiming {
 		value11 *float64          // javascript: double {progress Progress progress}
 		value12 *float64          // javascript: unrestricted double {currentIteration CurrentIteration currentIteration}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = (input.Get("endTime")).Float()
+	value8 = (value.Get("endTime")).Float()
 	out.EndTime = value8
-	value9 = (input.Get("activeDuration")).Float()
+	value9 = (value.Get("activeDuration")).Float()
 	out.ActiveDuration = value9
-	if input.Get("localTime").Type() != js.TypeNull && input.Get("localTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("localTime")).Float()
+	if value.Get("localTime").Type() != js.TypeNull && value.Get("localTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("localTime")).Float()
 		value10 = &__tmp
 	}
 	out.LocalTime = value10
-	if input.Get("progress").Type() != js.TypeNull && input.Get("progress").Type() != js.TypeUndefined {
-		__tmp := (input.Get("progress")).Float()
+	if value.Get("progress").Type() != js.TypeNull && value.Get("progress").Type() != js.TypeUndefined {
+		__tmp := (value.Get("progress")).Float()
 		value11 = &__tmp
 	}
 	out.Progress = value11
-	if input.Get("currentIteration").Type() != js.TypeNull && input.Get("currentIteration").Type() != js.TypeUndefined {
-		__tmp := (input.Get("currentIteration")).Float()
+	if value.Get("currentIteration").Type() != js.TypeNull && value.Get("currentIteration").Type() != js.TypeUndefined {
+		__tmp := (value.Get("currentIteration")).Float()
 		value12 = &__tmp
 	}
 	out.CurrentIteration = value12
@@ -649,7 +640,7 @@ type DocumentTimelineOptions struct {
 	OriginTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DocumentTimelineOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -659,15 +650,13 @@ func (_this *DocumentTimelineOptions) JSValue() js.Value {
 }
 
 // DocumentTimelineOptionsFromJS is allocating a new
-// DocumentTimelineOptions object and copy all values from
-// input javascript object
-func DocumentTimelineOptionsFromJS(value js.Wrapper) *DocumentTimelineOptions {
-	input := value.JSValue()
+// DocumentTimelineOptions object and copy all values in the value javascript object.
+func DocumentTimelineOptionsFromJS(value js.Value) *DocumentTimelineOptions {
 	var out DocumentTimelineOptions
 	var (
 		value0 float64 // javascript: double {originTime OriginTime originTime}
 	)
-	value0 = (input.Get("originTime")).Float()
+	value0 = (value.Get("originTime")).Float()
 	out.OriginTime = value0
 	return &out
 }
@@ -684,7 +673,7 @@ type EffectTiming struct {
 	Easing         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -708,10 +697,8 @@ func (_this *EffectTiming) JSValue() js.Value {
 }
 
 // EffectTimingFromJS is allocating a new
-// EffectTiming object and copy all values from
-// input javascript object
-func EffectTimingFromJS(value js.Wrapper) *EffectTiming {
-	input := value.JSValue()
+// EffectTiming object and copy all values in the value javascript object.
+func EffectTimingFromJS(value js.Value) *EffectTiming {
 	var out EffectTiming
 	var (
 		value0 float64           // javascript: double {delay Delay delay}
@@ -723,21 +710,21 @@ func EffectTimingFromJS(value js.Wrapper) *EffectTiming {
 		value6 PlaybackDirection // javascript: PlaybackDirection {direction Direction direction}
 		value7 string            // javascript: DOMString {easing Easing easing}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
 	return &out
 }
@@ -757,7 +744,7 @@ type KeyframeAnimationOptions struct {
 	Id                 string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyframeAnimationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -787,10 +774,8 @@ func (_this *KeyframeAnimationOptions) JSValue() js.Value {
 }
 
 // KeyframeAnimationOptionsFromJS is allocating a new
-// KeyframeAnimationOptions object and copy all values from
-// input javascript object
-func KeyframeAnimationOptionsFromJS(value js.Wrapper) *KeyframeAnimationOptions {
-	input := value.JSValue()
+// KeyframeAnimationOptions object and copy all values in the value javascript object.
+func KeyframeAnimationOptionsFromJS(value js.Value) *KeyframeAnimationOptions {
 	var out KeyframeAnimationOptions
 	var (
 		value0  float64                     // javascript: double {delay Delay delay}
@@ -805,27 +790,27 @@ func KeyframeAnimationOptionsFromJS(value js.Wrapper) *KeyframeAnimationOptions 
 		value9  CompositeOperation          // javascript: CompositeOperation {composite Composite composite}
 		value10 string                      // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = IterationCompositeOperationFromJS(input.Get("iterationComposite"))
+	value8 = IterationCompositeOperationFromJS(value.Get("iterationComposite"))
 	out.IterationComposite = value8
-	value9 = CompositeOperationFromJS(input.Get("composite"))
+	value9 = CompositeOperationFromJS(value.Get("composite"))
 	out.Composite = value9
-	value10 = (input.Get("id")).String()
+	value10 = (value.Get("id")).String()
 	out.Id = value10
 	return &out
 }
@@ -844,7 +829,7 @@ type KeyframeEffectOptions struct {
 	Composite          CompositeOperation
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyframeEffectOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -872,10 +857,8 @@ func (_this *KeyframeEffectOptions) JSValue() js.Value {
 }
 
 // KeyframeEffectOptionsFromJS is allocating a new
-// KeyframeEffectOptions object and copy all values from
-// input javascript object
-func KeyframeEffectOptionsFromJS(value js.Wrapper) *KeyframeEffectOptions {
-	input := value.JSValue()
+// KeyframeEffectOptions object and copy all values in the value javascript object.
+func KeyframeEffectOptionsFromJS(value js.Value) *KeyframeEffectOptions {
 	var out KeyframeEffectOptions
 	var (
 		value0 float64                     // javascript: double {delay Delay delay}
@@ -889,25 +872,25 @@ func KeyframeEffectOptionsFromJS(value js.Wrapper) *KeyframeEffectOptions {
 		value8 IterationCompositeOperation // javascript: IterationCompositeOperation {iterationComposite IterationComposite iterationComposite}
 		value9 CompositeOperation          // javascript: CompositeOperation {composite Composite composite}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = IterationCompositeOperationFromJS(input.Get("iterationComposite"))
+	value8 = IterationCompositeOperationFromJS(value.Get("iterationComposite"))
 	out.IterationComposite = value8
-	value9 = CompositeOperationFromJS(input.Get("composite"))
+	value9 = CompositeOperationFromJS(value.Get("composite"))
 	out.Composite = value9
 	return &out
 }
@@ -924,7 +907,7 @@ type OptionalEffectTiming struct {
 	Easing         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OptionalEffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -948,10 +931,8 @@ func (_this *OptionalEffectTiming) JSValue() js.Value {
 }
 
 // OptionalEffectTimingFromJS is allocating a new
-// OptionalEffectTiming object and copy all values from
-// input javascript object
-func OptionalEffectTimingFromJS(value js.Wrapper) *OptionalEffectTiming {
-	input := value.JSValue()
+// OptionalEffectTiming object and copy all values in the value javascript object.
+func OptionalEffectTimingFromJS(value js.Value) *OptionalEffectTiming {
 	var out OptionalEffectTiming
 	var (
 		value0 float64           // javascript: double {delay Delay delay}
@@ -963,21 +944,21 @@ func OptionalEffectTimingFromJS(value js.Wrapper) *OptionalEffectTiming {
 		value6 PlaybackDirection // javascript: PlaybackDirection {direction Direction direction}
 		value7 string            // javascript: DOMString {easing Easing easing}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
 	return &out
 }
@@ -987,15 +968,19 @@ type Animation struct {
 	domcore.EventTarget
 }
 
-// AnimationFromJS is casting a js.Wrapper into Animation.
-func AnimationFromJS(value js.Wrapper) *Animation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationFromJS is casting a js.Value into Animation.
+func AnimationFromJS(value js.Value) *Animation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Animation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationFromJS is casting from something that holds a js.Value into Animation.
+func AnimationFromWrapper(input core.Wrapper) *Animation {
+	return AnimationFromJS(input.JSValue())
 }
 
 func NewAnimation(effect *AnimationEffect, timeline *AnimationTimeline) (_result *Animation) {
@@ -1310,15 +1295,19 @@ func (_this *AnimationEffect) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AnimationEffectFromJS is casting a js.Wrapper into AnimationEffect.
-func AnimationEffectFromJS(value js.Wrapper) *AnimationEffect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationEffectFromJS is casting a js.Value into AnimationEffect.
+func AnimationEffectFromJS(value js.Value) *AnimationEffect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationEffect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationEffectFromJS is casting from something that holds a js.Value into AnimationEffect.
+func AnimationEffectFromWrapper(input core.Wrapper) *AnimationEffect {
+	return AnimationEffectFromJS(input.JSValue())
 }
 
 func (_this *AnimationEffect) GetTiming() (_result *EffectTiming) {
@@ -1368,15 +1357,19 @@ type AnimationPlaybackEvent struct {
 	domcore.Event
 }
 
-// AnimationPlaybackEventFromJS is casting a js.Wrapper into AnimationPlaybackEvent.
-func AnimationPlaybackEventFromJS(value js.Wrapper) *AnimationPlaybackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationPlaybackEventFromJS is casting a js.Value into AnimationPlaybackEvent.
+func AnimationPlaybackEventFromJS(value js.Value) *AnimationPlaybackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationPlaybackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationPlaybackEventFromJS is casting from something that holds a js.Value into AnimationPlaybackEvent.
+func AnimationPlaybackEventFromWrapper(input core.Wrapper) *AnimationPlaybackEvent {
+	return AnimationPlaybackEventFromJS(input.JSValue())
 }
 
 func NewAnimationPlaybackEvent(_type string, eventInitDict *AnimationPlaybackEventInit) (_result *AnimationPlaybackEvent) {
@@ -1436,15 +1429,19 @@ func (_this *AnimationTimeline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AnimationTimelineFromJS is casting a js.Wrapper into AnimationTimeline.
-func AnimationTimelineFromJS(value js.Wrapper) *AnimationTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationTimelineFromJS is casting a js.Value into AnimationTimeline.
+func AnimationTimelineFromJS(value js.Value) *AnimationTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationTimelineFromJS is casting from something that holds a js.Value into AnimationTimeline.
+func AnimationTimelineFromWrapper(input core.Wrapper) *AnimationTimeline {
+	return AnimationTimelineFromJS(input.JSValue())
 }
 
 // CurrentTime returning attribute 'currentTime' with
@@ -1464,15 +1461,19 @@ type DocumentTimeline struct {
 	AnimationTimeline
 }
 
-// DocumentTimelineFromJS is casting a js.Wrapper into DocumentTimeline.
-func DocumentTimelineFromJS(value js.Wrapper) *DocumentTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentTimelineFromJS is casting a js.Value into DocumentTimeline.
+func DocumentTimelineFromJS(value js.Value) *DocumentTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentTimelineFromJS is casting from something that holds a js.Value into DocumentTimeline.
+func DocumentTimelineFromWrapper(input core.Wrapper) *DocumentTimeline {
+	return DocumentTimelineFromJS(input.JSValue())
 }
 
 func NewDocumentTimeline(options *DocumentTimelineOptions) (_result *DocumentTimeline) {
@@ -1500,15 +1501,19 @@ type KeyframeEffect struct {
 	AnimationEffect
 }
 
-// KeyframeEffectFromJS is casting a js.Wrapper into KeyframeEffect.
-func KeyframeEffectFromJS(value js.Wrapper) *KeyframeEffect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyframeEffectFromJS is casting a js.Value into KeyframeEffect.
+func KeyframeEffectFromJS(value js.Value) *KeyframeEffect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &KeyframeEffect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyframeEffectFromJS is casting from something that holds a js.Value into KeyframeEffect.
+func KeyframeEffectFromWrapper(input core.Wrapper) *KeyframeEffect {
+	return KeyframeEffectFromJS(input.JSValue())
 }
 
 func NewKeyframeEffect(source *KeyframeEffect) (_result *KeyframeEffect) {

--- a/css/animations/webani/webani_js.go
+++ b/css/animations/webani/webani_js.go
@@ -5,6 +5,7 @@ package webani
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -310,7 +311,7 @@ type AnimationPlaybackEventInit struct {
 	TimelineTime *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnimationPlaybackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -340,10 +341,8 @@ func (_this *AnimationPlaybackEventInit) JSValue() js.Value {
 }
 
 // AnimationPlaybackEventInitFromJS is allocating a new
-// AnimationPlaybackEventInit object and copy all values from
-// input javascript object
-func AnimationPlaybackEventInitFromJS(value js.Wrapper) *AnimationPlaybackEventInit {
-	input := value.JSValue()
+// AnimationPlaybackEventInit object and copy all values in the value javascript object.
+func AnimationPlaybackEventInitFromJS(value js.Value) *AnimationPlaybackEventInit {
 	var out AnimationPlaybackEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -352,19 +351,19 @@ func AnimationPlaybackEventInitFromJS(value js.Wrapper) *AnimationPlaybackEventI
 		value3 *float64 // javascript: double {currentTime CurrentTime currentTime}
 		value4 *float64 // javascript: double {timelineTime TimelineTime timelineTime}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("currentTime").Type() != js.TypeNull && input.Get("currentTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("currentTime")).Float()
+	if value.Get("currentTime").Type() != js.TypeNull && value.Get("currentTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("currentTime")).Float()
 		value3 = &__tmp
 	}
 	out.CurrentTime = value3
-	if input.Get("timelineTime").Type() != js.TypeNull && input.Get("timelineTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("timelineTime")).Float()
+	if value.Get("timelineTime").Type() != js.TypeNull && value.Get("timelineTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("timelineTime")).Float()
 		value4 = &__tmp
 	}
 	out.TimelineTime = value4
@@ -379,7 +378,7 @@ type BaseComputedKeyframe struct {
 	Composite      CompositeOperationOrAuto
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BaseComputedKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -401,10 +400,8 @@ func (_this *BaseComputedKeyframe) JSValue() js.Value {
 }
 
 // BaseComputedKeyframeFromJS is allocating a new
-// BaseComputedKeyframe object and copy all values from
-// input javascript object
-func BaseComputedKeyframeFromJS(value js.Wrapper) *BaseComputedKeyframe {
-	input := value.JSValue()
+// BaseComputedKeyframe object and copy all values in the value javascript object.
+func BaseComputedKeyframeFromJS(value js.Value) *BaseComputedKeyframe {
 	var out BaseComputedKeyframe
 	var (
 		value0 *float64                 // javascript: double {offset Offset offset}
@@ -412,16 +409,16 @@ func BaseComputedKeyframeFromJS(value js.Wrapper) *BaseComputedKeyframe {
 		value2 string                   // javascript: DOMString {easing Easing easing}
 		value3 CompositeOperationOrAuto // javascript: CompositeOperationOrAuto {composite Composite composite}
 	)
-	if input.Get("offset").Type() != js.TypeNull && input.Get("offset").Type() != js.TypeUndefined {
-		__tmp := (input.Get("offset")).Float()
+	if value.Get("offset").Type() != js.TypeNull && value.Get("offset").Type() != js.TypeUndefined {
+		__tmp := (value.Get("offset")).Float()
 		value0 = &__tmp
 	}
 	out.Offset = value0
-	value1 = (input.Get("computedOffset")).Float()
+	value1 = (value.Get("computedOffset")).Float()
 	out.ComputedOffset = value1
-	value2 = (input.Get("easing")).String()
+	value2 = (value.Get("easing")).String()
 	out.Easing = value2
-	value3 = CompositeOperationOrAutoFromJS(input.Get("composite"))
+	value3 = CompositeOperationOrAutoFromJS(value.Get("composite"))
 	out.Composite = value3
 	return &out
 }
@@ -433,7 +430,7 @@ type BaseKeyframe struct {
 	Composite CompositeOperationOrAuto
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BaseKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -453,24 +450,22 @@ func (_this *BaseKeyframe) JSValue() js.Value {
 }
 
 // BaseKeyframeFromJS is allocating a new
-// BaseKeyframe object and copy all values from
-// input javascript object
-func BaseKeyframeFromJS(value js.Wrapper) *BaseKeyframe {
-	input := value.JSValue()
+// BaseKeyframe object and copy all values in the value javascript object.
+func BaseKeyframeFromJS(value js.Value) *BaseKeyframe {
 	var out BaseKeyframe
 	var (
 		value0 *float64                 // javascript: double {offset Offset offset}
 		value1 string                   // javascript: DOMString {easing Easing easing}
 		value2 CompositeOperationOrAuto // javascript: CompositeOperationOrAuto {composite Composite composite}
 	)
-	if input.Get("offset").Type() != js.TypeNull && input.Get("offset").Type() != js.TypeUndefined {
-		__tmp := (input.Get("offset")).Float()
+	if value.Get("offset").Type() != js.TypeNull && value.Get("offset").Type() != js.TypeUndefined {
+		__tmp := (value.Get("offset")).Float()
 		value0 = &__tmp
 	}
 	out.Offset = value0
-	value1 = (input.Get("easing")).String()
+	value1 = (value.Get("easing")).String()
 	out.Easing = value1
-	value2 = CompositeOperationOrAutoFromJS(input.Get("composite"))
+	value2 = CompositeOperationOrAutoFromJS(value.Get("composite"))
 	out.Composite = value2
 	return &out
 }
@@ -482,7 +477,7 @@ type BasePropertyIndexedKeyframe struct {
 	Composite *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasePropertyIndexedKeyframe) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -496,21 +491,19 @@ func (_this *BasePropertyIndexedKeyframe) JSValue() js.Value {
 }
 
 // BasePropertyIndexedKeyframeFromJS is allocating a new
-// BasePropertyIndexedKeyframe object and copy all values from
-// input javascript object
-func BasePropertyIndexedKeyframeFromJS(value js.Wrapper) *BasePropertyIndexedKeyframe {
-	input := value.JSValue()
+// BasePropertyIndexedKeyframe object and copy all values in the value javascript object.
+func BasePropertyIndexedKeyframeFromJS(value js.Value) *BasePropertyIndexedKeyframe {
 	var out BasePropertyIndexedKeyframe
 	var (
 		value0 *Union // javascript: Union {offset Offset offset}
 		value1 *Union // javascript: Union {easing Easing easing}
 		value2 *Union // javascript: Union {composite Composite composite}
 	)
-	value0 = UnionFromJS(input.Get("offset"))
+	value0 = UnionFromJS(value.Get("offset"))
 	out.Offset = value0
-	value1 = UnionFromJS(input.Get("easing"))
+	value1 = UnionFromJS(value.Get("easing"))
 	out.Easing = value1
-	value2 = UnionFromJS(input.Get("composite"))
+	value2 = UnionFromJS(value.Get("composite"))
 	out.Composite = value2
 	return &out
 }
@@ -532,7 +525,7 @@ type ComputedEffectTiming struct {
 	CurrentIteration *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ComputedEffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -584,10 +577,8 @@ func (_this *ComputedEffectTiming) JSValue() js.Value {
 }
 
 // ComputedEffectTimingFromJS is allocating a new
-// ComputedEffectTiming object and copy all values from
-// input javascript object
-func ComputedEffectTimingFromJS(value js.Wrapper) *ComputedEffectTiming {
-	input := value.JSValue()
+// ComputedEffectTiming object and copy all values in the value javascript object.
+func ComputedEffectTimingFromJS(value js.Value) *ComputedEffectTiming {
 	var out ComputedEffectTiming
 	var (
 		value0  float64           // javascript: double {delay Delay delay}
@@ -604,38 +595,38 @@ func ComputedEffectTimingFromJS(value js.Wrapper) *ComputedEffectTiming {
 		value11 *float64          // javascript: double {progress Progress progress}
 		value12 *float64          // javascript: unrestricted double {currentIteration CurrentIteration currentIteration}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = (input.Get("endTime")).Float()
+	value8 = (value.Get("endTime")).Float()
 	out.EndTime = value8
-	value9 = (input.Get("activeDuration")).Float()
+	value9 = (value.Get("activeDuration")).Float()
 	out.ActiveDuration = value9
-	if input.Get("localTime").Type() != js.TypeNull && input.Get("localTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("localTime")).Float()
+	if value.Get("localTime").Type() != js.TypeNull && value.Get("localTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("localTime")).Float()
 		value10 = &__tmp
 	}
 	out.LocalTime = value10
-	if input.Get("progress").Type() != js.TypeNull && input.Get("progress").Type() != js.TypeUndefined {
-		__tmp := (input.Get("progress")).Float()
+	if value.Get("progress").Type() != js.TypeNull && value.Get("progress").Type() != js.TypeUndefined {
+		__tmp := (value.Get("progress")).Float()
 		value11 = &__tmp
 	}
 	out.Progress = value11
-	if input.Get("currentIteration").Type() != js.TypeNull && input.Get("currentIteration").Type() != js.TypeUndefined {
-		__tmp := (input.Get("currentIteration")).Float()
+	if value.Get("currentIteration").Type() != js.TypeNull && value.Get("currentIteration").Type() != js.TypeUndefined {
+		__tmp := (value.Get("currentIteration")).Float()
 		value12 = &__tmp
 	}
 	out.CurrentIteration = value12
@@ -647,7 +638,7 @@ type DocumentTimelineOptions struct {
 	OriginTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DocumentTimelineOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -657,15 +648,13 @@ func (_this *DocumentTimelineOptions) JSValue() js.Value {
 }
 
 // DocumentTimelineOptionsFromJS is allocating a new
-// DocumentTimelineOptions object and copy all values from
-// input javascript object
-func DocumentTimelineOptionsFromJS(value js.Wrapper) *DocumentTimelineOptions {
-	input := value.JSValue()
+// DocumentTimelineOptions object and copy all values in the value javascript object.
+func DocumentTimelineOptionsFromJS(value js.Value) *DocumentTimelineOptions {
 	var out DocumentTimelineOptions
 	var (
 		value0 float64 // javascript: double {originTime OriginTime originTime}
 	)
-	value0 = (input.Get("originTime")).Float()
+	value0 = (value.Get("originTime")).Float()
 	out.OriginTime = value0
 	return &out
 }
@@ -682,7 +671,7 @@ type EffectTiming struct {
 	Easing         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -706,10 +695,8 @@ func (_this *EffectTiming) JSValue() js.Value {
 }
 
 // EffectTimingFromJS is allocating a new
-// EffectTiming object and copy all values from
-// input javascript object
-func EffectTimingFromJS(value js.Wrapper) *EffectTiming {
-	input := value.JSValue()
+// EffectTiming object and copy all values in the value javascript object.
+func EffectTimingFromJS(value js.Value) *EffectTiming {
 	var out EffectTiming
 	var (
 		value0 float64           // javascript: double {delay Delay delay}
@@ -721,21 +708,21 @@ func EffectTimingFromJS(value js.Wrapper) *EffectTiming {
 		value6 PlaybackDirection // javascript: PlaybackDirection {direction Direction direction}
 		value7 string            // javascript: DOMString {easing Easing easing}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
 	return &out
 }
@@ -755,7 +742,7 @@ type KeyframeAnimationOptions struct {
 	Id                 string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyframeAnimationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -785,10 +772,8 @@ func (_this *KeyframeAnimationOptions) JSValue() js.Value {
 }
 
 // KeyframeAnimationOptionsFromJS is allocating a new
-// KeyframeAnimationOptions object and copy all values from
-// input javascript object
-func KeyframeAnimationOptionsFromJS(value js.Wrapper) *KeyframeAnimationOptions {
-	input := value.JSValue()
+// KeyframeAnimationOptions object and copy all values in the value javascript object.
+func KeyframeAnimationOptionsFromJS(value js.Value) *KeyframeAnimationOptions {
 	var out KeyframeAnimationOptions
 	var (
 		value0  float64                     // javascript: double {delay Delay delay}
@@ -803,27 +788,27 @@ func KeyframeAnimationOptionsFromJS(value js.Wrapper) *KeyframeAnimationOptions 
 		value9  CompositeOperation          // javascript: CompositeOperation {composite Composite composite}
 		value10 string                      // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = IterationCompositeOperationFromJS(input.Get("iterationComposite"))
+	value8 = IterationCompositeOperationFromJS(value.Get("iterationComposite"))
 	out.IterationComposite = value8
-	value9 = CompositeOperationFromJS(input.Get("composite"))
+	value9 = CompositeOperationFromJS(value.Get("composite"))
 	out.Composite = value9
-	value10 = (input.Get("id")).String()
+	value10 = (value.Get("id")).String()
 	out.Id = value10
 	return &out
 }
@@ -842,7 +827,7 @@ type KeyframeEffectOptions struct {
 	Composite          CompositeOperation
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyframeEffectOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -870,10 +855,8 @@ func (_this *KeyframeEffectOptions) JSValue() js.Value {
 }
 
 // KeyframeEffectOptionsFromJS is allocating a new
-// KeyframeEffectOptions object and copy all values from
-// input javascript object
-func KeyframeEffectOptionsFromJS(value js.Wrapper) *KeyframeEffectOptions {
-	input := value.JSValue()
+// KeyframeEffectOptions object and copy all values in the value javascript object.
+func KeyframeEffectOptionsFromJS(value js.Value) *KeyframeEffectOptions {
 	var out KeyframeEffectOptions
 	var (
 		value0 float64                     // javascript: double {delay Delay delay}
@@ -887,25 +870,25 @@ func KeyframeEffectOptionsFromJS(value js.Wrapper) *KeyframeEffectOptions {
 		value8 IterationCompositeOperation // javascript: IterationCompositeOperation {iterationComposite IterationComposite iterationComposite}
 		value9 CompositeOperation          // javascript: CompositeOperation {composite Composite composite}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
-	value8 = IterationCompositeOperationFromJS(input.Get("iterationComposite"))
+	value8 = IterationCompositeOperationFromJS(value.Get("iterationComposite"))
 	out.IterationComposite = value8
-	value9 = CompositeOperationFromJS(input.Get("composite"))
+	value9 = CompositeOperationFromJS(value.Get("composite"))
 	out.Composite = value9
 	return &out
 }
@@ -922,7 +905,7 @@ type OptionalEffectTiming struct {
 	Easing         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OptionalEffectTiming) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -946,10 +929,8 @@ func (_this *OptionalEffectTiming) JSValue() js.Value {
 }
 
 // OptionalEffectTimingFromJS is allocating a new
-// OptionalEffectTiming object and copy all values from
-// input javascript object
-func OptionalEffectTimingFromJS(value js.Wrapper) *OptionalEffectTiming {
-	input := value.JSValue()
+// OptionalEffectTiming object and copy all values in the value javascript object.
+func OptionalEffectTimingFromJS(value js.Value) *OptionalEffectTiming {
 	var out OptionalEffectTiming
 	var (
 		value0 float64           // javascript: double {delay Delay delay}
@@ -961,21 +942,21 @@ func OptionalEffectTimingFromJS(value js.Wrapper) *OptionalEffectTiming {
 		value6 PlaybackDirection // javascript: PlaybackDirection {direction Direction direction}
 		value7 string            // javascript: DOMString {easing Easing easing}
 	)
-	value0 = (input.Get("delay")).Float()
+	value0 = (value.Get("delay")).Float()
 	out.Delay = value0
-	value1 = (input.Get("endDelay")).Float()
+	value1 = (value.Get("endDelay")).Float()
 	out.EndDelay = value1
-	value2 = FillModeFromJS(input.Get("fill"))
+	value2 = FillModeFromJS(value.Get("fill"))
 	out.Fill = value2
-	value3 = (input.Get("iterationStart")).Float()
+	value3 = (value.Get("iterationStart")).Float()
 	out.IterationStart = value3
-	value4 = (input.Get("iterations")).Float()
+	value4 = (value.Get("iterations")).Float()
 	out.Iterations = value4
-	value5 = UnionFromJS(input.Get("duration"))
+	value5 = UnionFromJS(value.Get("duration"))
 	out.Duration = value5
-	value6 = PlaybackDirectionFromJS(input.Get("direction"))
+	value6 = PlaybackDirectionFromJS(value.Get("direction"))
 	out.Direction = value6
-	value7 = (input.Get("easing")).String()
+	value7 = (value.Get("easing")).String()
 	out.Easing = value7
 	return &out
 }
@@ -985,15 +966,19 @@ type Animation struct {
 	domcore.EventTarget
 }
 
-// AnimationFromJS is casting a js.Wrapper into Animation.
-func AnimationFromJS(value js.Wrapper) *Animation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationFromJS is casting a js.Value into Animation.
+func AnimationFromJS(value js.Value) *Animation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Animation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationFromJS is casting from something that holds a js.Value into Animation.
+func AnimationFromWrapper(input core.Wrapper) *Animation {
+	return AnimationFromJS(input.JSValue())
 }
 
 func NewAnimation(effect *AnimationEffect, timeline *AnimationTimeline) (_result *Animation) {
@@ -1308,15 +1293,19 @@ func (_this *AnimationEffect) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AnimationEffectFromJS is casting a js.Wrapper into AnimationEffect.
-func AnimationEffectFromJS(value js.Wrapper) *AnimationEffect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationEffectFromJS is casting a js.Value into AnimationEffect.
+func AnimationEffectFromJS(value js.Value) *AnimationEffect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationEffect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationEffectFromJS is casting from something that holds a js.Value into AnimationEffect.
+func AnimationEffectFromWrapper(input core.Wrapper) *AnimationEffect {
+	return AnimationEffectFromJS(input.JSValue())
 }
 
 func (_this *AnimationEffect) GetTiming() (_result *EffectTiming) {
@@ -1366,15 +1355,19 @@ type AnimationPlaybackEvent struct {
 	domcore.Event
 }
 
-// AnimationPlaybackEventFromJS is casting a js.Wrapper into AnimationPlaybackEvent.
-func AnimationPlaybackEventFromJS(value js.Wrapper) *AnimationPlaybackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationPlaybackEventFromJS is casting a js.Value into AnimationPlaybackEvent.
+func AnimationPlaybackEventFromJS(value js.Value) *AnimationPlaybackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationPlaybackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationPlaybackEventFromJS is casting from something that holds a js.Value into AnimationPlaybackEvent.
+func AnimationPlaybackEventFromWrapper(input core.Wrapper) *AnimationPlaybackEvent {
+	return AnimationPlaybackEventFromJS(input.JSValue())
 }
 
 func NewAnimationPlaybackEvent(_type string, eventInitDict *AnimationPlaybackEventInit) (_result *AnimationPlaybackEvent) {
@@ -1434,15 +1427,19 @@ func (_this *AnimationTimeline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AnimationTimelineFromJS is casting a js.Wrapper into AnimationTimeline.
-func AnimationTimelineFromJS(value js.Wrapper) *AnimationTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnimationTimelineFromJS is casting a js.Value into AnimationTimeline.
+func AnimationTimelineFromJS(value js.Value) *AnimationTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnimationTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnimationTimelineFromJS is casting from something that holds a js.Value into AnimationTimeline.
+func AnimationTimelineFromWrapper(input core.Wrapper) *AnimationTimeline {
+	return AnimationTimelineFromJS(input.JSValue())
 }
 
 // CurrentTime returning attribute 'currentTime' with
@@ -1462,15 +1459,19 @@ type DocumentTimeline struct {
 	AnimationTimeline
 }
 
-// DocumentTimelineFromJS is casting a js.Wrapper into DocumentTimeline.
-func DocumentTimelineFromJS(value js.Wrapper) *DocumentTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentTimelineFromJS is casting a js.Value into DocumentTimeline.
+func DocumentTimelineFromJS(value js.Value) *DocumentTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentTimelineFromJS is casting from something that holds a js.Value into DocumentTimeline.
+func DocumentTimelineFromWrapper(input core.Wrapper) *DocumentTimeline {
+	return DocumentTimelineFromJS(input.JSValue())
 }
 
 func NewDocumentTimeline(options *DocumentTimelineOptions) (_result *DocumentTimeline) {
@@ -1498,15 +1499,19 @@ type KeyframeEffect struct {
 	AnimationEffect
 }
 
-// KeyframeEffectFromJS is casting a js.Wrapper into KeyframeEffect.
-func KeyframeEffectFromJS(value js.Wrapper) *KeyframeEffect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyframeEffectFromJS is casting a js.Value into KeyframeEffect.
+func KeyframeEffectFromJS(value js.Value) *KeyframeEffect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &KeyframeEffect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyframeEffectFromJS is casting from something that holds a js.Value into KeyframeEffect.
+func KeyframeEffectFromWrapper(input core.Wrapper) *KeyframeEffect {
+	return KeyframeEffectFromJS(input.JSValue())
 }
 
 func NewKeyframeEffect(source *KeyframeEffect) (_result *KeyframeEffect) {

--- a/css/conditional/conditional.go
+++ b/css/conditional/conditional.go
@@ -7,6 +7,7 @@ package conditional
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -42,15 +43,19 @@ type CSSConditionRule struct {
 	cssom.CSSGroupingRule
 }
 
-// CSSConditionRuleFromJS is casting a js.Wrapper into CSSConditionRule.
-func CSSConditionRuleFromJS(value js.Wrapper) *CSSConditionRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSConditionRuleFromJS is casting a js.Value into CSSConditionRule.
+func CSSConditionRuleFromJS(value js.Value) *CSSConditionRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSConditionRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSConditionRuleFromJS is casting from something that holds a js.Value into CSSConditionRule.
+func CSSConditionRuleFromWrapper(input core.Wrapper) *CSSConditionRule {
+	return CSSConditionRuleFromJS(input.JSValue())
 }
 
 // ConditionText returning attribute 'conditionText' with
@@ -74,15 +79,19 @@ type CSSMediaRule struct {
 	CSSConditionRule
 }
 
-// CSSMediaRuleFromJS is casting a js.Wrapper into CSSMediaRule.
-func CSSMediaRuleFromJS(value js.Wrapper) *CSSMediaRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMediaRuleFromJS is casting a js.Value into CSSMediaRule.
+func CSSMediaRuleFromJS(value js.Value) *CSSMediaRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMediaRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMediaRuleFromJS is casting from something that holds a js.Value into CSSMediaRule.
+func CSSMediaRuleFromWrapper(input core.Wrapper) *CSSMediaRule {
+	return CSSMediaRuleFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -99,13 +108,17 @@ type CSSSupportsRule struct {
 	CSSConditionRule
 }
 
-// CSSSupportsRuleFromJS is casting a js.Wrapper into CSSSupportsRule.
-func CSSSupportsRuleFromJS(value js.Wrapper) *CSSSupportsRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSupportsRuleFromJS is casting a js.Value into CSSSupportsRule.
+func CSSSupportsRuleFromJS(value js.Value) *CSSSupportsRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSupportsRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSupportsRuleFromJS is casting from something that holds a js.Value into CSSSupportsRule.
+func CSSSupportsRuleFromWrapper(input core.Wrapper) *CSSSupportsRule {
+	return CSSSupportsRuleFromJS(input.JSValue())
 }

--- a/css/conditional/conditional_js.go
+++ b/css/conditional/conditional_js.go
@@ -5,6 +5,7 @@ package conditional
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -40,15 +41,19 @@ type CSSConditionRule struct {
 	cssom.CSSGroupingRule
 }
 
-// CSSConditionRuleFromJS is casting a js.Wrapper into CSSConditionRule.
-func CSSConditionRuleFromJS(value js.Wrapper) *CSSConditionRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSConditionRuleFromJS is casting a js.Value into CSSConditionRule.
+func CSSConditionRuleFromJS(value js.Value) *CSSConditionRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSConditionRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSConditionRuleFromJS is casting from something that holds a js.Value into CSSConditionRule.
+func CSSConditionRuleFromWrapper(input core.Wrapper) *CSSConditionRule {
+	return CSSConditionRuleFromJS(input.JSValue())
 }
 
 // ConditionText returning attribute 'conditionText' with
@@ -72,15 +77,19 @@ type CSSMediaRule struct {
 	CSSConditionRule
 }
 
-// CSSMediaRuleFromJS is casting a js.Wrapper into CSSMediaRule.
-func CSSMediaRuleFromJS(value js.Wrapper) *CSSMediaRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMediaRuleFromJS is casting a js.Value into CSSMediaRule.
+func CSSMediaRuleFromJS(value js.Value) *CSSMediaRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMediaRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMediaRuleFromJS is casting from something that holds a js.Value into CSSMediaRule.
+func CSSMediaRuleFromWrapper(input core.Wrapper) *CSSMediaRule {
+	return CSSMediaRuleFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -97,13 +106,17 @@ type CSSSupportsRule struct {
 	CSSConditionRule
 }
 
-// CSSSupportsRuleFromJS is casting a js.Wrapper into CSSSupportsRule.
-func CSSSupportsRuleFromJS(value js.Wrapper) *CSSSupportsRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSupportsRuleFromJS is casting a js.Value into CSSSupportsRule.
+func CSSSupportsRuleFromJS(value js.Value) *CSSSupportsRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSupportsRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSupportsRuleFromJS is casting from something that holds a js.Value into CSSSupportsRule.
+func CSSSupportsRuleFromWrapper(input core.Wrapper) *CSSSupportsRule {
+	return CSSSupportsRuleFromJS(input.JSValue())
 }

--- a/css/counterstyles/counterstyles.go
+++ b/css/counterstyles/counterstyles.go
@@ -7,6 +7,7 @@ package counterstyles
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -41,15 +42,19 @@ type CSSCounterStyleRule struct {
 	cssom.CSSRule
 }
 
-// CSSCounterStyleRuleFromJS is casting a js.Wrapper into CSSCounterStyleRule.
-func CSSCounterStyleRuleFromJS(value js.Wrapper) *CSSCounterStyleRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSCounterStyleRuleFromJS is casting a js.Value into CSSCounterStyleRule.
+func CSSCounterStyleRuleFromJS(value js.Value) *CSSCounterStyleRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSCounterStyleRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSCounterStyleRuleFromJS is casting from something that holds a js.Value into CSSCounterStyleRule.
+func CSSCounterStyleRuleFromWrapper(input core.Wrapper) *CSSCounterStyleRule {
+	return CSSCounterStyleRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with

--- a/css/counterstyles/counterstyles_js.go
+++ b/css/counterstyles/counterstyles_js.go
@@ -5,6 +5,7 @@ package counterstyles
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -39,15 +40,19 @@ type CSSCounterStyleRule struct {
 	cssom.CSSRule
 }
 
-// CSSCounterStyleRuleFromJS is casting a js.Wrapper into CSSCounterStyleRule.
-func CSSCounterStyleRuleFromJS(value js.Wrapper) *CSSCounterStyleRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSCounterStyleRuleFromJS is casting a js.Value into CSSCounterStyleRule.
+func CSSCounterStyleRuleFromJS(value js.Value) *CSSCounterStyleRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSCounterStyleRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSCounterStyleRuleFromJS is casting from something that holds a js.Value into CSSCounterStyleRule.
+func CSSCounterStyleRuleFromWrapper(input core.Wrapper) *CSSCounterStyleRule {
+	return CSSCounterStyleRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with

--- a/css/css.go
+++ b/css/css.go
@@ -39,7 +39,7 @@ type PropertyDescriptor struct {
 	InitialValue string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PropertyDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -55,10 +55,8 @@ func (_this *PropertyDescriptor) JSValue() js.Value {
 }
 
 // PropertyDescriptorFromJS is allocating a new
-// PropertyDescriptor object and copy all values from
-// input javascript object
-func PropertyDescriptorFromJS(value js.Wrapper) *PropertyDescriptor {
-	input := value.JSValue()
+// PropertyDescriptor object and copy all values in the value javascript object.
+func PropertyDescriptorFromJS(value js.Value) *PropertyDescriptor {
 	var out PropertyDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -66,13 +64,13 @@ func PropertyDescriptorFromJS(value js.Wrapper) *PropertyDescriptor {
 		value2 bool   // javascript: boolean {inherits Inherits inherits}
 		value3 string // javascript: DOMString {initialValue InitialValue initialValue}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("syntax")).String()
+	value1 = (value.Get("syntax")).String()
 	out.Syntax = value1
-	value2 = (input.Get("inherits")).Bool()
+	value2 = (value.Get("inherits")).Bool()
 	out.Inherits = value2
-	value3 = (input.Get("initialValue")).String()
+	value3 = (value.Get("initialValue")).String()
 	out.InitialValue = value3
 	return &out
 }

--- a/css/css_js.go
+++ b/css/css_js.go
@@ -37,7 +37,7 @@ type PropertyDescriptor struct {
 	InitialValue string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PropertyDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -53,10 +53,8 @@ func (_this *PropertyDescriptor) JSValue() js.Value {
 }
 
 // PropertyDescriptorFromJS is allocating a new
-// PropertyDescriptor object and copy all values from
-// input javascript object
-func PropertyDescriptorFromJS(value js.Wrapper) *PropertyDescriptor {
-	input := value.JSValue()
+// PropertyDescriptor object and copy all values in the value javascript object.
+func PropertyDescriptorFromJS(value js.Value) *PropertyDescriptor {
 	var out PropertyDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
@@ -64,13 +62,13 @@ func PropertyDescriptorFromJS(value js.Wrapper) *PropertyDescriptor {
 		value2 bool   // javascript: boolean {inherits Inherits inherits}
 		value3 string // javascript: DOMString {initialValue InitialValue initialValue}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("syntax")).String()
+	value1 = (value.Get("syntax")).String()
 	out.Syntax = value1
-	value2 = (input.Get("inherits")).Bool()
+	value2 = (value.Get("inherits")).Bool()
 	out.Inherits = value2
-	value3 = (input.Get("initialValue")).String()
+	value3 = (value.Get("initialValue")).String()
 	out.InitialValue = value3
 	return &out
 }

--- a/css/cssom/cssom.go
+++ b/css/cssom/cssom.go
@@ -7,6 +7,7 @@ package cssom
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/typedom"
 )
 
@@ -41,15 +42,19 @@ type CSSGroupingRule struct {
 	CSSRule
 }
 
-// CSSGroupingRuleFromJS is casting a js.Wrapper into CSSGroupingRule.
-func CSSGroupingRuleFromJS(value js.Wrapper) *CSSGroupingRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSGroupingRuleFromJS is casting a js.Value into CSSGroupingRule.
+func CSSGroupingRuleFromJS(value js.Value) *CSSGroupingRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSGroupingRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSGroupingRuleFromJS is casting from something that holds a js.Value into CSSGroupingRule.
+func CSSGroupingRuleFromWrapper(input core.Wrapper) *CSSGroupingRule {
+	return CSSGroupingRuleFromJS(input.JSValue())
 }
 
 // CssRules returning attribute 'cssRules' with
@@ -106,15 +111,19 @@ type CSSImportRule struct {
 	CSSRule
 }
 
-// CSSImportRuleFromJS is casting a js.Wrapper into CSSImportRule.
-func CSSImportRuleFromJS(value js.Wrapper) *CSSImportRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSImportRuleFromJS is casting a js.Value into CSSImportRule.
+func CSSImportRuleFromJS(value js.Value) *CSSImportRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSImportRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSImportRuleFromJS is casting from something that holds a js.Value into CSSImportRule.
+func CSSImportRuleFromWrapper(input core.Wrapper) *CSSImportRule {
+	return CSSImportRuleFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -149,15 +158,19 @@ type CSSMarginRule struct {
 	CSSRule
 }
 
-// CSSMarginRuleFromJS is casting a js.Wrapper into CSSMarginRule.
-func CSSMarginRuleFromJS(value js.Wrapper) *CSSMarginRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMarginRuleFromJS is casting a js.Value into CSSMarginRule.
+func CSSMarginRuleFromJS(value js.Value) *CSSMarginRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMarginRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMarginRuleFromJS is casting from something that holds a js.Value into CSSMarginRule.
+func CSSMarginRuleFromWrapper(input core.Wrapper) *CSSMarginRule {
+	return CSSMarginRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -183,15 +196,19 @@ type CSSNamespaceRule struct {
 	CSSRule
 }
 
-// CSSNamespaceRuleFromJS is casting a js.Wrapper into CSSNamespaceRule.
-func CSSNamespaceRuleFromJS(value js.Wrapper) *CSSNamespaceRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNamespaceRuleFromJS is casting a js.Value into CSSNamespaceRule.
+func CSSNamespaceRuleFromJS(value js.Value) *CSSNamespaceRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNamespaceRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNamespaceRuleFromJS is casting from something that holds a js.Value into CSSNamespaceRule.
+func CSSNamespaceRuleFromWrapper(input core.Wrapper) *CSSNamespaceRule {
+	return CSSNamespaceRuleFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -217,15 +234,19 @@ type CSSPageRule struct {
 	CSSGroupingRule
 }
 
-// CSSPageRuleFromJS is casting a js.Wrapper into CSSPageRule.
-func CSSPageRuleFromJS(value js.Wrapper) *CSSPageRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPageRuleFromJS is casting a js.Value into CSSPageRule.
+func CSSPageRuleFromJS(value js.Value) *CSSPageRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPageRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPageRuleFromJS is casting from something that holds a js.Value into CSSPageRule.
+func CSSPageRuleFromWrapper(input core.Wrapper) *CSSPageRule {
+	return CSSPageRuleFromJS(input.JSValue())
 }
 
 // SelectorText returning attribute 'selectorText' with
@@ -263,15 +284,19 @@ func (_this *CSSRule) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSRuleFromJS is casting a js.Wrapper into CSSRule.
-func CSSRuleFromJS(value js.Wrapper) *CSSRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRuleFromJS is casting a js.Value into CSSRule.
+func CSSRuleFromJS(value js.Value) *CSSRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRuleFromJS is casting from something that holds a js.Value into CSSRule.
+func CSSRuleFromWrapper(input core.Wrapper) *CSSRule {
+	return CSSRuleFromJS(input.JSValue())
 }
 
 const (
@@ -349,15 +374,19 @@ func (_this *CSSRuleList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSRuleListFromJS is casting a js.Wrapper into CSSRuleList.
-func CSSRuleListFromJS(value js.Wrapper) *CSSRuleList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRuleListFromJS is casting a js.Value into CSSRuleList.
+func CSSRuleListFromJS(value js.Value) *CSSRuleList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRuleList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRuleListFromJS is casting from something that holds a js.Value into CSSRuleList.
+func CSSRuleListFromWrapper(input core.Wrapper) *CSSRuleList {
+	return CSSRuleListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -417,15 +446,19 @@ func (_this *CSSStyleDeclaration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSStyleDeclarationFromJS is casting a js.Wrapper into CSSStyleDeclaration.
-func CSSStyleDeclarationFromJS(value js.Wrapper) *CSSStyleDeclaration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleDeclarationFromJS is casting a js.Value into CSSStyleDeclaration.
+func CSSStyleDeclarationFromJS(value js.Value) *CSSStyleDeclaration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleDeclaration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleDeclarationFromJS is casting from something that holds a js.Value into CSSStyleDeclaration.
+func CSSStyleDeclarationFromWrapper(input core.Wrapper) *CSSStyleDeclaration {
+	return CSSStyleDeclarationFromJS(input.JSValue())
 }
 
 // CssText returning attribute 'cssText' with
@@ -596,15 +629,19 @@ type CSSStyleRule struct {
 	CSSRule
 }
 
-// CSSStyleRuleFromJS is casting a js.Wrapper into CSSStyleRule.
-func CSSStyleRuleFromJS(value js.Wrapper) *CSSStyleRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleRuleFromJS is casting a js.Value into CSSStyleRule.
+func CSSStyleRuleFromJS(value js.Value) *CSSStyleRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleRuleFromJS is casting from something that holds a js.Value into CSSStyleRule.
+func CSSStyleRuleFromWrapper(input core.Wrapper) *CSSStyleRule {
+	return CSSStyleRuleFromJS(input.JSValue())
 }
 
 // SelectorText returning attribute 'selectorText' with
@@ -646,15 +683,19 @@ type CSSStyleSheet struct {
 	StyleSheet
 }
 
-// CSSStyleSheetFromJS is casting a js.Wrapper into CSSStyleSheet.
-func CSSStyleSheetFromJS(value js.Wrapper) *CSSStyleSheet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleSheetFromJS is casting a js.Value into CSSStyleSheet.
+func CSSStyleSheetFromJS(value js.Value) *CSSStyleSheet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleSheet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleSheetFromJS is casting from something that holds a js.Value into CSSStyleSheet.
+func CSSStyleSheetFromWrapper(input core.Wrapper) *CSSStyleSheet {
+	return CSSStyleSheetFromJS(input.JSValue())
 }
 
 // OwnerRule returning attribute 'ownerRule' with
@@ -727,15 +768,19 @@ func (_this *MediaList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaListFromJS is casting a js.Wrapper into MediaList.
-func MediaListFromJS(value js.Wrapper) *MediaList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaListFromJS is casting a js.Value into MediaList.
+func MediaListFromJS(value js.Value) *MediaList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaListFromJS is casting from something that holds a js.Value into MediaList.
+func MediaListFromWrapper(input core.Wrapper) *MediaList {
+	return MediaListFromJS(input.JSValue())
 }
 
 // MediaText returning attribute 'mediaText' with
@@ -842,15 +887,19 @@ func (_this *StyleSheet) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StyleSheetFromJS is casting a js.Wrapper into StyleSheet.
-func StyleSheetFromJS(value js.Wrapper) *StyleSheet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StyleSheetFromJS is casting a js.Value into StyleSheet.
+func StyleSheetFromJS(value js.Value) *StyleSheet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StyleSheet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StyleSheetFromJS is casting from something that holds a js.Value into StyleSheet.
+func StyleSheetFromWrapper(input core.Wrapper) *StyleSheet {
+	return StyleSheetFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -943,15 +992,19 @@ func (_this *StyleSheetList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StyleSheetListFromJS is casting a js.Wrapper into StyleSheetList.
-func StyleSheetListFromJS(value js.Wrapper) *StyleSheetList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StyleSheetListFromJS is casting a js.Value into StyleSheetList.
+func StyleSheetListFromJS(value js.Value) *StyleSheetList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StyleSheetList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StyleSheetListFromJS is casting from something that holds a js.Value into StyleSheetList.
+func StyleSheetListFromWrapper(input core.Wrapper) *StyleSheetList {
+	return StyleSheetListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/css/cssom/cssom_js.go
+++ b/css/cssom/cssom_js.go
@@ -5,6 +5,7 @@ package cssom
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/typedom"
 )
 
@@ -39,15 +40,19 @@ type CSSGroupingRule struct {
 	CSSRule
 }
 
-// CSSGroupingRuleFromJS is casting a js.Wrapper into CSSGroupingRule.
-func CSSGroupingRuleFromJS(value js.Wrapper) *CSSGroupingRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSGroupingRuleFromJS is casting a js.Value into CSSGroupingRule.
+func CSSGroupingRuleFromJS(value js.Value) *CSSGroupingRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSGroupingRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSGroupingRuleFromJS is casting from something that holds a js.Value into CSSGroupingRule.
+func CSSGroupingRuleFromWrapper(input core.Wrapper) *CSSGroupingRule {
+	return CSSGroupingRuleFromJS(input.JSValue())
 }
 
 // CssRules returning attribute 'cssRules' with
@@ -104,15 +109,19 @@ type CSSImportRule struct {
 	CSSRule
 }
 
-// CSSImportRuleFromJS is casting a js.Wrapper into CSSImportRule.
-func CSSImportRuleFromJS(value js.Wrapper) *CSSImportRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSImportRuleFromJS is casting a js.Value into CSSImportRule.
+func CSSImportRuleFromJS(value js.Value) *CSSImportRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSImportRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSImportRuleFromJS is casting from something that holds a js.Value into CSSImportRule.
+func CSSImportRuleFromWrapper(input core.Wrapper) *CSSImportRule {
+	return CSSImportRuleFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -147,15 +156,19 @@ type CSSMarginRule struct {
 	CSSRule
 }
 
-// CSSMarginRuleFromJS is casting a js.Wrapper into CSSMarginRule.
-func CSSMarginRuleFromJS(value js.Wrapper) *CSSMarginRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMarginRuleFromJS is casting a js.Value into CSSMarginRule.
+func CSSMarginRuleFromJS(value js.Value) *CSSMarginRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMarginRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMarginRuleFromJS is casting from something that holds a js.Value into CSSMarginRule.
+func CSSMarginRuleFromWrapper(input core.Wrapper) *CSSMarginRule {
+	return CSSMarginRuleFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -181,15 +194,19 @@ type CSSNamespaceRule struct {
 	CSSRule
 }
 
-// CSSNamespaceRuleFromJS is casting a js.Wrapper into CSSNamespaceRule.
-func CSSNamespaceRuleFromJS(value js.Wrapper) *CSSNamespaceRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNamespaceRuleFromJS is casting a js.Value into CSSNamespaceRule.
+func CSSNamespaceRuleFromJS(value js.Value) *CSSNamespaceRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNamespaceRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNamespaceRuleFromJS is casting from something that holds a js.Value into CSSNamespaceRule.
+func CSSNamespaceRuleFromWrapper(input core.Wrapper) *CSSNamespaceRule {
+	return CSSNamespaceRuleFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -215,15 +232,19 @@ type CSSPageRule struct {
 	CSSGroupingRule
 }
 
-// CSSPageRuleFromJS is casting a js.Wrapper into CSSPageRule.
-func CSSPageRuleFromJS(value js.Wrapper) *CSSPageRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPageRuleFromJS is casting a js.Value into CSSPageRule.
+func CSSPageRuleFromJS(value js.Value) *CSSPageRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPageRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPageRuleFromJS is casting from something that holds a js.Value into CSSPageRule.
+func CSSPageRuleFromWrapper(input core.Wrapper) *CSSPageRule {
+	return CSSPageRuleFromJS(input.JSValue())
 }
 
 // SelectorText returning attribute 'selectorText' with
@@ -261,15 +282,19 @@ func (_this *CSSRule) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSRuleFromJS is casting a js.Wrapper into CSSRule.
-func CSSRuleFromJS(value js.Wrapper) *CSSRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRuleFromJS is casting a js.Value into CSSRule.
+func CSSRuleFromJS(value js.Value) *CSSRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRuleFromJS is casting from something that holds a js.Value into CSSRule.
+func CSSRuleFromWrapper(input core.Wrapper) *CSSRule {
+	return CSSRuleFromJS(input.JSValue())
 }
 
 const (
@@ -347,15 +372,19 @@ func (_this *CSSRuleList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSRuleListFromJS is casting a js.Wrapper into CSSRuleList.
-func CSSRuleListFromJS(value js.Wrapper) *CSSRuleList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRuleListFromJS is casting a js.Value into CSSRuleList.
+func CSSRuleListFromJS(value js.Value) *CSSRuleList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRuleList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRuleListFromJS is casting from something that holds a js.Value into CSSRuleList.
+func CSSRuleListFromWrapper(input core.Wrapper) *CSSRuleList {
+	return CSSRuleListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -415,15 +444,19 @@ func (_this *CSSStyleDeclaration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSStyleDeclarationFromJS is casting a js.Wrapper into CSSStyleDeclaration.
-func CSSStyleDeclarationFromJS(value js.Wrapper) *CSSStyleDeclaration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleDeclarationFromJS is casting a js.Value into CSSStyleDeclaration.
+func CSSStyleDeclarationFromJS(value js.Value) *CSSStyleDeclaration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleDeclaration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleDeclarationFromJS is casting from something that holds a js.Value into CSSStyleDeclaration.
+func CSSStyleDeclarationFromWrapper(input core.Wrapper) *CSSStyleDeclaration {
+	return CSSStyleDeclarationFromJS(input.JSValue())
 }
 
 // CssText returning attribute 'cssText' with
@@ -594,15 +627,19 @@ type CSSStyleRule struct {
 	CSSRule
 }
 
-// CSSStyleRuleFromJS is casting a js.Wrapper into CSSStyleRule.
-func CSSStyleRuleFromJS(value js.Wrapper) *CSSStyleRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleRuleFromJS is casting a js.Value into CSSStyleRule.
+func CSSStyleRuleFromJS(value js.Value) *CSSStyleRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleRuleFromJS is casting from something that holds a js.Value into CSSStyleRule.
+func CSSStyleRuleFromWrapper(input core.Wrapper) *CSSStyleRule {
+	return CSSStyleRuleFromJS(input.JSValue())
 }
 
 // SelectorText returning attribute 'selectorText' with
@@ -644,15 +681,19 @@ type CSSStyleSheet struct {
 	StyleSheet
 }
 
-// CSSStyleSheetFromJS is casting a js.Wrapper into CSSStyleSheet.
-func CSSStyleSheetFromJS(value js.Wrapper) *CSSStyleSheet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleSheetFromJS is casting a js.Value into CSSStyleSheet.
+func CSSStyleSheetFromJS(value js.Value) *CSSStyleSheet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleSheet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleSheetFromJS is casting from something that holds a js.Value into CSSStyleSheet.
+func CSSStyleSheetFromWrapper(input core.Wrapper) *CSSStyleSheet {
+	return CSSStyleSheetFromJS(input.JSValue())
 }
 
 // OwnerRule returning attribute 'ownerRule' with
@@ -725,15 +766,19 @@ func (_this *MediaList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaListFromJS is casting a js.Wrapper into MediaList.
-func MediaListFromJS(value js.Wrapper) *MediaList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaListFromJS is casting a js.Value into MediaList.
+func MediaListFromJS(value js.Value) *MediaList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaListFromJS is casting from something that holds a js.Value into MediaList.
+func MediaListFromWrapper(input core.Wrapper) *MediaList {
+	return MediaListFromJS(input.JSValue())
 }
 
 // MediaText returning attribute 'mediaText' with
@@ -840,15 +885,19 @@ func (_this *StyleSheet) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StyleSheetFromJS is casting a js.Wrapper into StyleSheet.
-func StyleSheetFromJS(value js.Wrapper) *StyleSheet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StyleSheetFromJS is casting a js.Value into StyleSheet.
+func StyleSheetFromJS(value js.Value) *StyleSheet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StyleSheet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StyleSheetFromJS is casting from something that holds a js.Value into StyleSheet.
+func StyleSheetFromWrapper(input core.Wrapper) *StyleSheet {
+	return StyleSheetFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -941,15 +990,19 @@ func (_this *StyleSheetList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StyleSheetListFromJS is casting a js.Wrapper into StyleSheetList.
-func StyleSheetListFromJS(value js.Wrapper) *StyleSheetList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StyleSheetListFromJS is casting a js.Value into StyleSheetList.
+func StyleSheetListFromJS(value js.Value) *StyleSheetList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StyleSheetList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StyleSheetListFromJS is casting from something that holds a js.Value into StyleSheetList.
+func StyleSheetListFromWrapper(input core.Wrapper) *StyleSheetList {
+	return StyleSheetListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/css/cssom/view/view.go
+++ b/css/cssom/view/view.go
@@ -7,6 +7,7 @@ package view
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/media/capabilities"
@@ -182,7 +183,7 @@ type BoxQuadOptions struct {
 	RelativeTo *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BoxQuadOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -194,18 +195,16 @@ func (_this *BoxQuadOptions) JSValue() js.Value {
 }
 
 // BoxQuadOptionsFromJS is allocating a new
-// BoxQuadOptions object and copy all values from
-// input javascript object
-func BoxQuadOptionsFromJS(value js.Wrapper) *BoxQuadOptions {
-	input := value.JSValue()
+// BoxQuadOptions object and copy all values in the value javascript object.
+func BoxQuadOptionsFromJS(value js.Value) *BoxQuadOptions {
 	var out BoxQuadOptions
 	var (
 		value0 CSSBoxType // javascript: CSSBoxType {box Box box}
 		value1 *Union     // javascript: Union {relativeTo RelativeTo relativeTo}
 	)
-	value0 = CSSBoxTypeFromJS(input.Get("box"))
+	value0 = CSSBoxTypeFromJS(value.Get("box"))
 	out.Box = value0
-	value1 = UnionFromJS(input.Get("relativeTo"))
+	value1 = UnionFromJS(value.Get("relativeTo"))
 	out.RelativeTo = value1
 	return &out
 }
@@ -216,7 +215,7 @@ type ConvertCoordinateOptions struct {
 	ToBox   CSSBoxType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConvertCoordinateOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -228,18 +227,16 @@ func (_this *ConvertCoordinateOptions) JSValue() js.Value {
 }
 
 // ConvertCoordinateOptionsFromJS is allocating a new
-// ConvertCoordinateOptions object and copy all values from
-// input javascript object
-func ConvertCoordinateOptionsFromJS(value js.Wrapper) *ConvertCoordinateOptions {
-	input := value.JSValue()
+// ConvertCoordinateOptions object and copy all values in the value javascript object.
+func ConvertCoordinateOptionsFromJS(value js.Value) *ConvertCoordinateOptions {
 	var out ConvertCoordinateOptions
 	var (
 		value0 CSSBoxType // javascript: CSSBoxType {fromBox FromBox fromBox}
 		value1 CSSBoxType // javascript: CSSBoxType {toBox ToBox toBox}
 	)
-	value0 = CSSBoxTypeFromJS(input.Get("fromBox"))
+	value0 = CSSBoxTypeFromJS(value.Get("fromBox"))
 	out.FromBox = value0
-	value1 = CSSBoxTypeFromJS(input.Get("toBox"))
+	value1 = CSSBoxTypeFromJS(value.Get("toBox"))
 	out.ToBox = value1
 	return &out
 }
@@ -253,7 +250,7 @@ type MediaQueryListEventInit struct {
 	Matches    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaQueryListEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -271,10 +268,8 @@ func (_this *MediaQueryListEventInit) JSValue() js.Value {
 }
 
 // MediaQueryListEventInitFromJS is allocating a new
-// MediaQueryListEventInit object and copy all values from
-// input javascript object
-func MediaQueryListEventInitFromJS(value js.Wrapper) *MediaQueryListEventInit {
-	input := value.JSValue()
+// MediaQueryListEventInit object and copy all values in the value javascript object.
+func MediaQueryListEventInitFromJS(value js.Value) *MediaQueryListEventInit {
 	var out MediaQueryListEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -283,15 +278,15 @@ func MediaQueryListEventInitFromJS(value js.Wrapper) *MediaQueryListEventInit {
 		value3 string // javascript: DOMString {media Media media}
 		value4 bool   // javascript: boolean {matches Matches matches}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("media")).String()
+	value3 = (value.Get("media")).String()
 	out.Media = value3
-	value4 = (input.Get("matches")).Bool()
+	value4 = (value.Get("matches")).Bool()
 	out.Matches = value4
 	return &out
 }
@@ -303,7 +298,7 @@ type ScrollIntoViewOptions struct {
 	Inline   ScrollLogicalPosition
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollIntoViewOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -317,21 +312,19 @@ func (_this *ScrollIntoViewOptions) JSValue() js.Value {
 }
 
 // ScrollIntoViewOptionsFromJS is allocating a new
-// ScrollIntoViewOptions object and copy all values from
-// input javascript object
-func ScrollIntoViewOptionsFromJS(value js.Wrapper) *ScrollIntoViewOptions {
-	input := value.JSValue()
+// ScrollIntoViewOptions object and copy all values in the value javascript object.
+func ScrollIntoViewOptionsFromJS(value js.Value) *ScrollIntoViewOptions {
 	var out ScrollIntoViewOptions
 	var (
 		value0 ScrollBehavior        // javascript: ScrollBehavior {behavior Behavior behavior}
 		value1 ScrollLogicalPosition // javascript: ScrollLogicalPosition {block Block block}
 		value2 ScrollLogicalPosition // javascript: ScrollLogicalPosition {inline Inline inline}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
-	value1 = ScrollLogicalPositionFromJS(input.Get("block"))
+	value1 = ScrollLogicalPositionFromJS(value.Get("block"))
 	out.Block = value1
-	value2 = ScrollLogicalPositionFromJS(input.Get("inline"))
+	value2 = ScrollLogicalPositionFromJS(value.Get("inline"))
 	out.Inline = value2
 	return &out
 }
@@ -341,7 +334,7 @@ type ScrollOptions struct {
 	Behavior ScrollBehavior
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -351,15 +344,13 @@ func (_this *ScrollOptions) JSValue() js.Value {
 }
 
 // ScrollOptionsFromJS is allocating a new
-// ScrollOptions object and copy all values from
-// input javascript object
-func ScrollOptionsFromJS(value js.Wrapper) *ScrollOptions {
-	input := value.JSValue()
+// ScrollOptions object and copy all values in the value javascript object.
+func ScrollOptionsFromJS(value js.Value) *ScrollOptions {
 	var out ScrollOptions
 	var (
 		value0 ScrollBehavior // javascript: ScrollBehavior {behavior Behavior behavior}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
 	return &out
 }
@@ -371,7 +362,7 @@ type ScrollToOptions struct {
 	Top      float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollToOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -385,21 +376,19 @@ func (_this *ScrollToOptions) JSValue() js.Value {
 }
 
 // ScrollToOptionsFromJS is allocating a new
-// ScrollToOptions object and copy all values from
-// input javascript object
-func ScrollToOptionsFromJS(value js.Wrapper) *ScrollToOptions {
-	input := value.JSValue()
+// ScrollToOptions object and copy all values in the value javascript object.
+func ScrollToOptionsFromJS(value js.Value) *ScrollToOptions {
 	var out ScrollToOptions
 	var (
 		value0 ScrollBehavior // javascript: ScrollBehavior {behavior Behavior behavior}
 		value1 float64        // javascript: unrestricted double {left Left left}
 		value2 float64        // javascript: unrestricted double {top Top top}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
-	value1 = (input.Get("left")).Float()
+	value1 = (value.Get("left")).Float()
 	out.Left = value1
-	value2 = (input.Get("top")).Float()
+	value2 = (value.Get("top")).Float()
 	out.Top = value2
 	return &out
 }
@@ -414,15 +403,19 @@ func (_this *CaretPosition) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CaretPositionFromJS is casting a js.Wrapper into CaretPosition.
-func CaretPositionFromJS(value js.Wrapper) *CaretPosition {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CaretPositionFromJS is casting a js.Value into CaretPosition.
+func CaretPositionFromJS(value js.Value) *CaretPosition {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CaretPosition{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CaretPositionFromJS is casting from something that holds a js.Value into CaretPosition.
+func CaretPositionFromWrapper(input core.Wrapper) *CaretPosition {
+	return CaretPositionFromJS(input.JSValue())
 }
 
 // OffsetNode returning attribute 'offsetNode' with
@@ -464,15 +457,19 @@ type MediaQueryList struct {
 	domcore.EventTarget
 }
 
-// MediaQueryListFromJS is casting a js.Wrapper into MediaQueryList.
-func MediaQueryListFromJS(value js.Wrapper) *MediaQueryList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaQueryListFromJS is casting a js.Value into MediaQueryList.
+func MediaQueryListFromJS(value js.Value) *MediaQueryList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaQueryList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaQueryListFromJS is casting from something that holds a js.Value into MediaQueryList.
+func MediaQueryListFromWrapper(input core.Wrapper) *MediaQueryList {
+	return MediaQueryListFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -563,15 +560,19 @@ type MediaQueryListEvent struct {
 	domcore.Event
 }
 
-// MediaQueryListEventFromJS is casting a js.Wrapper into MediaQueryListEvent.
-func MediaQueryListEventFromJS(value js.Wrapper) *MediaQueryListEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaQueryListEventFromJS is casting a js.Value into MediaQueryListEvent.
+func MediaQueryListEventFromJS(value js.Value) *MediaQueryListEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaQueryListEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaQueryListEventFromJS is casting from something that holds a js.Value into MediaQueryListEvent.
+func MediaQueryListEventFromWrapper(input core.Wrapper) *MediaQueryListEvent {
+	return MediaQueryListEventFromJS(input.JSValue())
 }
 
 func NewMediaQueryListEvent(_type string, eventInitDict *MediaQueryListEventInit) (_result *MediaQueryListEvent) {
@@ -625,15 +626,19 @@ func (_this *Screen) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ScreenFromJS is casting a js.Wrapper into Screen.
-func ScreenFromJS(value js.Wrapper) *Screen {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenFromJS is casting a js.Value into Screen.
+func ScreenFromJS(value js.Value) *Screen {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Screen{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenFromJS is casting from something that holds a js.Value into Screen.
+func ScreenFromWrapper(input core.Wrapper) *Screen {
+	return ScreenFromJS(input.JSValue())
 }
 
 // AvailWidth returning attribute 'availWidth' with

--- a/css/cssom/view/view_js.go
+++ b/css/cssom/view/view_js.go
@@ -5,6 +5,7 @@ package view
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/media/capabilities"
@@ -180,7 +181,7 @@ type BoxQuadOptions struct {
 	RelativeTo *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BoxQuadOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -192,18 +193,16 @@ func (_this *BoxQuadOptions) JSValue() js.Value {
 }
 
 // BoxQuadOptionsFromJS is allocating a new
-// BoxQuadOptions object and copy all values from
-// input javascript object
-func BoxQuadOptionsFromJS(value js.Wrapper) *BoxQuadOptions {
-	input := value.JSValue()
+// BoxQuadOptions object and copy all values in the value javascript object.
+func BoxQuadOptionsFromJS(value js.Value) *BoxQuadOptions {
 	var out BoxQuadOptions
 	var (
 		value0 CSSBoxType // javascript: CSSBoxType {box Box box}
 		value1 *Union     // javascript: Union {relativeTo RelativeTo relativeTo}
 	)
-	value0 = CSSBoxTypeFromJS(input.Get("box"))
+	value0 = CSSBoxTypeFromJS(value.Get("box"))
 	out.Box = value0
-	value1 = UnionFromJS(input.Get("relativeTo"))
+	value1 = UnionFromJS(value.Get("relativeTo"))
 	out.RelativeTo = value1
 	return &out
 }
@@ -214,7 +213,7 @@ type ConvertCoordinateOptions struct {
 	ToBox   CSSBoxType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConvertCoordinateOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -226,18 +225,16 @@ func (_this *ConvertCoordinateOptions) JSValue() js.Value {
 }
 
 // ConvertCoordinateOptionsFromJS is allocating a new
-// ConvertCoordinateOptions object and copy all values from
-// input javascript object
-func ConvertCoordinateOptionsFromJS(value js.Wrapper) *ConvertCoordinateOptions {
-	input := value.JSValue()
+// ConvertCoordinateOptions object and copy all values in the value javascript object.
+func ConvertCoordinateOptionsFromJS(value js.Value) *ConvertCoordinateOptions {
 	var out ConvertCoordinateOptions
 	var (
 		value0 CSSBoxType // javascript: CSSBoxType {fromBox FromBox fromBox}
 		value1 CSSBoxType // javascript: CSSBoxType {toBox ToBox toBox}
 	)
-	value0 = CSSBoxTypeFromJS(input.Get("fromBox"))
+	value0 = CSSBoxTypeFromJS(value.Get("fromBox"))
 	out.FromBox = value0
-	value1 = CSSBoxTypeFromJS(input.Get("toBox"))
+	value1 = CSSBoxTypeFromJS(value.Get("toBox"))
 	out.ToBox = value1
 	return &out
 }
@@ -251,7 +248,7 @@ type MediaQueryListEventInit struct {
 	Matches    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaQueryListEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -269,10 +266,8 @@ func (_this *MediaQueryListEventInit) JSValue() js.Value {
 }
 
 // MediaQueryListEventInitFromJS is allocating a new
-// MediaQueryListEventInit object and copy all values from
-// input javascript object
-func MediaQueryListEventInitFromJS(value js.Wrapper) *MediaQueryListEventInit {
-	input := value.JSValue()
+// MediaQueryListEventInit object and copy all values in the value javascript object.
+func MediaQueryListEventInitFromJS(value js.Value) *MediaQueryListEventInit {
 	var out MediaQueryListEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -281,15 +276,15 @@ func MediaQueryListEventInitFromJS(value js.Wrapper) *MediaQueryListEventInit {
 		value3 string // javascript: DOMString {media Media media}
 		value4 bool   // javascript: boolean {matches Matches matches}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("media")).String()
+	value3 = (value.Get("media")).String()
 	out.Media = value3
-	value4 = (input.Get("matches")).Bool()
+	value4 = (value.Get("matches")).Bool()
 	out.Matches = value4
 	return &out
 }
@@ -301,7 +296,7 @@ type ScrollIntoViewOptions struct {
 	Inline   ScrollLogicalPosition
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollIntoViewOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -315,21 +310,19 @@ func (_this *ScrollIntoViewOptions) JSValue() js.Value {
 }
 
 // ScrollIntoViewOptionsFromJS is allocating a new
-// ScrollIntoViewOptions object and copy all values from
-// input javascript object
-func ScrollIntoViewOptionsFromJS(value js.Wrapper) *ScrollIntoViewOptions {
-	input := value.JSValue()
+// ScrollIntoViewOptions object and copy all values in the value javascript object.
+func ScrollIntoViewOptionsFromJS(value js.Value) *ScrollIntoViewOptions {
 	var out ScrollIntoViewOptions
 	var (
 		value0 ScrollBehavior        // javascript: ScrollBehavior {behavior Behavior behavior}
 		value1 ScrollLogicalPosition // javascript: ScrollLogicalPosition {block Block block}
 		value2 ScrollLogicalPosition // javascript: ScrollLogicalPosition {inline Inline inline}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
-	value1 = ScrollLogicalPositionFromJS(input.Get("block"))
+	value1 = ScrollLogicalPositionFromJS(value.Get("block"))
 	out.Block = value1
-	value2 = ScrollLogicalPositionFromJS(input.Get("inline"))
+	value2 = ScrollLogicalPositionFromJS(value.Get("inline"))
 	out.Inline = value2
 	return &out
 }
@@ -339,7 +332,7 @@ type ScrollOptions struct {
 	Behavior ScrollBehavior
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -349,15 +342,13 @@ func (_this *ScrollOptions) JSValue() js.Value {
 }
 
 // ScrollOptionsFromJS is allocating a new
-// ScrollOptions object and copy all values from
-// input javascript object
-func ScrollOptionsFromJS(value js.Wrapper) *ScrollOptions {
-	input := value.JSValue()
+// ScrollOptions object and copy all values in the value javascript object.
+func ScrollOptionsFromJS(value js.Value) *ScrollOptions {
 	var out ScrollOptions
 	var (
 		value0 ScrollBehavior // javascript: ScrollBehavior {behavior Behavior behavior}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
 	return &out
 }
@@ -369,7 +360,7 @@ type ScrollToOptions struct {
 	Top      float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollToOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -383,21 +374,19 @@ func (_this *ScrollToOptions) JSValue() js.Value {
 }
 
 // ScrollToOptionsFromJS is allocating a new
-// ScrollToOptions object and copy all values from
-// input javascript object
-func ScrollToOptionsFromJS(value js.Wrapper) *ScrollToOptions {
-	input := value.JSValue()
+// ScrollToOptions object and copy all values in the value javascript object.
+func ScrollToOptionsFromJS(value js.Value) *ScrollToOptions {
 	var out ScrollToOptions
 	var (
 		value0 ScrollBehavior // javascript: ScrollBehavior {behavior Behavior behavior}
 		value1 float64        // javascript: unrestricted double {left Left left}
 		value2 float64        // javascript: unrestricted double {top Top top}
 	)
-	value0 = ScrollBehaviorFromJS(input.Get("behavior"))
+	value0 = ScrollBehaviorFromJS(value.Get("behavior"))
 	out.Behavior = value0
-	value1 = (input.Get("left")).Float()
+	value1 = (value.Get("left")).Float()
 	out.Left = value1
-	value2 = (input.Get("top")).Float()
+	value2 = (value.Get("top")).Float()
 	out.Top = value2
 	return &out
 }
@@ -412,15 +401,19 @@ func (_this *CaretPosition) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CaretPositionFromJS is casting a js.Wrapper into CaretPosition.
-func CaretPositionFromJS(value js.Wrapper) *CaretPosition {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CaretPositionFromJS is casting a js.Value into CaretPosition.
+func CaretPositionFromJS(value js.Value) *CaretPosition {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CaretPosition{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CaretPositionFromJS is casting from something that holds a js.Value into CaretPosition.
+func CaretPositionFromWrapper(input core.Wrapper) *CaretPosition {
+	return CaretPositionFromJS(input.JSValue())
 }
 
 // OffsetNode returning attribute 'offsetNode' with
@@ -462,15 +455,19 @@ type MediaQueryList struct {
 	domcore.EventTarget
 }
 
-// MediaQueryListFromJS is casting a js.Wrapper into MediaQueryList.
-func MediaQueryListFromJS(value js.Wrapper) *MediaQueryList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaQueryListFromJS is casting a js.Value into MediaQueryList.
+func MediaQueryListFromJS(value js.Value) *MediaQueryList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaQueryList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaQueryListFromJS is casting from something that holds a js.Value into MediaQueryList.
+func MediaQueryListFromWrapper(input core.Wrapper) *MediaQueryList {
+	return MediaQueryListFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -561,15 +558,19 @@ type MediaQueryListEvent struct {
 	domcore.Event
 }
 
-// MediaQueryListEventFromJS is casting a js.Wrapper into MediaQueryListEvent.
-func MediaQueryListEventFromJS(value js.Wrapper) *MediaQueryListEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaQueryListEventFromJS is casting a js.Value into MediaQueryListEvent.
+func MediaQueryListEventFromJS(value js.Value) *MediaQueryListEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaQueryListEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaQueryListEventFromJS is casting from something that holds a js.Value into MediaQueryListEvent.
+func MediaQueryListEventFromWrapper(input core.Wrapper) *MediaQueryListEvent {
+	return MediaQueryListEventFromJS(input.JSValue())
 }
 
 func NewMediaQueryListEvent(_type string, eventInitDict *MediaQueryListEventInit) (_result *MediaQueryListEvent) {
@@ -623,15 +624,19 @@ func (_this *Screen) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ScreenFromJS is casting a js.Wrapper into Screen.
-func ScreenFromJS(value js.Wrapper) *Screen {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenFromJS is casting a js.Value into Screen.
+func ScreenFromJS(value js.Value) *Screen {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Screen{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenFromJS is casting from something that holds a js.Value into Screen.
+func ScreenFromWrapper(input core.Wrapper) *Screen {
+	return ScreenFromJS(input.JSValue())
 }
 
 // AvailWidth returning attribute 'availWidth' with

--- a/css/deviceadapt/deviceadapt.go
+++ b/css/deviceadapt/deviceadapt.go
@@ -7,6 +7,7 @@ package deviceadapt
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -42,15 +43,19 @@ type CSSViewportRule struct {
 	cssom.CSSRule
 }
 
-// CSSViewportRuleFromJS is casting a js.Wrapper into CSSViewportRule.
-func CSSViewportRuleFromJS(value js.Wrapper) *CSSViewportRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSViewportRuleFromJS is casting a js.Value into CSSViewportRule.
+func CSSViewportRuleFromJS(value js.Value) *CSSViewportRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSViewportRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSViewportRuleFromJS is casting from something that holds a js.Value into CSSViewportRule.
+func CSSViewportRuleFromWrapper(input core.Wrapper) *CSSViewportRule {
+	return CSSViewportRuleFromJS(input.JSValue())
 }
 
 // Style returning attribute 'style' with

--- a/css/deviceadapt/deviceadapt_js.go
+++ b/css/deviceadapt/deviceadapt_js.go
@@ -5,6 +5,7 @@ package deviceadapt
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -40,15 +41,19 @@ type CSSViewportRule struct {
 	cssom.CSSRule
 }
 
-// CSSViewportRuleFromJS is casting a js.Wrapper into CSSViewportRule.
-func CSSViewportRuleFromJS(value js.Wrapper) *CSSViewportRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSViewportRuleFromJS is casting a js.Value into CSSViewportRule.
+func CSSViewportRuleFromJS(value js.Value) *CSSViewportRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSViewportRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSViewportRuleFromJS is casting from something that holds a js.Value into CSSViewportRule.
+func CSSViewportRuleFromWrapper(input core.Wrapper) *CSSViewportRule {
+	return CSSViewportRuleFromJS(input.JSValue())
 }
 
 // Style returning attribute 'style' with

--- a/css/fonts/fonts.go
+++ b/css/fonts/fonts.go
@@ -7,6 +7,7 @@ package fonts
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -155,7 +156,7 @@ type CSSFontFeatureValuesMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -171,26 +172,24 @@ func (_this *CSSFontFeatureValuesMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapEntryIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapEntryIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapEntryIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapEntryIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapEntryIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapEntryIteratorValue {
 	var out CSSFontFeatureValuesMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -201,7 +200,7 @@ type CSSFontFeatureValuesMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -213,18 +212,16 @@ func (_this *CSSFontFeatureValuesMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapKeyIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapKeyIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapKeyIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapKeyIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapKeyIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapKeyIteratorValue {
 	var out CSSFontFeatureValuesMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -235,7 +232,7 @@ type CSSFontFeatureValuesMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -251,26 +248,24 @@ func (_this *CSSFontFeatureValuesMapValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapValueIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapValueIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapValueIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapValueIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapValueIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapValueIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapValueIteratorValue {
 	var out CSSFontFeatureValuesMapValueIteratorValue
 	var (
 		value0 []uint // javascript: sequence<unsigned long> {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]uint, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 uint
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = (uint)((__seq_in0).Int())
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -281,7 +276,7 @@ type CSSFontPaletteValuesRuleEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -297,26 +292,24 @@ func (_this *CSSFontPaletteValuesRuleEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleEntryIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleEntryIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleEntryIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleEntryIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleEntryIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleEntryIteratorValue {
 	var out CSSFontPaletteValuesRuleEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -327,7 +320,7 @@ type CSSFontPaletteValuesRuleKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -339,18 +332,16 @@ func (_this *CSSFontPaletteValuesRuleKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleKeyIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleKeyIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleKeyIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleKeyIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleKeyIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleKeyIteratorValue {
 	var out CSSFontPaletteValuesRuleKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -361,7 +352,7 @@ type CSSFontPaletteValuesRuleValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -373,18 +364,16 @@ func (_this *CSSFontPaletteValuesRuleValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleValueIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleValueIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleValueIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleValueIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleValueIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleValueIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleValueIteratorValue {
 	var out CSSFontPaletteValuesRuleValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -394,15 +383,19 @@ type CSSFontFaceRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontFaceRuleFromJS is casting a js.Wrapper into CSSFontFaceRule.
-func CSSFontFaceRuleFromJS(value js.Wrapper) *CSSFontFaceRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFaceRuleFromJS is casting a js.Value into CSSFontFaceRule.
+func CSSFontFaceRuleFromJS(value js.Value) *CSSFontFaceRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFaceRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFaceRuleFromJS is casting from something that holds a js.Value into CSSFontFaceRule.
+func CSSFontFaceRuleFromWrapper(input core.Wrapper) *CSSFontFaceRule {
+	return CSSFontFaceRuleFromJS(input.JSValue())
 }
 
 // Style returning attribute 'style' with
@@ -424,15 +417,19 @@ func (_this *CSSFontFeatureValuesMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapFromJS is casting a js.Wrapper into CSSFontFeatureValuesMap.
-func CSSFontFeatureValuesMapFromJS(value js.Wrapper) *CSSFontFeatureValuesMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapFromJS is casting a js.Value into CSSFontFeatureValuesMap.
+func CSSFontFeatureValuesMapFromJS(value js.Value) *CSSFontFeatureValuesMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMap.
+func CSSFontFeatureValuesMapFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMap {
+	return CSSFontFeatureValuesMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -605,15 +602,19 @@ func (_this *CSSFontFeatureValuesMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapEntryIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapEntryIterator.
-func CSSFontFeatureValuesMapEntryIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapEntryIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapEntryIterator.
+func CSSFontFeatureValuesMapEntryIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapEntryIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapEntryIterator.
+func CSSFontFeatureValuesMapEntryIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapEntryIterator {
+	return CSSFontFeatureValuesMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapEntryIterator) Next() (_result *CSSFontFeatureValuesMapEntryIteratorValue) {
@@ -640,15 +641,19 @@ func (_this *CSSFontFeatureValuesMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapKeyIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapKeyIterator.
-func CSSFontFeatureValuesMapKeyIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapKeyIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapKeyIterator.
+func CSSFontFeatureValuesMapKeyIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapKeyIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapKeyIterator.
+func CSSFontFeatureValuesMapKeyIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapKeyIterator {
+	return CSSFontFeatureValuesMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapKeyIterator) Next() (_result *CSSFontFeatureValuesMapKeyIteratorValue) {
@@ -675,15 +680,19 @@ func (_this *CSSFontFeatureValuesMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapValueIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapValueIterator.
-func CSSFontFeatureValuesMapValueIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapValueIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapValueIterator.
+func CSSFontFeatureValuesMapValueIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapValueIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapValueIterator.
+func CSSFontFeatureValuesMapValueIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapValueIterator {
+	return CSSFontFeatureValuesMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapValueIterator) Next() (_result *CSSFontFeatureValuesMapValueIteratorValue) {
@@ -705,15 +714,19 @@ type CSSFontFeatureValuesRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontFeatureValuesRuleFromJS is casting a js.Wrapper into CSSFontFeatureValuesRule.
-func CSSFontFeatureValuesRuleFromJS(value js.Wrapper) *CSSFontFeatureValuesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesRuleFromJS is casting a js.Value into CSSFontFeatureValuesRule.
+func CSSFontFeatureValuesRuleFromJS(value js.Value) *CSSFontFeatureValuesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesRuleFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesRule.
+func CSSFontFeatureValuesRuleFromWrapper(input core.Wrapper) *CSSFontFeatureValuesRule {
+	return CSSFontFeatureValuesRuleFromJS(input.JSValue())
 }
 
 // FontFamily returning attribute 'fontFamily' with
@@ -791,15 +804,19 @@ type CSSFontPaletteValuesRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontPaletteValuesRuleFromJS is casting a js.Wrapper into CSSFontPaletteValuesRule.
-func CSSFontPaletteValuesRuleFromJS(value js.Wrapper) *CSSFontPaletteValuesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleFromJS is casting a js.Value into CSSFontPaletteValuesRule.
+func CSSFontPaletteValuesRuleFromJS(value js.Value) *CSSFontPaletteValuesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRule.
+func CSSFontPaletteValuesRuleFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRule {
+	return CSSFontPaletteValuesRuleFromJS(input.JSValue())
 }
 
 // FontFamily returning attribute 'fontFamily' with
@@ -1002,15 +1019,19 @@ func (_this *CSSFontPaletteValuesRuleEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleEntryIterator.
-func CSSFontPaletteValuesRuleEntryIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleEntryIterator.
+func CSSFontPaletteValuesRuleEntryIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleEntryIterator.
+func CSSFontPaletteValuesRuleEntryIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleEntryIterator {
+	return CSSFontPaletteValuesRuleEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleEntryIterator) Next() (_result *CSSFontPaletteValuesRuleEntryIteratorValue) {
@@ -1037,15 +1058,19 @@ func (_this *CSSFontPaletteValuesRuleKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleKeyIterator.
-func CSSFontPaletteValuesRuleKeyIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleKeyIterator.
+func CSSFontPaletteValuesRuleKeyIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleKeyIterator.
+func CSSFontPaletteValuesRuleKeyIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleKeyIterator {
+	return CSSFontPaletteValuesRuleKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleKeyIterator) Next() (_result *CSSFontPaletteValuesRuleKeyIteratorValue) {
@@ -1072,15 +1097,19 @@ func (_this *CSSFontPaletteValuesRuleValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleValueIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleValueIterator.
-func CSSFontPaletteValuesRuleValueIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleValueIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleValueIterator.
+func CSSFontPaletteValuesRuleValueIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleValueIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleValueIterator.
+func CSSFontPaletteValuesRuleValueIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleValueIterator {
+	return CSSFontPaletteValuesRuleValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleValueIterator) Next() (_result *CSSFontPaletteValuesRuleValueIteratorValue) {

--- a/css/fonts/fonts_js.go
+++ b/css/fonts/fonts_js.go
@@ -5,6 +5,7 @@ package fonts
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/cssom"
 )
 
@@ -153,7 +154,7 @@ type CSSFontFeatureValuesMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -169,26 +170,24 @@ func (_this *CSSFontFeatureValuesMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapEntryIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapEntryIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapEntryIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapEntryIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapEntryIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapEntryIteratorValue {
 	var out CSSFontFeatureValuesMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -199,7 +198,7 @@ type CSSFontFeatureValuesMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -211,18 +210,16 @@ func (_this *CSSFontFeatureValuesMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapKeyIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapKeyIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapKeyIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapKeyIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapKeyIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapKeyIteratorValue {
 	var out CSSFontFeatureValuesMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -233,7 +230,7 @@ type CSSFontFeatureValuesMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontFeatureValuesMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -249,26 +246,24 @@ func (_this *CSSFontFeatureValuesMapValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontFeatureValuesMapValueIteratorValueFromJS is allocating a new
-// CSSFontFeatureValuesMapValueIteratorValue object and copy all values from
-// input javascript object
-func CSSFontFeatureValuesMapValueIteratorValueFromJS(value js.Wrapper) *CSSFontFeatureValuesMapValueIteratorValue {
-	input := value.JSValue()
+// CSSFontFeatureValuesMapValueIteratorValue object and copy all values in the value javascript object.
+func CSSFontFeatureValuesMapValueIteratorValueFromJS(value js.Value) *CSSFontFeatureValuesMapValueIteratorValue {
 	var out CSSFontFeatureValuesMapValueIteratorValue
 	var (
 		value0 []uint // javascript: sequence<unsigned long> {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]uint, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 uint
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = (uint)((__seq_in0).Int())
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -279,7 +274,7 @@ type CSSFontPaletteValuesRuleEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -295,26 +290,24 @@ func (_this *CSSFontPaletteValuesRuleEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleEntryIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleEntryIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleEntryIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleEntryIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleEntryIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleEntryIteratorValue {
 	var out CSSFontPaletteValuesRuleEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -325,7 +318,7 @@ type CSSFontPaletteValuesRuleKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -337,18 +330,16 @@ func (_this *CSSFontPaletteValuesRuleKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleKeyIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleKeyIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleKeyIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleKeyIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleKeyIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleKeyIteratorValue {
 	var out CSSFontPaletteValuesRuleKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -359,7 +350,7 @@ type CSSFontPaletteValuesRuleValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSFontPaletteValuesRuleValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -371,18 +362,16 @@ func (_this *CSSFontPaletteValuesRuleValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSFontPaletteValuesRuleValueIteratorValueFromJS is allocating a new
-// CSSFontPaletteValuesRuleValueIteratorValue object and copy all values from
-// input javascript object
-func CSSFontPaletteValuesRuleValueIteratorValueFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleValueIteratorValue {
-	input := value.JSValue()
+// CSSFontPaletteValuesRuleValueIteratorValue object and copy all values in the value javascript object.
+func CSSFontPaletteValuesRuleValueIteratorValueFromJS(value js.Value) *CSSFontPaletteValuesRuleValueIteratorValue {
 	var out CSSFontPaletteValuesRuleValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -392,15 +381,19 @@ type CSSFontFaceRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontFaceRuleFromJS is casting a js.Wrapper into CSSFontFaceRule.
-func CSSFontFaceRuleFromJS(value js.Wrapper) *CSSFontFaceRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFaceRuleFromJS is casting a js.Value into CSSFontFaceRule.
+func CSSFontFaceRuleFromJS(value js.Value) *CSSFontFaceRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFaceRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFaceRuleFromJS is casting from something that holds a js.Value into CSSFontFaceRule.
+func CSSFontFaceRuleFromWrapper(input core.Wrapper) *CSSFontFaceRule {
+	return CSSFontFaceRuleFromJS(input.JSValue())
 }
 
 // Style returning attribute 'style' with
@@ -422,15 +415,19 @@ func (_this *CSSFontFeatureValuesMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapFromJS is casting a js.Wrapper into CSSFontFeatureValuesMap.
-func CSSFontFeatureValuesMapFromJS(value js.Wrapper) *CSSFontFeatureValuesMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapFromJS is casting a js.Value into CSSFontFeatureValuesMap.
+func CSSFontFeatureValuesMapFromJS(value js.Value) *CSSFontFeatureValuesMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMap.
+func CSSFontFeatureValuesMapFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMap {
+	return CSSFontFeatureValuesMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -603,15 +600,19 @@ func (_this *CSSFontFeatureValuesMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapEntryIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapEntryIterator.
-func CSSFontFeatureValuesMapEntryIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapEntryIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapEntryIterator.
+func CSSFontFeatureValuesMapEntryIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapEntryIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapEntryIterator.
+func CSSFontFeatureValuesMapEntryIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapEntryIterator {
+	return CSSFontFeatureValuesMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapEntryIterator) Next() (_result *CSSFontFeatureValuesMapEntryIteratorValue) {
@@ -638,15 +639,19 @@ func (_this *CSSFontFeatureValuesMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapKeyIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapKeyIterator.
-func CSSFontFeatureValuesMapKeyIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapKeyIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapKeyIterator.
+func CSSFontFeatureValuesMapKeyIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapKeyIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapKeyIterator.
+func CSSFontFeatureValuesMapKeyIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapKeyIterator {
+	return CSSFontFeatureValuesMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapKeyIterator) Next() (_result *CSSFontFeatureValuesMapKeyIteratorValue) {
@@ -673,15 +678,19 @@ func (_this *CSSFontFeatureValuesMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontFeatureValuesMapValueIteratorFromJS is casting a js.Wrapper into CSSFontFeatureValuesMapValueIterator.
-func CSSFontFeatureValuesMapValueIteratorFromJS(value js.Wrapper) *CSSFontFeatureValuesMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesMapValueIteratorFromJS is casting a js.Value into CSSFontFeatureValuesMapValueIterator.
+func CSSFontFeatureValuesMapValueIteratorFromJS(value js.Value) *CSSFontFeatureValuesMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesMapValueIteratorFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesMapValueIterator.
+func CSSFontFeatureValuesMapValueIteratorFromWrapper(input core.Wrapper) *CSSFontFeatureValuesMapValueIterator {
+	return CSSFontFeatureValuesMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontFeatureValuesMapValueIterator) Next() (_result *CSSFontFeatureValuesMapValueIteratorValue) {
@@ -703,15 +712,19 @@ type CSSFontFeatureValuesRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontFeatureValuesRuleFromJS is casting a js.Wrapper into CSSFontFeatureValuesRule.
-func CSSFontFeatureValuesRuleFromJS(value js.Wrapper) *CSSFontFeatureValuesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontFeatureValuesRuleFromJS is casting a js.Value into CSSFontFeatureValuesRule.
+func CSSFontFeatureValuesRuleFromJS(value js.Value) *CSSFontFeatureValuesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontFeatureValuesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontFeatureValuesRuleFromJS is casting from something that holds a js.Value into CSSFontFeatureValuesRule.
+func CSSFontFeatureValuesRuleFromWrapper(input core.Wrapper) *CSSFontFeatureValuesRule {
+	return CSSFontFeatureValuesRuleFromJS(input.JSValue())
 }
 
 // FontFamily returning attribute 'fontFamily' with
@@ -789,15 +802,19 @@ type CSSFontPaletteValuesRule struct {
 	cssom.CSSRule
 }
 
-// CSSFontPaletteValuesRuleFromJS is casting a js.Wrapper into CSSFontPaletteValuesRule.
-func CSSFontPaletteValuesRuleFromJS(value js.Wrapper) *CSSFontPaletteValuesRule {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleFromJS is casting a js.Value into CSSFontPaletteValuesRule.
+func CSSFontPaletteValuesRuleFromJS(value js.Value) *CSSFontPaletteValuesRule {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRule{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRule.
+func CSSFontPaletteValuesRuleFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRule {
+	return CSSFontPaletteValuesRuleFromJS(input.JSValue())
 }
 
 // FontFamily returning attribute 'fontFamily' with
@@ -1000,15 +1017,19 @@ func (_this *CSSFontPaletteValuesRuleEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleEntryIterator.
-func CSSFontPaletteValuesRuleEntryIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleEntryIterator.
+func CSSFontPaletteValuesRuleEntryIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleEntryIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleEntryIterator.
+func CSSFontPaletteValuesRuleEntryIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleEntryIterator {
+	return CSSFontPaletteValuesRuleEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleEntryIterator) Next() (_result *CSSFontPaletteValuesRuleEntryIteratorValue) {
@@ -1035,15 +1056,19 @@ func (_this *CSSFontPaletteValuesRuleKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleKeyIterator.
-func CSSFontPaletteValuesRuleKeyIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleKeyIterator.
+func CSSFontPaletteValuesRuleKeyIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleKeyIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleKeyIterator.
+func CSSFontPaletteValuesRuleKeyIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleKeyIterator {
+	return CSSFontPaletteValuesRuleKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleKeyIterator) Next() (_result *CSSFontPaletteValuesRuleKeyIteratorValue) {
@@ -1070,15 +1095,19 @@ func (_this *CSSFontPaletteValuesRuleValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSFontPaletteValuesRuleValueIteratorFromJS is casting a js.Wrapper into CSSFontPaletteValuesRuleValueIterator.
-func CSSFontPaletteValuesRuleValueIteratorFromJS(value js.Wrapper) *CSSFontPaletteValuesRuleValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSFontPaletteValuesRuleValueIteratorFromJS is casting a js.Value into CSSFontPaletteValuesRuleValueIterator.
+func CSSFontPaletteValuesRuleValueIteratorFromJS(value js.Value) *CSSFontPaletteValuesRuleValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSFontPaletteValuesRuleValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSFontPaletteValuesRuleValueIteratorFromJS is casting from something that holds a js.Value into CSSFontPaletteValuesRuleValueIterator.
+func CSSFontPaletteValuesRuleValueIteratorFromWrapper(input core.Wrapper) *CSSFontPaletteValuesRuleValueIterator {
+	return CSSFontPaletteValuesRuleValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSFontPaletteValuesRuleValueIterator) Next() (_result *CSSFontPaletteValuesRuleValueIteratorValue) {

--- a/css/fonts/loading/loading.go
+++ b/css/fonts/loading/loading.go
@@ -7,6 +7,7 @@ package loading
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -364,7 +365,7 @@ type FontFaceDescriptors struct {
 	Display           string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceDescriptors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -388,10 +389,8 @@ func (_this *FontFaceDescriptors) JSValue() js.Value {
 }
 
 // FontFaceDescriptorsFromJS is allocating a new
-// FontFaceDescriptors object and copy all values from
-// input javascript object
-func FontFaceDescriptorsFromJS(value js.Wrapper) *FontFaceDescriptors {
-	input := value.JSValue()
+// FontFaceDescriptors object and copy all values in the value javascript object.
+func FontFaceDescriptorsFromJS(value js.Value) *FontFaceDescriptors {
 	var out FontFaceDescriptors
 	var (
 		value0 string // javascript: DOMString {style Style style}
@@ -403,21 +402,21 @@ func FontFaceDescriptorsFromJS(value js.Wrapper) *FontFaceDescriptors {
 		value6 string // javascript: DOMString {variationSettings VariationSettings variationSettings}
 		value7 string // javascript: DOMString {display Display display}
 	)
-	value0 = (input.Get("style")).String()
+	value0 = (value.Get("style")).String()
 	out.Style = value0
-	value1 = (input.Get("weight")).String()
+	value1 = (value.Get("weight")).String()
 	out.Weight = value1
-	value2 = (input.Get("stretch")).String()
+	value2 = (value.Get("stretch")).String()
 	out.Stretch = value2
-	value3 = (input.Get("unicodeRange")).String()
+	value3 = (value.Get("unicodeRange")).String()
 	out.UnicodeRange = value3
-	value4 = (input.Get("variant")).String()
+	value4 = (value.Get("variant")).String()
 	out.Variant = value4
-	value5 = (input.Get("featureSettings")).String()
+	value5 = (value.Get("featureSettings")).String()
 	out.FeatureSettings = value5
-	value6 = (input.Get("variationSettings")).String()
+	value6 = (value.Get("variationSettings")).String()
 	out.VariationSettings = value6
-	value7 = (input.Get("display")).String()
+	value7 = (value.Get("display")).String()
 	out.Display = value7
 	return &out
 }
@@ -428,7 +427,7 @@ type FontFaceSetEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -444,26 +443,24 @@ func (_this *FontFaceSetEntryIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetEntryIteratorValueFromJS is allocating a new
-// FontFaceSetEntryIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetEntryIteratorValueFromJS(value js.Wrapper) *FontFaceSetEntryIteratorValue {
-	input := value.JSValue()
+// FontFaceSetEntryIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetEntryIteratorValueFromJS(value js.Value) *FontFaceSetEntryIteratorValue {
 	var out FontFaceSetEntryIteratorValue
 	var (
 		value0 []*FontFace // javascript: sequence<FontFace> {value Value value}
 		value1 bool        // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]*FontFace, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *FontFace
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = FontFaceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -474,7 +471,7 @@ type FontFaceSetKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -486,18 +483,16 @@ func (_this *FontFaceSetKeyIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetKeyIteratorValueFromJS is allocating a new
-// FontFaceSetKeyIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetKeyIteratorValueFromJS(value js.Wrapper) *FontFaceSetKeyIteratorValue {
-	input := value.JSValue()
+// FontFaceSetKeyIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetKeyIteratorValueFromJS(value js.Value) *FontFaceSetKeyIteratorValue {
 	var out FontFaceSetKeyIteratorValue
 	var (
 		value0 *FontFace // javascript: FontFace {value Value value}
 		value1 bool      // javascript: boolean {done Done done}
 	)
-	value0 = FontFaceFromJS(input.Get("value"))
+	value0 = FontFaceFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -510,7 +505,7 @@ type FontFaceSetLoadEventInit struct {
 	Fontfaces  []*FontFace
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetLoadEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -530,10 +525,8 @@ func (_this *FontFaceSetLoadEventInit) JSValue() js.Value {
 }
 
 // FontFaceSetLoadEventInitFromJS is allocating a new
-// FontFaceSetLoadEventInit object and copy all values from
-// input javascript object
-func FontFaceSetLoadEventInitFromJS(value js.Wrapper) *FontFaceSetLoadEventInit {
-	input := value.JSValue()
+// FontFaceSetLoadEventInit object and copy all values in the value javascript object.
+func FontFaceSetLoadEventInitFromJS(value js.Value) *FontFaceSetLoadEventInit {
 	var out FontFaceSetLoadEventInit
 	var (
 		value0 bool        // javascript: boolean {bubbles Bubbles bubbles}
@@ -541,17 +534,17 @@ func FontFaceSetLoadEventInitFromJS(value js.Wrapper) *FontFaceSetLoadEventInit 
 		value2 bool        // javascript: boolean {composed Composed composed}
 		value3 []*FontFace // javascript: sequence<FontFace> {fontfaces Fontfaces fontfaces}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("fontfaces").Length()
+	__length3 := value.Get("fontfaces").Length()
 	__array3 := make([]*FontFace, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *FontFace
-		__seq_in3 := input.Get("fontfaces").Index(__idx3)
+		__seq_in3 := value.Get("fontfaces").Index(__idx3)
 		__seq_out3 = FontFaceFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -566,7 +559,7 @@ type FontFaceSetValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -578,18 +571,16 @@ func (_this *FontFaceSetValueIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetValueIteratorValueFromJS is allocating a new
-// FontFaceSetValueIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetValueIteratorValueFromJS(value js.Wrapper) *FontFaceSetValueIteratorValue {
-	input := value.JSValue()
+// FontFaceSetValueIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetValueIteratorValueFromJS(value js.Value) *FontFaceSetValueIteratorValue {
 	var out FontFaceSetValueIteratorValue
 	var (
 		value0 *FontFace // javascript: FontFace {value Value value}
 		value1 bool      // javascript: boolean {done Done done}
 	)
-	value0 = FontFaceFromJS(input.Get("value"))
+	value0 = FontFaceFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -604,15 +595,19 @@ func (_this *FontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceFromJS is casting a js.Wrapper into FontFace.
-func FontFaceFromJS(value js.Wrapper) *FontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceFromJS is casting a js.Value into FontFace.
+func FontFaceFromJS(value js.Value) *FontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceFromJS is casting from something that holds a js.Value into FontFace.
+func FontFaceFromWrapper(input core.Wrapper) *FontFace {
+	return FontFaceFromJS(input.JSValue())
 }
 
 func NewFontFace(family string, source *Union, descriptors *FontFaceDescriptors) (_result *FontFace) {
@@ -822,15 +817,19 @@ type FontFaceSet struct {
 	domcore.EventTarget
 }
 
-// FontFaceSetFromJS is casting a js.Wrapper into FontFaceSet.
-func FontFaceSetFromJS(value js.Wrapper) *FontFaceSet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetFromJS is casting a js.Value into FontFaceSet.
+func FontFaceSetFromJS(value js.Value) *FontFaceSet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetFromJS is casting from something that holds a js.Value into FontFaceSet.
+func FontFaceSetFromWrapper(input core.Wrapper) *FontFaceSet {
+	return FontFaceSetFromJS(input.JSValue())
 }
 
 func NewFontFaceSet(initialFaces []*FontFace) (_result *FontFaceSet) {
@@ -1188,15 +1187,19 @@ func (_this *FontFaceSetEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetEntryIteratorFromJS is casting a js.Wrapper into FontFaceSetEntryIterator.
-func FontFaceSetEntryIteratorFromJS(value js.Wrapper) *FontFaceSetEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetEntryIteratorFromJS is casting a js.Value into FontFaceSetEntryIterator.
+func FontFaceSetEntryIteratorFromJS(value js.Value) *FontFaceSetEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetEntryIteratorFromJS is casting from something that holds a js.Value into FontFaceSetEntryIterator.
+func FontFaceSetEntryIteratorFromWrapper(input core.Wrapper) *FontFaceSetEntryIterator {
+	return FontFaceSetEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetEntryIterator) Next() (_result *FontFaceSetEntryIteratorValue) {
@@ -1223,15 +1226,19 @@ func (_this *FontFaceSetKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetKeyIteratorFromJS is casting a js.Wrapper into FontFaceSetKeyIterator.
-func FontFaceSetKeyIteratorFromJS(value js.Wrapper) *FontFaceSetKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetKeyIteratorFromJS is casting a js.Value into FontFaceSetKeyIterator.
+func FontFaceSetKeyIteratorFromJS(value js.Value) *FontFaceSetKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetKeyIteratorFromJS is casting from something that holds a js.Value into FontFaceSetKeyIterator.
+func FontFaceSetKeyIteratorFromWrapper(input core.Wrapper) *FontFaceSetKeyIterator {
+	return FontFaceSetKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetKeyIterator) Next() (_result *FontFaceSetKeyIteratorValue) {
@@ -1253,15 +1260,19 @@ type FontFaceSetLoadEvent struct {
 	domcore.Event
 }
 
-// FontFaceSetLoadEventFromJS is casting a js.Wrapper into FontFaceSetLoadEvent.
-func FontFaceSetLoadEventFromJS(value js.Wrapper) *FontFaceSetLoadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetLoadEventFromJS is casting a js.Value into FontFaceSetLoadEvent.
+func FontFaceSetLoadEventFromJS(value js.Value) *FontFaceSetLoadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetLoadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetLoadEventFromJS is casting from something that holds a js.Value into FontFaceSetLoadEvent.
+func FontFaceSetLoadEventFromWrapper(input core.Wrapper) *FontFaceSetLoadEvent {
+	return FontFaceSetLoadEventFromJS(input.JSValue())
 }
 
 func NewFontFaceSetLoadEvent(_type string, eventInitDict *FontFaceSetLoadEventInit) (_result *FontFaceSetLoadEvent) {
@@ -1306,15 +1317,19 @@ func (_this *FontFaceSetValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetValueIteratorFromJS is casting a js.Wrapper into FontFaceSetValueIterator.
-func FontFaceSetValueIteratorFromJS(value js.Wrapper) *FontFaceSetValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetValueIteratorFromJS is casting a js.Value into FontFaceSetValueIterator.
+func FontFaceSetValueIteratorFromJS(value js.Value) *FontFaceSetValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetValueIteratorFromJS is casting from something that holds a js.Value into FontFaceSetValueIterator.
+func FontFaceSetValueIteratorFromWrapper(input core.Wrapper) *FontFaceSetValueIterator {
+	return FontFaceSetValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetValueIterator) Next() (_result *FontFaceSetValueIteratorValue) {
@@ -1341,15 +1356,19 @@ func (_this *FontFaceSource) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSourceFromJS is casting a js.Wrapper into FontFaceSource.
-func FontFaceSourceFromJS(value js.Wrapper) *FontFaceSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSourceFromJS is casting a js.Value into FontFaceSource.
+func FontFaceSourceFromJS(value js.Value) *FontFaceSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSourceFromJS is casting from something that holds a js.Value into FontFaceSource.
+func FontFaceSourceFromWrapper(input core.Wrapper) *FontFaceSource {
+	return FontFaceSourceFromJS(input.JSValue())
 }
 
 // Fonts returning attribute 'fonts' with
@@ -1371,15 +1390,19 @@ func (_this *PromiseFontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFontFaceFromJS is casting a js.Wrapper into PromiseFontFace.
-func PromiseFontFaceFromJS(value js.Wrapper) *PromiseFontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFontFaceFromJS is casting a js.Value into PromiseFontFace.
+func PromiseFontFaceFromJS(value js.Value) *PromiseFontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFontFaceFromJS is casting from something that holds a js.Value into PromiseFontFace.
+func PromiseFontFaceFromWrapper(input core.Wrapper) *PromiseFontFace {
+	return PromiseFontFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseFontFace) Then(onFulfilled *PromiseFontFaceOnFulfilled, onRejected *PromiseFontFaceOnRejected) (_result *PromiseFontFace) {
@@ -1476,15 +1499,19 @@ func (_this *PromiseSequenceFontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceFontFaceFromJS is casting a js.Wrapper into PromiseSequenceFontFace.
-func PromiseSequenceFontFaceFromJS(value js.Wrapper) *PromiseSequenceFontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceFontFaceFromJS is casting a js.Value into PromiseSequenceFontFace.
+func PromiseSequenceFontFaceFromJS(value js.Value) *PromiseSequenceFontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceFontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceFontFaceFromJS is casting from something that holds a js.Value into PromiseSequenceFontFace.
+func PromiseSequenceFontFaceFromWrapper(input core.Wrapper) *PromiseSequenceFontFace {
+	return PromiseSequenceFontFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceFontFace) Then(onFulfilled *PromiseSequenceFontFaceOnFulfilled, onRejected *PromiseSequenceFontFaceOnRejected) (_result *PromiseSequenceFontFace) {

--- a/css/fonts/loading/loading_js.go
+++ b/css/fonts/loading/loading_js.go
@@ -5,6 +5,7 @@ package loading
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -362,7 +363,7 @@ type FontFaceDescriptors struct {
 	Display           string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceDescriptors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -386,10 +387,8 @@ func (_this *FontFaceDescriptors) JSValue() js.Value {
 }
 
 // FontFaceDescriptorsFromJS is allocating a new
-// FontFaceDescriptors object and copy all values from
-// input javascript object
-func FontFaceDescriptorsFromJS(value js.Wrapper) *FontFaceDescriptors {
-	input := value.JSValue()
+// FontFaceDescriptors object and copy all values in the value javascript object.
+func FontFaceDescriptorsFromJS(value js.Value) *FontFaceDescriptors {
 	var out FontFaceDescriptors
 	var (
 		value0 string // javascript: DOMString {style Style style}
@@ -401,21 +400,21 @@ func FontFaceDescriptorsFromJS(value js.Wrapper) *FontFaceDescriptors {
 		value6 string // javascript: DOMString {variationSettings VariationSettings variationSettings}
 		value7 string // javascript: DOMString {display Display display}
 	)
-	value0 = (input.Get("style")).String()
+	value0 = (value.Get("style")).String()
 	out.Style = value0
-	value1 = (input.Get("weight")).String()
+	value1 = (value.Get("weight")).String()
 	out.Weight = value1
-	value2 = (input.Get("stretch")).String()
+	value2 = (value.Get("stretch")).String()
 	out.Stretch = value2
-	value3 = (input.Get("unicodeRange")).String()
+	value3 = (value.Get("unicodeRange")).String()
 	out.UnicodeRange = value3
-	value4 = (input.Get("variant")).String()
+	value4 = (value.Get("variant")).String()
 	out.Variant = value4
-	value5 = (input.Get("featureSettings")).String()
+	value5 = (value.Get("featureSettings")).String()
 	out.FeatureSettings = value5
-	value6 = (input.Get("variationSettings")).String()
+	value6 = (value.Get("variationSettings")).String()
 	out.VariationSettings = value6
-	value7 = (input.Get("display")).String()
+	value7 = (value.Get("display")).String()
 	out.Display = value7
 	return &out
 }
@@ -426,7 +425,7 @@ type FontFaceSetEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -442,26 +441,24 @@ func (_this *FontFaceSetEntryIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetEntryIteratorValueFromJS is allocating a new
-// FontFaceSetEntryIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetEntryIteratorValueFromJS(value js.Wrapper) *FontFaceSetEntryIteratorValue {
-	input := value.JSValue()
+// FontFaceSetEntryIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetEntryIteratorValueFromJS(value js.Value) *FontFaceSetEntryIteratorValue {
 	var out FontFaceSetEntryIteratorValue
 	var (
 		value0 []*FontFace // javascript: sequence<FontFace> {value Value value}
 		value1 bool        // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]*FontFace, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *FontFace
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = FontFaceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -472,7 +469,7 @@ type FontFaceSetKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -484,18 +481,16 @@ func (_this *FontFaceSetKeyIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetKeyIteratorValueFromJS is allocating a new
-// FontFaceSetKeyIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetKeyIteratorValueFromJS(value js.Wrapper) *FontFaceSetKeyIteratorValue {
-	input := value.JSValue()
+// FontFaceSetKeyIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetKeyIteratorValueFromJS(value js.Value) *FontFaceSetKeyIteratorValue {
 	var out FontFaceSetKeyIteratorValue
 	var (
 		value0 *FontFace // javascript: FontFace {value Value value}
 		value1 bool      // javascript: boolean {done Done done}
 	)
-	value0 = FontFaceFromJS(input.Get("value"))
+	value0 = FontFaceFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -508,7 +503,7 @@ type FontFaceSetLoadEventInit struct {
 	Fontfaces  []*FontFace
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetLoadEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -528,10 +523,8 @@ func (_this *FontFaceSetLoadEventInit) JSValue() js.Value {
 }
 
 // FontFaceSetLoadEventInitFromJS is allocating a new
-// FontFaceSetLoadEventInit object and copy all values from
-// input javascript object
-func FontFaceSetLoadEventInitFromJS(value js.Wrapper) *FontFaceSetLoadEventInit {
-	input := value.JSValue()
+// FontFaceSetLoadEventInit object and copy all values in the value javascript object.
+func FontFaceSetLoadEventInitFromJS(value js.Value) *FontFaceSetLoadEventInit {
 	var out FontFaceSetLoadEventInit
 	var (
 		value0 bool        // javascript: boolean {bubbles Bubbles bubbles}
@@ -539,17 +532,17 @@ func FontFaceSetLoadEventInitFromJS(value js.Wrapper) *FontFaceSetLoadEventInit 
 		value2 bool        // javascript: boolean {composed Composed composed}
 		value3 []*FontFace // javascript: sequence<FontFace> {fontfaces Fontfaces fontfaces}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	__length3 := input.Get("fontfaces").Length()
+	__length3 := value.Get("fontfaces").Length()
 	__array3 := make([]*FontFace, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *FontFace
-		__seq_in3 := input.Get("fontfaces").Index(__idx3)
+		__seq_in3 := value.Get("fontfaces").Index(__idx3)
 		__seq_out3 = FontFaceFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -564,7 +557,7 @@ type FontFaceSetValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FontFaceSetValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -576,18 +569,16 @@ func (_this *FontFaceSetValueIteratorValue) JSValue() js.Value {
 }
 
 // FontFaceSetValueIteratorValueFromJS is allocating a new
-// FontFaceSetValueIteratorValue object and copy all values from
-// input javascript object
-func FontFaceSetValueIteratorValueFromJS(value js.Wrapper) *FontFaceSetValueIteratorValue {
-	input := value.JSValue()
+// FontFaceSetValueIteratorValue object and copy all values in the value javascript object.
+func FontFaceSetValueIteratorValueFromJS(value js.Value) *FontFaceSetValueIteratorValue {
 	var out FontFaceSetValueIteratorValue
 	var (
 		value0 *FontFace // javascript: FontFace {value Value value}
 		value1 bool      // javascript: boolean {done Done done}
 	)
-	value0 = FontFaceFromJS(input.Get("value"))
+	value0 = FontFaceFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -602,15 +593,19 @@ func (_this *FontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceFromJS is casting a js.Wrapper into FontFace.
-func FontFaceFromJS(value js.Wrapper) *FontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceFromJS is casting a js.Value into FontFace.
+func FontFaceFromJS(value js.Value) *FontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceFromJS is casting from something that holds a js.Value into FontFace.
+func FontFaceFromWrapper(input core.Wrapper) *FontFace {
+	return FontFaceFromJS(input.JSValue())
 }
 
 func NewFontFace(family string, source *Union, descriptors *FontFaceDescriptors) (_result *FontFace) {
@@ -820,15 +815,19 @@ type FontFaceSet struct {
 	domcore.EventTarget
 }
 
-// FontFaceSetFromJS is casting a js.Wrapper into FontFaceSet.
-func FontFaceSetFromJS(value js.Wrapper) *FontFaceSet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetFromJS is casting a js.Value into FontFaceSet.
+func FontFaceSetFromJS(value js.Value) *FontFaceSet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetFromJS is casting from something that holds a js.Value into FontFaceSet.
+func FontFaceSetFromWrapper(input core.Wrapper) *FontFaceSet {
+	return FontFaceSetFromJS(input.JSValue())
 }
 
 func NewFontFaceSet(initialFaces []*FontFace) (_result *FontFaceSet) {
@@ -1186,15 +1185,19 @@ func (_this *FontFaceSetEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetEntryIteratorFromJS is casting a js.Wrapper into FontFaceSetEntryIterator.
-func FontFaceSetEntryIteratorFromJS(value js.Wrapper) *FontFaceSetEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetEntryIteratorFromJS is casting a js.Value into FontFaceSetEntryIterator.
+func FontFaceSetEntryIteratorFromJS(value js.Value) *FontFaceSetEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetEntryIteratorFromJS is casting from something that holds a js.Value into FontFaceSetEntryIterator.
+func FontFaceSetEntryIteratorFromWrapper(input core.Wrapper) *FontFaceSetEntryIterator {
+	return FontFaceSetEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetEntryIterator) Next() (_result *FontFaceSetEntryIteratorValue) {
@@ -1221,15 +1224,19 @@ func (_this *FontFaceSetKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetKeyIteratorFromJS is casting a js.Wrapper into FontFaceSetKeyIterator.
-func FontFaceSetKeyIteratorFromJS(value js.Wrapper) *FontFaceSetKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetKeyIteratorFromJS is casting a js.Value into FontFaceSetKeyIterator.
+func FontFaceSetKeyIteratorFromJS(value js.Value) *FontFaceSetKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetKeyIteratorFromJS is casting from something that holds a js.Value into FontFaceSetKeyIterator.
+func FontFaceSetKeyIteratorFromWrapper(input core.Wrapper) *FontFaceSetKeyIterator {
+	return FontFaceSetKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetKeyIterator) Next() (_result *FontFaceSetKeyIteratorValue) {
@@ -1251,15 +1258,19 @@ type FontFaceSetLoadEvent struct {
 	domcore.Event
 }
 
-// FontFaceSetLoadEventFromJS is casting a js.Wrapper into FontFaceSetLoadEvent.
-func FontFaceSetLoadEventFromJS(value js.Wrapper) *FontFaceSetLoadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetLoadEventFromJS is casting a js.Value into FontFaceSetLoadEvent.
+func FontFaceSetLoadEventFromJS(value js.Value) *FontFaceSetLoadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetLoadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetLoadEventFromJS is casting from something that holds a js.Value into FontFaceSetLoadEvent.
+func FontFaceSetLoadEventFromWrapper(input core.Wrapper) *FontFaceSetLoadEvent {
+	return FontFaceSetLoadEventFromJS(input.JSValue())
 }
 
 func NewFontFaceSetLoadEvent(_type string, eventInitDict *FontFaceSetLoadEventInit) (_result *FontFaceSetLoadEvent) {
@@ -1304,15 +1315,19 @@ func (_this *FontFaceSetValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSetValueIteratorFromJS is casting a js.Wrapper into FontFaceSetValueIterator.
-func FontFaceSetValueIteratorFromJS(value js.Wrapper) *FontFaceSetValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSetValueIteratorFromJS is casting a js.Value into FontFaceSetValueIterator.
+func FontFaceSetValueIteratorFromJS(value js.Value) *FontFaceSetValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSetValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSetValueIteratorFromJS is casting from something that holds a js.Value into FontFaceSetValueIterator.
+func FontFaceSetValueIteratorFromWrapper(input core.Wrapper) *FontFaceSetValueIterator {
+	return FontFaceSetValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *FontFaceSetValueIterator) Next() (_result *FontFaceSetValueIteratorValue) {
@@ -1339,15 +1354,19 @@ func (_this *FontFaceSource) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFaceSourceFromJS is casting a js.Wrapper into FontFaceSource.
-func FontFaceSourceFromJS(value js.Wrapper) *FontFaceSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFaceSourceFromJS is casting a js.Value into FontFaceSource.
+func FontFaceSourceFromJS(value js.Value) *FontFaceSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontFaceSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFaceSourceFromJS is casting from something that holds a js.Value into FontFaceSource.
+func FontFaceSourceFromWrapper(input core.Wrapper) *FontFaceSource {
+	return FontFaceSourceFromJS(input.JSValue())
 }
 
 // Fonts returning attribute 'fonts' with
@@ -1369,15 +1388,19 @@ func (_this *PromiseFontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFontFaceFromJS is casting a js.Wrapper into PromiseFontFace.
-func PromiseFontFaceFromJS(value js.Wrapper) *PromiseFontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFontFaceFromJS is casting a js.Value into PromiseFontFace.
+func PromiseFontFaceFromJS(value js.Value) *PromiseFontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFontFaceFromJS is casting from something that holds a js.Value into PromiseFontFace.
+func PromiseFontFaceFromWrapper(input core.Wrapper) *PromiseFontFace {
+	return PromiseFontFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseFontFace) Then(onFulfilled *PromiseFontFaceOnFulfilled, onRejected *PromiseFontFaceOnRejected) (_result *PromiseFontFace) {
@@ -1474,15 +1497,19 @@ func (_this *PromiseSequenceFontFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceFontFaceFromJS is casting a js.Wrapper into PromiseSequenceFontFace.
-func PromiseSequenceFontFaceFromJS(value js.Wrapper) *PromiseSequenceFontFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceFontFaceFromJS is casting a js.Value into PromiseSequenceFontFace.
+func PromiseSequenceFontFaceFromJS(value js.Value) *PromiseSequenceFontFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceFontFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceFontFaceFromJS is casting from something that holds a js.Value into PromiseSequenceFontFace.
+func PromiseSequenceFontFaceFromWrapper(input core.Wrapper) *PromiseSequenceFontFace {
+	return PromiseSequenceFontFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceFontFace) Then(onFulfilled *PromiseSequenceFontFaceOnFulfilled, onRejected *PromiseSequenceFontFaceOnRejected) (_result *PromiseSequenceFontFace) {

--- a/css/layout/layout.go
+++ b/css/layout/layout.go
@@ -7,6 +7,7 @@ package layout
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/typedom"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/webidl"
@@ -384,7 +385,7 @@ type BreakTokenOptions struct {
 	Data             js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BreakTokenOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -400,26 +401,24 @@ func (_this *BreakTokenOptions) JSValue() js.Value {
 }
 
 // BreakTokenOptionsFromJS is allocating a new
-// BreakTokenOptions object and copy all values from
-// input javascript object
-func BreakTokenOptionsFromJS(value js.Wrapper) *BreakTokenOptions {
-	input := value.JSValue()
+// BreakTokenOptions object and copy all values in the value javascript object.
+func BreakTokenOptionsFromJS(value js.Value) *BreakTokenOptions {
 	var out BreakTokenOptions
 	var (
 		value0 []*ChildBreakToken // javascript: sequence<ChildBreakToken> {childBreakTokens ChildBreakTokens childBreakTokens}
 		value1 js.Value           // javascript: any {data Data data}
 	)
-	__length0 := input.Get("childBreakTokens").Length()
+	__length0 := value.Get("childBreakTokens").Length()
 	__array0 := make([]*ChildBreakToken, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *ChildBreakToken
-		__seq_in0 := input.Get("childBreakTokens").Index(__idx0)
+		__seq_in0 := value.Get("childBreakTokens").Index(__idx0)
 		__seq_out0 = ChildBreakTokenFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.ChildBreakTokens = value0
-	value1 = input.Get("data")
+	value1 = value.Get("data")
 	out.Data = value1
 	return &out
 }
@@ -434,7 +433,7 @@ type FragmentResultOptions struct {
 	BreakToken     *BreakTokenOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FragmentResultOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -458,10 +457,8 @@ func (_this *FragmentResultOptions) JSValue() js.Value {
 }
 
 // FragmentResultOptionsFromJS is allocating a new
-// FragmentResultOptions object and copy all values from
-// input javascript object
-func FragmentResultOptionsFromJS(value js.Wrapper) *FragmentResultOptions {
-	input := value.JSValue()
+// FragmentResultOptions object and copy all values in the value javascript object.
+func FragmentResultOptionsFromJS(value js.Value) *FragmentResultOptions {
 	var out FragmentResultOptions
 	var (
 		value0 float64            // javascript: double {inlineSize InlineSize inlineSize}
@@ -471,25 +468,25 @@ func FragmentResultOptionsFromJS(value js.Wrapper) *FragmentResultOptions {
 		value4 js.Value           // javascript: any {data Data data}
 		value5 *BreakTokenOptions // javascript: BreakTokenOptions {breakToken BreakToken breakToken}
 	)
-	value0 = (input.Get("inlineSize")).Float()
+	value0 = (value.Get("inlineSize")).Float()
 	out.InlineSize = value0
-	value1 = (input.Get("blockSize")).Float()
+	value1 = (value.Get("blockSize")).Float()
 	out.BlockSize = value1
-	value2 = (input.Get("autoBlockSize")).Float()
+	value2 = (value.Get("autoBlockSize")).Float()
 	out.AutoBlockSize = value2
-	__length3 := input.Get("childFragments").Length()
+	__length3 := value.Get("childFragments").Length()
 	__array3 := make([]*LayoutFragment, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *LayoutFragment
-		__seq_in3 := input.Get("childFragments").Index(__idx3)
+		__seq_in3 := value.Get("childFragments").Index(__idx3)
 		__seq_out3 = LayoutFragmentFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.ChildFragments = value3
-	value4 = input.Get("data")
+	value4 = value.Get("data")
 	out.Data = value4
-	value5 = BreakTokenOptionsFromJS(input.Get("breakToken"))
+	value5 = BreakTokenOptionsFromJS(value.Get("breakToken"))
 	out.BreakToken = value5
 	return &out
 }
@@ -500,7 +497,7 @@ type IntrinsicSizesResultOptions struct {
 	MinContentSize float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntrinsicSizesResultOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -512,18 +509,16 @@ func (_this *IntrinsicSizesResultOptions) JSValue() js.Value {
 }
 
 // IntrinsicSizesResultOptionsFromJS is allocating a new
-// IntrinsicSizesResultOptions object and copy all values from
-// input javascript object
-func IntrinsicSizesResultOptionsFromJS(value js.Wrapper) *IntrinsicSizesResultOptions {
-	input := value.JSValue()
+// IntrinsicSizesResultOptions object and copy all values in the value javascript object.
+func IntrinsicSizesResultOptionsFromJS(value js.Value) *IntrinsicSizesResultOptions {
 	var out IntrinsicSizesResultOptions
 	var (
 		value0 float64 // javascript: double {maxContentSize MaxContentSize maxContentSize}
 		value1 float64 // javascript: double {minContentSize MinContentSize minContentSize}
 	)
-	value0 = (input.Get("maxContentSize")).Float()
+	value0 = (value.Get("maxContentSize")).Float()
 	out.MaxContentSize = value0
-	value1 = (input.Get("minContentSize")).Float()
+	value1 = (value.Get("minContentSize")).Float()
 	out.MinContentSize = value1
 	return &out
 }
@@ -541,7 +536,7 @@ type LayoutConstraintsOptions struct {
 	Data                     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutConstraintsOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -567,10 +562,8 @@ func (_this *LayoutConstraintsOptions) JSValue() js.Value {
 }
 
 // LayoutConstraintsOptionsFromJS is allocating a new
-// LayoutConstraintsOptions object and copy all values from
-// input javascript object
-func LayoutConstraintsOptionsFromJS(value js.Wrapper) *LayoutConstraintsOptions {
-	input := value.JSValue()
+// LayoutConstraintsOptions object and copy all values in the value javascript object.
+func LayoutConstraintsOptionsFromJS(value js.Value) *LayoutConstraintsOptions {
 	var out LayoutConstraintsOptions
 	var (
 		value0 float64                // javascript: double {availableInlineSize AvailableInlineSize availableInlineSize}
@@ -583,23 +576,23 @@ func LayoutConstraintsOptionsFromJS(value js.Wrapper) *LayoutConstraintsOptions 
 		value7 BlockFragmentationType // javascript: BlockFragmentationType {blockFragmentationType BlockFragmentationType blockFragmentationType}
 		value8 js.Value               // javascript: any {data Data data}
 	)
-	value0 = (input.Get("availableInlineSize")).Float()
+	value0 = (value.Get("availableInlineSize")).Float()
 	out.AvailableInlineSize = value0
-	value1 = (input.Get("availableBlockSize")).Float()
+	value1 = (value.Get("availableBlockSize")).Float()
 	out.AvailableBlockSize = value1
-	value2 = (input.Get("fixedInlineSize")).Float()
+	value2 = (value.Get("fixedInlineSize")).Float()
 	out.FixedInlineSize = value2
-	value3 = (input.Get("fixedBlockSize")).Float()
+	value3 = (value.Get("fixedBlockSize")).Float()
 	out.FixedBlockSize = value3
-	value4 = (input.Get("percentageInlineSize")).Float()
+	value4 = (value.Get("percentageInlineSize")).Float()
 	out.PercentageInlineSize = value4
-	value5 = (input.Get("percentageBlockSize")).Float()
+	value5 = (value.Get("percentageBlockSize")).Float()
 	out.PercentageBlockSize = value5
-	value6 = (input.Get("blockFragmentationOffset")).Float()
+	value6 = (value.Get("blockFragmentationOffset")).Float()
 	out.BlockFragmentationOffset = value6
-	value7 = BlockFragmentationTypeFromJS(input.Get("blockFragmentationType"))
+	value7 = BlockFragmentationTypeFromJS(value.Get("blockFragmentationType"))
 	out.BlockFragmentationType = value7
-	value8 = input.Get("data")
+	value8 = value.Get("data")
 	out.Data = value8
 	return &out
 }
@@ -610,7 +603,7 @@ type LayoutOptions struct {
 	Sizing       LayoutSizingMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -622,18 +615,16 @@ func (_this *LayoutOptions) JSValue() js.Value {
 }
 
 // LayoutOptionsFromJS is allocating a new
-// LayoutOptions object and copy all values from
-// input javascript object
-func LayoutOptionsFromJS(value js.Wrapper) *LayoutOptions {
-	input := value.JSValue()
+// LayoutOptions object and copy all values in the value javascript object.
+func LayoutOptionsFromJS(value js.Value) *LayoutOptions {
 	var out LayoutOptions
 	var (
 		value0 ChildDisplayType // javascript: ChildDisplayType {childDisplay ChildDisplay childDisplay}
 		value1 LayoutSizingMode // javascript: LayoutSizingMode {sizing Sizing sizing}
 	)
-	value0 = ChildDisplayTypeFromJS(input.Get("childDisplay"))
+	value0 = ChildDisplayTypeFromJS(value.Get("childDisplay"))
 	out.ChildDisplay = value0
-	value1 = LayoutSizingModeFromJS(input.Get("sizing"))
+	value1 = LayoutSizingModeFromJS(value.Get("sizing"))
 	out.Sizing = value1
 	return &out
 }
@@ -648,15 +639,19 @@ func (_this *BreakToken) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BreakTokenFromJS is casting a js.Wrapper into BreakToken.
-func BreakTokenFromJS(value js.Wrapper) *BreakToken {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BreakTokenFromJS is casting a js.Value into BreakToken.
+func BreakTokenFromJS(value js.Value) *BreakToken {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BreakToken{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BreakTokenFromJS is casting from something that holds a js.Value into BreakToken.
+func BreakTokenFromWrapper(input core.Wrapper) *BreakToken {
+	return BreakTokenFromJS(input.JSValue())
 }
 
 // ChildBreakTokens returning attribute 'childBreakTokens' with
@@ -687,15 +682,19 @@ func (_this *ChildBreakToken) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ChildBreakTokenFromJS is casting a js.Wrapper into ChildBreakToken.
-func ChildBreakTokenFromJS(value js.Wrapper) *ChildBreakToken {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChildBreakTokenFromJS is casting a js.Value into ChildBreakToken.
+func ChildBreakTokenFromJS(value js.Value) *ChildBreakToken {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChildBreakToken{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChildBreakTokenFromJS is casting from something that holds a js.Value into ChildBreakToken.
+func ChildBreakTokenFromWrapper(input core.Wrapper) *ChildBreakToken {
+	return ChildBreakTokenFromJS(input.JSValue())
 }
 
 // BreakType returning attribute 'breakType' with
@@ -726,15 +725,19 @@ func (_this *FragmentResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FragmentResultFromJS is casting a js.Wrapper into FragmentResult.
-func FragmentResultFromJS(value js.Wrapper) *FragmentResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FragmentResultFromJS is casting a js.Value into FragmentResult.
+func FragmentResultFromJS(value js.Value) *FragmentResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FragmentResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FragmentResultFromJS is casting from something that holds a js.Value into FragmentResult.
+func FragmentResultFromWrapper(input core.Wrapper) *FragmentResult {
+	return FragmentResultFromJS(input.JSValue())
 }
 
 func NewFragmentResult(options *FragmentResultOptions) (_result *FragmentResult) {
@@ -783,15 +786,19 @@ func (_this *IntrinsicSizes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntrinsicSizesFromJS is casting a js.Wrapper into IntrinsicSizes.
-func IntrinsicSizesFromJS(value js.Wrapper) *IntrinsicSizes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntrinsicSizesFromJS is casting a js.Value into IntrinsicSizes.
+func IntrinsicSizesFromJS(value js.Value) *IntrinsicSizes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntrinsicSizes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntrinsicSizesFromJS is casting from something that holds a js.Value into IntrinsicSizes.
+func IntrinsicSizesFromWrapper(input core.Wrapper) *IntrinsicSizes {
+	return IntrinsicSizesFromJS(input.JSValue())
 }
 
 // MinContentSize returning attribute 'minContentSize' with
@@ -822,15 +829,19 @@ func (_this *LayoutChild) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutChildFromJS is casting a js.Wrapper into LayoutChild.
-func LayoutChildFromJS(value js.Wrapper) *LayoutChild {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutChildFromJS is casting a js.Value into LayoutChild.
+func LayoutChildFromJS(value js.Value) *LayoutChild {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutChild{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutChildFromJS is casting from something that holds a js.Value into LayoutChild.
+func LayoutChildFromWrapper(input core.Wrapper) *LayoutChild {
+	return LayoutChildFromJS(input.JSValue())
 }
 
 // StyleMap returning attribute 'styleMap' with
@@ -886,15 +897,19 @@ func (_this *LayoutConstraints) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutConstraintsFromJS is casting a js.Wrapper into LayoutConstraints.
-func LayoutConstraintsFromJS(value js.Wrapper) *LayoutConstraints {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutConstraintsFromJS is casting a js.Value into LayoutConstraints.
+func LayoutConstraintsFromJS(value js.Value) *LayoutConstraints {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutConstraints{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutConstraintsFromJS is casting from something that holds a js.Value into LayoutConstraints.
+func LayoutConstraintsFromWrapper(input core.Wrapper) *LayoutConstraints {
+	return LayoutConstraintsFromJS(input.JSValue())
 }
 
 // AvailableInlineSize returning attribute 'availableInlineSize' with
@@ -997,15 +1012,19 @@ func (_this *LayoutEdges) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutEdgesFromJS is casting a js.Wrapper into LayoutEdges.
-func LayoutEdgesFromJS(value js.Wrapper) *LayoutEdges {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutEdgesFromJS is casting a js.Value into LayoutEdges.
+func LayoutEdgesFromJS(value js.Value) *LayoutEdges {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutEdges{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutEdgesFromJS is casting from something that holds a js.Value into LayoutEdges.
+func LayoutEdgesFromWrapper(input core.Wrapper) *LayoutEdges {
+	return LayoutEdgesFromJS(input.JSValue())
 }
 
 // InlineStart returning attribute 'inlineStart' with
@@ -1072,15 +1091,19 @@ func (_this *LayoutFragment) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutFragmentFromJS is casting a js.Wrapper into LayoutFragment.
-func LayoutFragmentFromJS(value js.Wrapper) *LayoutFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutFragmentFromJS is casting a js.Value into LayoutFragment.
+func LayoutFragmentFromJS(value js.Value) *LayoutFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutFragmentFromJS is casting from something that holds a js.Value into LayoutFragment.
+func LayoutFragmentFromWrapper(input core.Wrapper) *LayoutFragment {
+	return LayoutFragmentFromJS(input.JSValue())
 }
 
 // InlineSize returning attribute 'inlineSize' with
@@ -1158,15 +1181,19 @@ type LayoutWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// LayoutWorkletGlobalScopeFromJS is casting a js.Wrapper into LayoutWorkletGlobalScope.
-func LayoutWorkletGlobalScopeFromJS(value js.Wrapper) *LayoutWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutWorkletGlobalScopeFromJS is casting a js.Value into LayoutWorkletGlobalScope.
+func LayoutWorkletGlobalScopeFromJS(value js.Value) *LayoutWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutWorkletGlobalScopeFromJS is casting from something that holds a js.Value into LayoutWorkletGlobalScope.
+func LayoutWorkletGlobalScopeFromWrapper(input core.Wrapper) *LayoutWorkletGlobalScope {
+	return LayoutWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 func (_this *LayoutWorkletGlobalScope) RegisterLayout(name string, layoutCtor *webidl.VoidFunction) {
@@ -1201,15 +1228,19 @@ func (_this *PromiseIntrinsicSizes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseIntrinsicSizesFromJS is casting a js.Wrapper into PromiseIntrinsicSizes.
-func PromiseIntrinsicSizesFromJS(value js.Wrapper) *PromiseIntrinsicSizes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseIntrinsicSizesFromJS is casting a js.Value into PromiseIntrinsicSizes.
+func PromiseIntrinsicSizesFromJS(value js.Value) *PromiseIntrinsicSizes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseIntrinsicSizes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseIntrinsicSizesFromJS is casting from something that holds a js.Value into PromiseIntrinsicSizes.
+func PromiseIntrinsicSizesFromWrapper(input core.Wrapper) *PromiseIntrinsicSizes {
+	return PromiseIntrinsicSizesFromJS(input.JSValue())
 }
 
 func (_this *PromiseIntrinsicSizes) Then(onFulfilled *PromiseIntrinsicSizesOnFulfilled, onRejected *PromiseIntrinsicSizesOnRejected) (_result *PromiseIntrinsicSizes) {
@@ -1306,15 +1337,19 @@ func (_this *PromiseLayoutFragment) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseLayoutFragmentFromJS is casting a js.Wrapper into PromiseLayoutFragment.
-func PromiseLayoutFragmentFromJS(value js.Wrapper) *PromiseLayoutFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseLayoutFragmentFromJS is casting a js.Value into PromiseLayoutFragment.
+func PromiseLayoutFragmentFromJS(value js.Value) *PromiseLayoutFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseLayoutFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseLayoutFragmentFromJS is casting from something that holds a js.Value into PromiseLayoutFragment.
+func PromiseLayoutFragmentFromWrapper(input core.Wrapper) *PromiseLayoutFragment {
+	return PromiseLayoutFragmentFromJS(input.JSValue())
 }
 
 func (_this *PromiseLayoutFragment) Then(onFulfilled *PromiseLayoutFragmentOnFulfilled, onRejected *PromiseLayoutFragmentOnRejected) (_result *PromiseLayoutFragment) {

--- a/css/layout/layout_js.go
+++ b/css/layout/layout_js.go
@@ -5,6 +5,7 @@ package layout
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/typedom"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/webidl"
@@ -382,7 +383,7 @@ type BreakTokenOptions struct {
 	Data             js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BreakTokenOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -398,26 +399,24 @@ func (_this *BreakTokenOptions) JSValue() js.Value {
 }
 
 // BreakTokenOptionsFromJS is allocating a new
-// BreakTokenOptions object and copy all values from
-// input javascript object
-func BreakTokenOptionsFromJS(value js.Wrapper) *BreakTokenOptions {
-	input := value.JSValue()
+// BreakTokenOptions object and copy all values in the value javascript object.
+func BreakTokenOptionsFromJS(value js.Value) *BreakTokenOptions {
 	var out BreakTokenOptions
 	var (
 		value0 []*ChildBreakToken // javascript: sequence<ChildBreakToken> {childBreakTokens ChildBreakTokens childBreakTokens}
 		value1 js.Value           // javascript: any {data Data data}
 	)
-	__length0 := input.Get("childBreakTokens").Length()
+	__length0 := value.Get("childBreakTokens").Length()
 	__array0 := make([]*ChildBreakToken, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *ChildBreakToken
-		__seq_in0 := input.Get("childBreakTokens").Index(__idx0)
+		__seq_in0 := value.Get("childBreakTokens").Index(__idx0)
 		__seq_out0 = ChildBreakTokenFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.ChildBreakTokens = value0
-	value1 = input.Get("data")
+	value1 = value.Get("data")
 	out.Data = value1
 	return &out
 }
@@ -432,7 +431,7 @@ type FragmentResultOptions struct {
 	BreakToken     *BreakTokenOptions
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FragmentResultOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -456,10 +455,8 @@ func (_this *FragmentResultOptions) JSValue() js.Value {
 }
 
 // FragmentResultOptionsFromJS is allocating a new
-// FragmentResultOptions object and copy all values from
-// input javascript object
-func FragmentResultOptionsFromJS(value js.Wrapper) *FragmentResultOptions {
-	input := value.JSValue()
+// FragmentResultOptions object and copy all values in the value javascript object.
+func FragmentResultOptionsFromJS(value js.Value) *FragmentResultOptions {
 	var out FragmentResultOptions
 	var (
 		value0 float64            // javascript: double {inlineSize InlineSize inlineSize}
@@ -469,25 +466,25 @@ func FragmentResultOptionsFromJS(value js.Wrapper) *FragmentResultOptions {
 		value4 js.Value           // javascript: any {data Data data}
 		value5 *BreakTokenOptions // javascript: BreakTokenOptions {breakToken BreakToken breakToken}
 	)
-	value0 = (input.Get("inlineSize")).Float()
+	value0 = (value.Get("inlineSize")).Float()
 	out.InlineSize = value0
-	value1 = (input.Get("blockSize")).Float()
+	value1 = (value.Get("blockSize")).Float()
 	out.BlockSize = value1
-	value2 = (input.Get("autoBlockSize")).Float()
+	value2 = (value.Get("autoBlockSize")).Float()
 	out.AutoBlockSize = value2
-	__length3 := input.Get("childFragments").Length()
+	__length3 := value.Get("childFragments").Length()
 	__array3 := make([]*LayoutFragment, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *LayoutFragment
-		__seq_in3 := input.Get("childFragments").Index(__idx3)
+		__seq_in3 := value.Get("childFragments").Index(__idx3)
 		__seq_out3 = LayoutFragmentFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.ChildFragments = value3
-	value4 = input.Get("data")
+	value4 = value.Get("data")
 	out.Data = value4
-	value5 = BreakTokenOptionsFromJS(input.Get("breakToken"))
+	value5 = BreakTokenOptionsFromJS(value.Get("breakToken"))
 	out.BreakToken = value5
 	return &out
 }
@@ -498,7 +495,7 @@ type IntrinsicSizesResultOptions struct {
 	MinContentSize float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntrinsicSizesResultOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -510,18 +507,16 @@ func (_this *IntrinsicSizesResultOptions) JSValue() js.Value {
 }
 
 // IntrinsicSizesResultOptionsFromJS is allocating a new
-// IntrinsicSizesResultOptions object and copy all values from
-// input javascript object
-func IntrinsicSizesResultOptionsFromJS(value js.Wrapper) *IntrinsicSizesResultOptions {
-	input := value.JSValue()
+// IntrinsicSizesResultOptions object and copy all values in the value javascript object.
+func IntrinsicSizesResultOptionsFromJS(value js.Value) *IntrinsicSizesResultOptions {
 	var out IntrinsicSizesResultOptions
 	var (
 		value0 float64 // javascript: double {maxContentSize MaxContentSize maxContentSize}
 		value1 float64 // javascript: double {minContentSize MinContentSize minContentSize}
 	)
-	value0 = (input.Get("maxContentSize")).Float()
+	value0 = (value.Get("maxContentSize")).Float()
 	out.MaxContentSize = value0
-	value1 = (input.Get("minContentSize")).Float()
+	value1 = (value.Get("minContentSize")).Float()
 	out.MinContentSize = value1
 	return &out
 }
@@ -539,7 +534,7 @@ type LayoutConstraintsOptions struct {
 	Data                     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutConstraintsOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -565,10 +560,8 @@ func (_this *LayoutConstraintsOptions) JSValue() js.Value {
 }
 
 // LayoutConstraintsOptionsFromJS is allocating a new
-// LayoutConstraintsOptions object and copy all values from
-// input javascript object
-func LayoutConstraintsOptionsFromJS(value js.Wrapper) *LayoutConstraintsOptions {
-	input := value.JSValue()
+// LayoutConstraintsOptions object and copy all values in the value javascript object.
+func LayoutConstraintsOptionsFromJS(value js.Value) *LayoutConstraintsOptions {
 	var out LayoutConstraintsOptions
 	var (
 		value0 float64                // javascript: double {availableInlineSize AvailableInlineSize availableInlineSize}
@@ -581,23 +574,23 @@ func LayoutConstraintsOptionsFromJS(value js.Wrapper) *LayoutConstraintsOptions 
 		value7 BlockFragmentationType // javascript: BlockFragmentationType {blockFragmentationType BlockFragmentationType blockFragmentationType}
 		value8 js.Value               // javascript: any {data Data data}
 	)
-	value0 = (input.Get("availableInlineSize")).Float()
+	value0 = (value.Get("availableInlineSize")).Float()
 	out.AvailableInlineSize = value0
-	value1 = (input.Get("availableBlockSize")).Float()
+	value1 = (value.Get("availableBlockSize")).Float()
 	out.AvailableBlockSize = value1
-	value2 = (input.Get("fixedInlineSize")).Float()
+	value2 = (value.Get("fixedInlineSize")).Float()
 	out.FixedInlineSize = value2
-	value3 = (input.Get("fixedBlockSize")).Float()
+	value3 = (value.Get("fixedBlockSize")).Float()
 	out.FixedBlockSize = value3
-	value4 = (input.Get("percentageInlineSize")).Float()
+	value4 = (value.Get("percentageInlineSize")).Float()
 	out.PercentageInlineSize = value4
-	value5 = (input.Get("percentageBlockSize")).Float()
+	value5 = (value.Get("percentageBlockSize")).Float()
 	out.PercentageBlockSize = value5
-	value6 = (input.Get("blockFragmentationOffset")).Float()
+	value6 = (value.Get("blockFragmentationOffset")).Float()
 	out.BlockFragmentationOffset = value6
-	value7 = BlockFragmentationTypeFromJS(input.Get("blockFragmentationType"))
+	value7 = BlockFragmentationTypeFromJS(value.Get("blockFragmentationType"))
 	out.BlockFragmentationType = value7
-	value8 = input.Get("data")
+	value8 = value.Get("data")
 	out.Data = value8
 	return &out
 }
@@ -608,7 +601,7 @@ type LayoutOptions struct {
 	Sizing       LayoutSizingMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -620,18 +613,16 @@ func (_this *LayoutOptions) JSValue() js.Value {
 }
 
 // LayoutOptionsFromJS is allocating a new
-// LayoutOptions object and copy all values from
-// input javascript object
-func LayoutOptionsFromJS(value js.Wrapper) *LayoutOptions {
-	input := value.JSValue()
+// LayoutOptions object and copy all values in the value javascript object.
+func LayoutOptionsFromJS(value js.Value) *LayoutOptions {
 	var out LayoutOptions
 	var (
 		value0 ChildDisplayType // javascript: ChildDisplayType {childDisplay ChildDisplay childDisplay}
 		value1 LayoutSizingMode // javascript: LayoutSizingMode {sizing Sizing sizing}
 	)
-	value0 = ChildDisplayTypeFromJS(input.Get("childDisplay"))
+	value0 = ChildDisplayTypeFromJS(value.Get("childDisplay"))
 	out.ChildDisplay = value0
-	value1 = LayoutSizingModeFromJS(input.Get("sizing"))
+	value1 = LayoutSizingModeFromJS(value.Get("sizing"))
 	out.Sizing = value1
 	return &out
 }
@@ -646,15 +637,19 @@ func (_this *BreakToken) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BreakTokenFromJS is casting a js.Wrapper into BreakToken.
-func BreakTokenFromJS(value js.Wrapper) *BreakToken {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BreakTokenFromJS is casting a js.Value into BreakToken.
+func BreakTokenFromJS(value js.Value) *BreakToken {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BreakToken{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BreakTokenFromJS is casting from something that holds a js.Value into BreakToken.
+func BreakTokenFromWrapper(input core.Wrapper) *BreakToken {
+	return BreakTokenFromJS(input.JSValue())
 }
 
 // ChildBreakTokens returning attribute 'childBreakTokens' with
@@ -685,15 +680,19 @@ func (_this *ChildBreakToken) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ChildBreakTokenFromJS is casting a js.Wrapper into ChildBreakToken.
-func ChildBreakTokenFromJS(value js.Wrapper) *ChildBreakToken {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChildBreakTokenFromJS is casting a js.Value into ChildBreakToken.
+func ChildBreakTokenFromJS(value js.Value) *ChildBreakToken {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChildBreakToken{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChildBreakTokenFromJS is casting from something that holds a js.Value into ChildBreakToken.
+func ChildBreakTokenFromWrapper(input core.Wrapper) *ChildBreakToken {
+	return ChildBreakTokenFromJS(input.JSValue())
 }
 
 // BreakType returning attribute 'breakType' with
@@ -724,15 +723,19 @@ func (_this *FragmentResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FragmentResultFromJS is casting a js.Wrapper into FragmentResult.
-func FragmentResultFromJS(value js.Wrapper) *FragmentResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FragmentResultFromJS is casting a js.Value into FragmentResult.
+func FragmentResultFromJS(value js.Value) *FragmentResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FragmentResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FragmentResultFromJS is casting from something that holds a js.Value into FragmentResult.
+func FragmentResultFromWrapper(input core.Wrapper) *FragmentResult {
+	return FragmentResultFromJS(input.JSValue())
 }
 
 func NewFragmentResult(options *FragmentResultOptions) (_result *FragmentResult) {
@@ -781,15 +784,19 @@ func (_this *IntrinsicSizes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntrinsicSizesFromJS is casting a js.Wrapper into IntrinsicSizes.
-func IntrinsicSizesFromJS(value js.Wrapper) *IntrinsicSizes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntrinsicSizesFromJS is casting a js.Value into IntrinsicSizes.
+func IntrinsicSizesFromJS(value js.Value) *IntrinsicSizes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntrinsicSizes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntrinsicSizesFromJS is casting from something that holds a js.Value into IntrinsicSizes.
+func IntrinsicSizesFromWrapper(input core.Wrapper) *IntrinsicSizes {
+	return IntrinsicSizesFromJS(input.JSValue())
 }
 
 // MinContentSize returning attribute 'minContentSize' with
@@ -820,15 +827,19 @@ func (_this *LayoutChild) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutChildFromJS is casting a js.Wrapper into LayoutChild.
-func LayoutChildFromJS(value js.Wrapper) *LayoutChild {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutChildFromJS is casting a js.Value into LayoutChild.
+func LayoutChildFromJS(value js.Value) *LayoutChild {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutChild{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutChildFromJS is casting from something that holds a js.Value into LayoutChild.
+func LayoutChildFromWrapper(input core.Wrapper) *LayoutChild {
+	return LayoutChildFromJS(input.JSValue())
 }
 
 // StyleMap returning attribute 'styleMap' with
@@ -884,15 +895,19 @@ func (_this *LayoutConstraints) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutConstraintsFromJS is casting a js.Wrapper into LayoutConstraints.
-func LayoutConstraintsFromJS(value js.Wrapper) *LayoutConstraints {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutConstraintsFromJS is casting a js.Value into LayoutConstraints.
+func LayoutConstraintsFromJS(value js.Value) *LayoutConstraints {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutConstraints{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutConstraintsFromJS is casting from something that holds a js.Value into LayoutConstraints.
+func LayoutConstraintsFromWrapper(input core.Wrapper) *LayoutConstraints {
+	return LayoutConstraintsFromJS(input.JSValue())
 }
 
 // AvailableInlineSize returning attribute 'availableInlineSize' with
@@ -995,15 +1010,19 @@ func (_this *LayoutEdges) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutEdgesFromJS is casting a js.Wrapper into LayoutEdges.
-func LayoutEdgesFromJS(value js.Wrapper) *LayoutEdges {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutEdgesFromJS is casting a js.Value into LayoutEdges.
+func LayoutEdgesFromJS(value js.Value) *LayoutEdges {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutEdges{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutEdgesFromJS is casting from something that holds a js.Value into LayoutEdges.
+func LayoutEdgesFromWrapper(input core.Wrapper) *LayoutEdges {
+	return LayoutEdgesFromJS(input.JSValue())
 }
 
 // InlineStart returning attribute 'inlineStart' with
@@ -1070,15 +1089,19 @@ func (_this *LayoutFragment) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutFragmentFromJS is casting a js.Wrapper into LayoutFragment.
-func LayoutFragmentFromJS(value js.Wrapper) *LayoutFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutFragmentFromJS is casting a js.Value into LayoutFragment.
+func LayoutFragmentFromJS(value js.Value) *LayoutFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutFragmentFromJS is casting from something that holds a js.Value into LayoutFragment.
+func LayoutFragmentFromWrapper(input core.Wrapper) *LayoutFragment {
+	return LayoutFragmentFromJS(input.JSValue())
 }
 
 // InlineSize returning attribute 'inlineSize' with
@@ -1156,15 +1179,19 @@ type LayoutWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// LayoutWorkletGlobalScopeFromJS is casting a js.Wrapper into LayoutWorkletGlobalScope.
-func LayoutWorkletGlobalScopeFromJS(value js.Wrapper) *LayoutWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutWorkletGlobalScopeFromJS is casting a js.Value into LayoutWorkletGlobalScope.
+func LayoutWorkletGlobalScopeFromJS(value js.Value) *LayoutWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutWorkletGlobalScopeFromJS is casting from something that holds a js.Value into LayoutWorkletGlobalScope.
+func LayoutWorkletGlobalScopeFromWrapper(input core.Wrapper) *LayoutWorkletGlobalScope {
+	return LayoutWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 func (_this *LayoutWorkletGlobalScope) RegisterLayout(name string, layoutCtor *webidl.VoidFunction) {
@@ -1199,15 +1226,19 @@ func (_this *PromiseIntrinsicSizes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseIntrinsicSizesFromJS is casting a js.Wrapper into PromiseIntrinsicSizes.
-func PromiseIntrinsicSizesFromJS(value js.Wrapper) *PromiseIntrinsicSizes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseIntrinsicSizesFromJS is casting a js.Value into PromiseIntrinsicSizes.
+func PromiseIntrinsicSizesFromJS(value js.Value) *PromiseIntrinsicSizes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseIntrinsicSizes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseIntrinsicSizesFromJS is casting from something that holds a js.Value into PromiseIntrinsicSizes.
+func PromiseIntrinsicSizesFromWrapper(input core.Wrapper) *PromiseIntrinsicSizes {
+	return PromiseIntrinsicSizesFromJS(input.JSValue())
 }
 
 func (_this *PromiseIntrinsicSizes) Then(onFulfilled *PromiseIntrinsicSizesOnFulfilled, onRejected *PromiseIntrinsicSizesOnRejected) (_result *PromiseIntrinsicSizes) {
@@ -1304,15 +1335,19 @@ func (_this *PromiseLayoutFragment) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseLayoutFragmentFromJS is casting a js.Wrapper into PromiseLayoutFragment.
-func PromiseLayoutFragmentFromJS(value js.Wrapper) *PromiseLayoutFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseLayoutFragmentFromJS is casting a js.Value into PromiseLayoutFragment.
+func PromiseLayoutFragmentFromJS(value js.Value) *PromiseLayoutFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseLayoutFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseLayoutFragmentFromJS is casting from something that holds a js.Value into PromiseLayoutFragment.
+func PromiseLayoutFragmentFromWrapper(input core.Wrapper) *PromiseLayoutFragment {
+	return PromiseLayoutFragmentFromJS(input.JSValue())
 }
 
 func (_this *PromiseLayoutFragment) Then(onFulfilled *PromiseLayoutFragmentOnFulfilled, onRejected *PromiseLayoutFragmentOnRejected) (_result *PromiseLayoutFragment) {

--- a/css/masking/masking.go
+++ b/css/masking/masking.go
@@ -7,6 +7,7 @@ package masking
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/svg"
 )
 
@@ -44,15 +45,19 @@ type SVGClipPathElement struct {
 	svg.SVGElement
 }
 
-// SVGClipPathElementFromJS is casting a js.Wrapper into SVGClipPathElement.
-func SVGClipPathElementFromJS(value js.Wrapper) *SVGClipPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGClipPathElementFromJS is casting a js.Value into SVGClipPathElement.
+func SVGClipPathElementFromJS(value js.Value) *SVGClipPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGClipPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGClipPathElementFromJS is casting from something that holds a js.Value into SVGClipPathElement.
+func SVGClipPathElementFromWrapper(input core.Wrapper) *SVGClipPathElement {
+	return SVGClipPathElementFromJS(input.JSValue())
 }
 
 // ClipPathUnits returning attribute 'clipPathUnits' with
@@ -78,15 +83,19 @@ type SVGMaskElement struct {
 	svg.SVGElement
 }
 
-// SVGMaskElementFromJS is casting a js.Wrapper into SVGMaskElement.
-func SVGMaskElementFromJS(value js.Wrapper) *SVGMaskElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMaskElementFromJS is casting a js.Value into SVGMaskElement.
+func SVGMaskElementFromJS(value js.Value) *SVGMaskElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMaskElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMaskElementFromJS is casting from something that holds a js.Value into SVGMaskElement.
+func SVGMaskElementFromWrapper(input core.Wrapper) *SVGMaskElement {
+	return SVGMaskElementFromJS(input.JSValue())
 }
 
 // MaskUnits returning attribute 'maskUnits' with

--- a/css/masking/masking_js.go
+++ b/css/masking/masking_js.go
@@ -5,6 +5,7 @@ package masking
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/svg"
 )
 
@@ -42,15 +43,19 @@ type SVGClipPathElement struct {
 	svg.SVGElement
 }
 
-// SVGClipPathElementFromJS is casting a js.Wrapper into SVGClipPathElement.
-func SVGClipPathElementFromJS(value js.Wrapper) *SVGClipPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGClipPathElementFromJS is casting a js.Value into SVGClipPathElement.
+func SVGClipPathElementFromJS(value js.Value) *SVGClipPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGClipPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGClipPathElementFromJS is casting from something that holds a js.Value into SVGClipPathElement.
+func SVGClipPathElementFromWrapper(input core.Wrapper) *SVGClipPathElement {
+	return SVGClipPathElementFromJS(input.JSValue())
 }
 
 // ClipPathUnits returning attribute 'clipPathUnits' with
@@ -76,15 +81,19 @@ type SVGMaskElement struct {
 	svg.SVGElement
 }
 
-// SVGMaskElementFromJS is casting a js.Wrapper into SVGMaskElement.
-func SVGMaskElementFromJS(value js.Wrapper) *SVGMaskElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMaskElementFromJS is casting a js.Value into SVGMaskElement.
+func SVGMaskElementFromJS(value js.Value) *SVGMaskElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMaskElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMaskElementFromJS is casting from something that holds a js.Value into SVGMaskElement.
+func SVGMaskElementFromWrapper(input core.Wrapper) *SVGMaskElement {
+	return SVGMaskElementFromJS(input.JSValue())
 }
 
 // MaskUnits returning attribute 'maskUnits' with

--- a/css/paint/paint.go
+++ b/css/paint/paint.go
@@ -7,6 +7,7 @@ package paint
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/html/canvas"
@@ -55,7 +56,7 @@ type PaintRenderingContext2DSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaintRenderingContext2DSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -65,15 +66,13 @@ func (_this *PaintRenderingContext2DSettings) JSValue() js.Value {
 }
 
 // PaintRenderingContext2DSettingsFromJS is allocating a new
-// PaintRenderingContext2DSettings object and copy all values from
-// input javascript object
-func PaintRenderingContext2DSettingsFromJS(value js.Wrapper) *PaintRenderingContext2DSettings {
-	input := value.JSValue()
+// PaintRenderingContext2DSettings object and copy all values in the value javascript object.
+func PaintRenderingContext2DSettingsFromJS(value js.Value) *PaintRenderingContext2DSettings {
 	var out PaintRenderingContext2DSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -88,15 +87,19 @@ func (_this *PaintRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaintRenderingContext2DFromJS is casting a js.Wrapper into PaintRenderingContext2D.
-func PaintRenderingContext2DFromJS(value js.Wrapper) *PaintRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintRenderingContext2DFromJS is casting a js.Value into PaintRenderingContext2D.
+func PaintRenderingContext2DFromJS(value js.Value) *PaintRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintRenderingContext2DFromJS is casting from something that holds a js.Value into PaintRenderingContext2D.
+func PaintRenderingContext2DFromWrapper(input core.Wrapper) *PaintRenderingContext2D {
+	return PaintRenderingContext2DFromJS(input.JSValue())
 }
 
 // GlobalAlpha returning attribute 'globalAlpha' with
@@ -1143,15 +1146,19 @@ func (_this *PaintSize) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaintSizeFromJS is casting a js.Wrapper into PaintSize.
-func PaintSizeFromJS(value js.Wrapper) *PaintSize {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintSizeFromJS is casting a js.Value into PaintSize.
+func PaintSizeFromJS(value js.Value) *PaintSize {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintSize{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintSizeFromJS is casting from something that holds a js.Value into PaintSize.
+func PaintSizeFromWrapper(input core.Wrapper) *PaintSize {
+	return PaintSizeFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -1177,15 +1184,19 @@ type PaintWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// PaintWorkletGlobalScopeFromJS is casting a js.Wrapper into PaintWorkletGlobalScope.
-func PaintWorkletGlobalScopeFromJS(value js.Wrapper) *PaintWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintWorkletGlobalScopeFromJS is casting a js.Value into PaintWorkletGlobalScope.
+func PaintWorkletGlobalScopeFromJS(value js.Value) *PaintWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintWorkletGlobalScopeFromJS is casting from something that holds a js.Value into PaintWorkletGlobalScope.
+func PaintWorkletGlobalScopeFromWrapper(input core.Wrapper) *PaintWorkletGlobalScope {
+	return PaintWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 // DevicePixelRatio returning attribute 'devicePixelRatio' with

--- a/css/paint/paint_js.go
+++ b/css/paint/paint_js.go
@@ -5,6 +5,7 @@ package paint
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/html/canvas"
@@ -53,7 +54,7 @@ type PaintRenderingContext2DSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaintRenderingContext2DSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -63,15 +64,13 @@ func (_this *PaintRenderingContext2DSettings) JSValue() js.Value {
 }
 
 // PaintRenderingContext2DSettingsFromJS is allocating a new
-// PaintRenderingContext2DSettings object and copy all values from
-// input javascript object
-func PaintRenderingContext2DSettingsFromJS(value js.Wrapper) *PaintRenderingContext2DSettings {
-	input := value.JSValue()
+// PaintRenderingContext2DSettings object and copy all values in the value javascript object.
+func PaintRenderingContext2DSettingsFromJS(value js.Value) *PaintRenderingContext2DSettings {
 	var out PaintRenderingContext2DSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -86,15 +85,19 @@ func (_this *PaintRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaintRenderingContext2DFromJS is casting a js.Wrapper into PaintRenderingContext2D.
-func PaintRenderingContext2DFromJS(value js.Wrapper) *PaintRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintRenderingContext2DFromJS is casting a js.Value into PaintRenderingContext2D.
+func PaintRenderingContext2DFromJS(value js.Value) *PaintRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintRenderingContext2DFromJS is casting from something that holds a js.Value into PaintRenderingContext2D.
+func PaintRenderingContext2DFromWrapper(input core.Wrapper) *PaintRenderingContext2D {
+	return PaintRenderingContext2DFromJS(input.JSValue())
 }
 
 // GlobalAlpha returning attribute 'globalAlpha' with
@@ -1141,15 +1144,19 @@ func (_this *PaintSize) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaintSizeFromJS is casting a js.Wrapper into PaintSize.
-func PaintSizeFromJS(value js.Wrapper) *PaintSize {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintSizeFromJS is casting a js.Value into PaintSize.
+func PaintSizeFromJS(value js.Value) *PaintSize {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintSize{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintSizeFromJS is casting from something that holds a js.Value into PaintSize.
+func PaintSizeFromWrapper(input core.Wrapper) *PaintSize {
+	return PaintSizeFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -1175,15 +1182,19 @@ type PaintWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// PaintWorkletGlobalScopeFromJS is casting a js.Wrapper into PaintWorkletGlobalScope.
-func PaintWorkletGlobalScopeFromJS(value js.Wrapper) *PaintWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaintWorkletGlobalScopeFromJS is casting a js.Value into PaintWorkletGlobalScope.
+func PaintWorkletGlobalScopeFromJS(value js.Value) *PaintWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaintWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaintWorkletGlobalScopeFromJS is casting from something that holds a js.Value into PaintWorkletGlobalScope.
+func PaintWorkletGlobalScopeFromWrapper(input core.Wrapper) *PaintWorkletGlobalScope {
+	return PaintWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 // DevicePixelRatio returning attribute 'devicePixelRatio' with

--- a/css/pseudo/pseudo.go
+++ b/css/pseudo/pseudo.go
@@ -7,6 +7,7 @@ package pseudo
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/css/cssom/view"
@@ -61,15 +62,19 @@ func (_this *CSSPseudoElement) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSPseudoElementFromJS is casting a js.Wrapper into CSSPseudoElement.
-func CSSPseudoElementFromJS(value js.Wrapper) *CSSPseudoElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPseudoElementFromJS is casting a js.Value into CSSPseudoElement.
+func CSSPseudoElementFromJS(value js.Value) *CSSPseudoElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPseudoElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPseudoElementFromJS is casting from something that holds a js.Value into CSSPseudoElement.
+func CSSPseudoElementFromWrapper(input core.Wrapper) *CSSPseudoElement {
+	return CSSPseudoElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -255,15 +260,19 @@ func (_this *CSSPseudoElementList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSPseudoElementListFromJS is casting a js.Wrapper into CSSPseudoElementList.
-func CSSPseudoElementListFromJS(value js.Wrapper) *CSSPseudoElementList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPseudoElementListFromJS is casting a js.Value into CSSPseudoElementList.
+func CSSPseudoElementListFromJS(value js.Value) *CSSPseudoElementList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPseudoElementList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPseudoElementListFromJS is casting from something that holds a js.Value into CSSPseudoElementList.
+func CSSPseudoElementListFromWrapper(input core.Wrapper) *CSSPseudoElementList {
+	return CSSPseudoElementListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/css/pseudo/pseudo_js.go
+++ b/css/pseudo/pseudo_js.go
@@ -5,6 +5,7 @@ package pseudo
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/css/cssom/view"
@@ -59,15 +60,19 @@ func (_this *CSSPseudoElement) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSPseudoElementFromJS is casting a js.Wrapper into CSSPseudoElement.
-func CSSPseudoElementFromJS(value js.Wrapper) *CSSPseudoElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPseudoElementFromJS is casting a js.Value into CSSPseudoElement.
+func CSSPseudoElementFromJS(value js.Value) *CSSPseudoElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPseudoElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPseudoElementFromJS is casting from something that holds a js.Value into CSSPseudoElement.
+func CSSPseudoElementFromWrapper(input core.Wrapper) *CSSPseudoElement {
+	return CSSPseudoElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -253,15 +258,19 @@ func (_this *CSSPseudoElementList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSPseudoElementListFromJS is casting a js.Wrapper into CSSPseudoElementList.
-func CSSPseudoElementListFromJS(value js.Wrapper) *CSSPseudoElementList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPseudoElementListFromJS is casting a js.Value into CSSPseudoElementList.
+func CSSPseudoElementListFromJS(value js.Value) *CSSPseudoElementList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPseudoElementList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPseudoElementListFromJS is casting from something that holds a js.Value into CSSPseudoElementList.
+func CSSPseudoElementListFromWrapper(input core.Wrapper) *CSSPseudoElementList {
+	return CSSPseudoElementListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/css/regions/regions.go
+++ b/css/regions/regions.go
@@ -7,6 +7,7 @@ package regions
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
@@ -44,15 +45,19 @@ type NamedFlow struct {
 	domcore.EventTarget
 }
 
-// NamedFlowFromJS is casting a js.Wrapper into NamedFlow.
-func NamedFlowFromJS(value js.Wrapper) *NamedFlow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedFlowFromJS is casting a js.Value into NamedFlow.
+func NamedFlowFromJS(value js.Value) *NamedFlow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedFlow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedFlowFromJS is casting from something that holds a js.Value into NamedFlow.
+func NamedFlowFromWrapper(input core.Wrapper) *NamedFlow {
+	return NamedFlowFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -161,15 +166,19 @@ func (_this *NamedFlowMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NamedFlowMapFromJS is casting a js.Wrapper into NamedFlowMap.
-func NamedFlowMapFromJS(value js.Wrapper) *NamedFlowMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedFlowMapFromJS is casting a js.Value into NamedFlowMap.
+func NamedFlowMapFromJS(value js.Value) *NamedFlowMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedFlowMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedFlowMapFromJS is casting from something that holds a js.Value into NamedFlowMap.
+func NamedFlowMapFromWrapper(input core.Wrapper) *NamedFlowMap {
+	return NamedFlowMapFromJS(input.JSValue())
 }
 
 func (_this *NamedFlowMap) Get(flowName string) (_result *NamedFlow) {
@@ -255,15 +264,19 @@ func (_this *Region) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RegionFromJS is casting a js.Wrapper into Region.
-func RegionFromJS(value js.Wrapper) *Region {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RegionFromJS is casting a js.Value into Region.
+func RegionFromJS(value js.Value) *Region {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Region{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RegionFromJS is casting from something that holds a js.Value into Region.
+func RegionFromWrapper(input core.Wrapper) *Region {
+	return RegionFromJS(input.JSValue())
 }
 
 // RegionOverset returning attribute 'regionOverset' with

--- a/css/regions/regions_js.go
+++ b/css/regions/regions_js.go
@@ -5,6 +5,7 @@ package regions
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
@@ -42,15 +43,19 @@ type NamedFlow struct {
 	domcore.EventTarget
 }
 
-// NamedFlowFromJS is casting a js.Wrapper into NamedFlow.
-func NamedFlowFromJS(value js.Wrapper) *NamedFlow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedFlowFromJS is casting a js.Value into NamedFlow.
+func NamedFlowFromJS(value js.Value) *NamedFlow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedFlow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedFlowFromJS is casting from something that holds a js.Value into NamedFlow.
+func NamedFlowFromWrapper(input core.Wrapper) *NamedFlow {
+	return NamedFlowFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -159,15 +164,19 @@ func (_this *NamedFlowMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NamedFlowMapFromJS is casting a js.Wrapper into NamedFlowMap.
-func NamedFlowMapFromJS(value js.Wrapper) *NamedFlowMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedFlowMapFromJS is casting a js.Value into NamedFlowMap.
+func NamedFlowMapFromJS(value js.Value) *NamedFlowMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedFlowMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedFlowMapFromJS is casting from something that holds a js.Value into NamedFlowMap.
+func NamedFlowMapFromWrapper(input core.Wrapper) *NamedFlowMap {
+	return NamedFlowMapFromJS(input.JSValue())
 }
 
 func (_this *NamedFlowMap) Get(flowName string) (_result *NamedFlow) {
@@ -253,15 +262,19 @@ func (_this *Region) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RegionFromJS is casting a js.Wrapper into Region.
-func RegionFromJS(value js.Wrapper) *Region {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RegionFromJS is casting a js.Value into Region.
+func RegionFromJS(value js.Value) *Region {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Region{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RegionFromJS is casting from something that holds a js.Value into Region.
+func RegionFromWrapper(input core.Wrapper) *Region {
+	return RegionFromJS(input.JSValue())
 }
 
 // RegionOverset returning attribute 'regionOverset' with

--- a/css/resizeobserver/resizeobserver.go
+++ b/css/resizeobserver/resizeobserver.go
@@ -7,6 +7,7 @@ package resizeobserver
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/geometry"
 )
@@ -105,15 +106,19 @@ func (_this *ResizeObservation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObservationFromJS is casting a js.Wrapper into ResizeObservation.
-func ResizeObservationFromJS(value js.Wrapper) *ResizeObservation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObservationFromJS is casting a js.Value into ResizeObservation.
+func ResizeObservationFromJS(value js.Value) *ResizeObservation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObservation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObservationFromJS is casting from something that holds a js.Value into ResizeObservation.
+func ResizeObservationFromWrapper(input core.Wrapper) *ResizeObservation {
+	return ResizeObservationFromJS(input.JSValue())
 }
 
 func NewResizeObservation(target *dom.Element) (_result *ResizeObservation) {
@@ -185,15 +190,19 @@ func (_this *ResizeObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObserverFromJS is casting a js.Wrapper into ResizeObserver.
-func ResizeObserverFromJS(value js.Wrapper) *ResizeObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObserverFromJS is casting a js.Value into ResizeObserver.
+func ResizeObserverFromJS(value js.Value) *ResizeObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObserverFromJS is casting from something that holds a js.Value into ResizeObserver.
+func ResizeObserverFromWrapper(input core.Wrapper) *ResizeObserver {
+	return ResizeObserverFromJS(input.JSValue())
 }
 
 func NewResizeObserver(callback *ResizeObserverCallback) (_result *ResizeObserver) {
@@ -264,15 +273,19 @@ func (_this *ResizeObserverEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObserverEntryFromJS is casting a js.Wrapper into ResizeObserverEntry.
-func ResizeObserverEntryFromJS(value js.Wrapper) *ResizeObserverEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObserverEntryFromJS is casting a js.Value into ResizeObserverEntry.
+func ResizeObserverEntryFromJS(value js.Value) *ResizeObserverEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObserverEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObserverEntryFromJS is casting from something that holds a js.Value into ResizeObserverEntry.
+func ResizeObserverEntryFromWrapper(input core.Wrapper) *ResizeObserverEntry {
+	return ResizeObserverEntryFromJS(input.JSValue())
 }
 
 func NewResizeObserverEntry(target *dom.Element) (_result *ResizeObserverEntry) {

--- a/css/resizeobserver/resizeobserver_js.go
+++ b/css/resizeobserver/resizeobserver_js.go
@@ -5,6 +5,7 @@ package resizeobserver
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/geometry"
 )
@@ -103,15 +104,19 @@ func (_this *ResizeObservation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObservationFromJS is casting a js.Wrapper into ResizeObservation.
-func ResizeObservationFromJS(value js.Wrapper) *ResizeObservation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObservationFromJS is casting a js.Value into ResizeObservation.
+func ResizeObservationFromJS(value js.Value) *ResizeObservation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObservation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObservationFromJS is casting from something that holds a js.Value into ResizeObservation.
+func ResizeObservationFromWrapper(input core.Wrapper) *ResizeObservation {
+	return ResizeObservationFromJS(input.JSValue())
 }
 
 func NewResizeObservation(target *dom.Element) (_result *ResizeObservation) {
@@ -183,15 +188,19 @@ func (_this *ResizeObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObserverFromJS is casting a js.Wrapper into ResizeObserver.
-func ResizeObserverFromJS(value js.Wrapper) *ResizeObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObserverFromJS is casting a js.Value into ResizeObserver.
+func ResizeObserverFromJS(value js.Value) *ResizeObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObserverFromJS is casting from something that holds a js.Value into ResizeObserver.
+func ResizeObserverFromWrapper(input core.Wrapper) *ResizeObserver {
+	return ResizeObserverFromJS(input.JSValue())
 }
 
 func NewResizeObserver(callback *ResizeObserverCallback) (_result *ResizeObserver) {
@@ -262,15 +271,19 @@ func (_this *ResizeObserverEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResizeObserverEntryFromJS is casting a js.Wrapper into ResizeObserverEntry.
-func ResizeObserverEntryFromJS(value js.Wrapper) *ResizeObserverEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResizeObserverEntryFromJS is casting a js.Value into ResizeObserverEntry.
+func ResizeObserverEntryFromJS(value js.Value) *ResizeObserverEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResizeObserverEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResizeObserverEntryFromJS is casting from something that holds a js.Value into ResizeObserverEntry.
+func ResizeObserverEntryFromWrapper(input core.Wrapper) *ResizeObserverEntry {
+	return ResizeObserverEntryFromJS(input.JSValue())
 }
 
 func NewResizeObserverEntry(target *dom.Element) (_result *ResizeObserverEntry) {

--- a/css/scrollanimations/scrollanimations.go
+++ b/css/scrollanimations/scrollanimations.go
@@ -7,6 +7,7 @@ package scrollanimations
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/dom"
 )
@@ -134,7 +135,7 @@ type ScrollTimelineOptions struct {
 	Fill              webani.FillMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollTimelineOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -154,10 +155,8 @@ func (_this *ScrollTimelineOptions) JSValue() js.Value {
 }
 
 // ScrollTimelineOptionsFromJS is allocating a new
-// ScrollTimelineOptions object and copy all values from
-// input javascript object
-func ScrollTimelineOptionsFromJS(value js.Wrapper) *ScrollTimelineOptions {
-	input := value.JSValue()
+// ScrollTimelineOptions object and copy all values in the value javascript object.
+func ScrollTimelineOptionsFromJS(value js.Value) *ScrollTimelineOptions {
 	var out ScrollTimelineOptions
 	var (
 		value0 *dom.Element    // javascript: Element {scrollSource ScrollSource scrollSource}
@@ -167,19 +166,19 @@ func ScrollTimelineOptionsFromJS(value js.Wrapper) *ScrollTimelineOptions {
 		value4 *Union          // javascript: Union {timeRange TimeRange timeRange}
 		value5 webani.FillMode // javascript: FillMode {fill Fill fill}
 	)
-	if input.Get("scrollSource").Type() != js.TypeNull && input.Get("scrollSource").Type() != js.TypeUndefined {
-		value0 = dom.ElementFromJS(input.Get("scrollSource"))
+	if value.Get("scrollSource").Type() != js.TypeNull && value.Get("scrollSource").Type() != js.TypeUndefined {
+		value0 = dom.ElementFromJS(value.Get("scrollSource"))
 	}
 	out.ScrollSource = value0
-	value1 = ScrollDirectionFromJS(input.Get("orientation"))
+	value1 = ScrollDirectionFromJS(value.Get("orientation"))
 	out.Orientation = value1
-	value2 = (input.Get("startScrollOffset")).String()
+	value2 = (value.Get("startScrollOffset")).String()
 	out.StartScrollOffset = value2
-	value3 = (input.Get("endScrollOffset")).String()
+	value3 = (value.Get("endScrollOffset")).String()
 	out.EndScrollOffset = value3
-	value4 = UnionFromJS(input.Get("timeRange"))
+	value4 = UnionFromJS(value.Get("timeRange"))
 	out.TimeRange = value4
-	value5 = webani.FillModeFromJS(input.Get("fill"))
+	value5 = webani.FillModeFromJS(value.Get("fill"))
 	out.Fill = value5
 	return &out
 }
@@ -189,15 +188,19 @@ type ScrollTimeline struct {
 	webani.AnimationTimeline
 }
 
-// ScrollTimelineFromJS is casting a js.Wrapper into ScrollTimeline.
-func ScrollTimelineFromJS(value js.Wrapper) *ScrollTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScrollTimelineFromJS is casting a js.Value into ScrollTimeline.
+func ScrollTimelineFromJS(value js.Value) *ScrollTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScrollTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScrollTimelineFromJS is casting from something that holds a js.Value into ScrollTimeline.
+func ScrollTimelineFromWrapper(input core.Wrapper) *ScrollTimeline {
+	return ScrollTimelineFromJS(input.JSValue())
 }
 
 func NewScrollTimeline(options *ScrollTimelineOptions) (_result *ScrollTimeline) {

--- a/css/scrollanimations/scrollanimations_js.go
+++ b/css/scrollanimations/scrollanimations_js.go
@@ -5,6 +5,7 @@ package scrollanimations
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/dom"
 )
@@ -132,7 +133,7 @@ type ScrollTimelineOptions struct {
 	Fill              webani.FillMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ScrollTimelineOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -152,10 +153,8 @@ func (_this *ScrollTimelineOptions) JSValue() js.Value {
 }
 
 // ScrollTimelineOptionsFromJS is allocating a new
-// ScrollTimelineOptions object and copy all values from
-// input javascript object
-func ScrollTimelineOptionsFromJS(value js.Wrapper) *ScrollTimelineOptions {
-	input := value.JSValue()
+// ScrollTimelineOptions object and copy all values in the value javascript object.
+func ScrollTimelineOptionsFromJS(value js.Value) *ScrollTimelineOptions {
 	var out ScrollTimelineOptions
 	var (
 		value0 *dom.Element    // javascript: Element {scrollSource ScrollSource scrollSource}
@@ -165,19 +164,19 @@ func ScrollTimelineOptionsFromJS(value js.Wrapper) *ScrollTimelineOptions {
 		value4 *Union          // javascript: Union {timeRange TimeRange timeRange}
 		value5 webani.FillMode // javascript: FillMode {fill Fill fill}
 	)
-	if input.Get("scrollSource").Type() != js.TypeNull && input.Get("scrollSource").Type() != js.TypeUndefined {
-		value0 = dom.ElementFromJS(input.Get("scrollSource"))
+	if value.Get("scrollSource").Type() != js.TypeNull && value.Get("scrollSource").Type() != js.TypeUndefined {
+		value0 = dom.ElementFromJS(value.Get("scrollSource"))
 	}
 	out.ScrollSource = value0
-	value1 = ScrollDirectionFromJS(input.Get("orientation"))
+	value1 = ScrollDirectionFromJS(value.Get("orientation"))
 	out.Orientation = value1
-	value2 = (input.Get("startScrollOffset")).String()
+	value2 = (value.Get("startScrollOffset")).String()
 	out.StartScrollOffset = value2
-	value3 = (input.Get("endScrollOffset")).String()
+	value3 = (value.Get("endScrollOffset")).String()
 	out.EndScrollOffset = value3
-	value4 = UnionFromJS(input.Get("timeRange"))
+	value4 = UnionFromJS(value.Get("timeRange"))
 	out.TimeRange = value4
-	value5 = webani.FillModeFromJS(input.Get("fill"))
+	value5 = webani.FillModeFromJS(value.Get("fill"))
 	out.Fill = value5
 	return &out
 }
@@ -187,15 +186,19 @@ type ScrollTimeline struct {
 	webani.AnimationTimeline
 }
 
-// ScrollTimelineFromJS is casting a js.Wrapper into ScrollTimeline.
-func ScrollTimelineFromJS(value js.Wrapper) *ScrollTimeline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScrollTimelineFromJS is casting a js.Value into ScrollTimeline.
+func ScrollTimelineFromJS(value js.Value) *ScrollTimeline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScrollTimeline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScrollTimelineFromJS is casting from something that holds a js.Value into ScrollTimeline.
+func ScrollTimelineFromWrapper(input core.Wrapper) *ScrollTimeline {
+	return ScrollTimelineFromJS(input.JSValue())
 }
 
 func NewScrollTimeline(options *ScrollTimelineOptions) (_result *ScrollTimeline) {

--- a/css/transitions/transitions.go
+++ b/css/transitions/transitions.go
@@ -7,6 +7,7 @@ package transitions
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -46,7 +47,7 @@ type TransitionEventInit struct {
 	PseudoElement string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TransitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -66,10 +67,8 @@ func (_this *TransitionEventInit) JSValue() js.Value {
 }
 
 // TransitionEventInitFromJS is allocating a new
-// TransitionEventInit object and copy all values from
-// input javascript object
-func TransitionEventInitFromJS(value js.Wrapper) *TransitionEventInit {
-	input := value.JSValue()
+// TransitionEventInit object and copy all values in the value javascript object.
+func TransitionEventInitFromJS(value js.Value) *TransitionEventInit {
 	var out TransitionEventInit
 	var (
 		value0 bool    // javascript: boolean {bubbles Bubbles bubbles}
@@ -79,17 +78,17 @@ func TransitionEventInitFromJS(value js.Wrapper) *TransitionEventInit {
 		value4 float64 // javascript: double {elapsedTime ElapsedTime elapsedTime}
 		value5 string  // javascript: DOMString {pseudoElement PseudoElement pseudoElement}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("propertyName")).String()
+	value3 = (value.Get("propertyName")).String()
 	out.PropertyName = value3
-	value4 = (input.Get("elapsedTime")).Float()
+	value4 = (value.Get("elapsedTime")).Float()
 	out.ElapsedTime = value4
-	value5 = (input.Get("pseudoElement")).String()
+	value5 = (value.Get("pseudoElement")).String()
 	out.PseudoElement = value5
 	return &out
 }
@@ -99,15 +98,19 @@ type TransitionEvent struct {
 	domcore.Event
 }
 
-// TransitionEventFromJS is casting a js.Wrapper into TransitionEvent.
-func TransitionEventFromJS(value js.Wrapper) *TransitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TransitionEventFromJS is casting a js.Value into TransitionEvent.
+func TransitionEventFromJS(value js.Value) *TransitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TransitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TransitionEventFromJS is casting from something that holds a js.Value into TransitionEvent.
+func TransitionEventFromWrapper(input core.Wrapper) *TransitionEvent {
+	return TransitionEventFromJS(input.JSValue())
 }
 
 func NewTransitionEvent(_type string, transitionEventInitDict *TransitionEventInit) (_result *TransitionEvent) {

--- a/css/transitions/transitions_js.go
+++ b/css/transitions/transitions_js.go
@@ -5,6 +5,7 @@ package transitions
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -44,7 +45,7 @@ type TransitionEventInit struct {
 	PseudoElement string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TransitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -64,10 +65,8 @@ func (_this *TransitionEventInit) JSValue() js.Value {
 }
 
 // TransitionEventInitFromJS is allocating a new
-// TransitionEventInit object and copy all values from
-// input javascript object
-func TransitionEventInitFromJS(value js.Wrapper) *TransitionEventInit {
-	input := value.JSValue()
+// TransitionEventInit object and copy all values in the value javascript object.
+func TransitionEventInitFromJS(value js.Value) *TransitionEventInit {
 	var out TransitionEventInit
 	var (
 		value0 bool    // javascript: boolean {bubbles Bubbles bubbles}
@@ -77,17 +76,17 @@ func TransitionEventInitFromJS(value js.Wrapper) *TransitionEventInit {
 		value4 float64 // javascript: double {elapsedTime ElapsedTime elapsedTime}
 		value5 string  // javascript: DOMString {pseudoElement PseudoElement pseudoElement}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("propertyName")).String()
+	value3 = (value.Get("propertyName")).String()
 	out.PropertyName = value3
-	value4 = (input.Get("elapsedTime")).Float()
+	value4 = (value.Get("elapsedTime")).Float()
 	out.ElapsedTime = value4
-	value5 = (input.Get("pseudoElement")).String()
+	value5 = (value.Get("pseudoElement")).String()
 	out.PseudoElement = value5
 	return &out
 }
@@ -97,15 +96,19 @@ type TransitionEvent struct {
 	domcore.Event
 }
 
-// TransitionEventFromJS is casting a js.Wrapper into TransitionEvent.
-func TransitionEventFromJS(value js.Wrapper) *TransitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TransitionEventFromJS is casting a js.Value into TransitionEvent.
+func TransitionEventFromJS(value js.Value) *TransitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TransitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TransitionEventFromJS is casting from something that holds a js.Value into TransitionEvent.
+func TransitionEventFromWrapper(input core.Wrapper) *TransitionEvent {
+	return TransitionEventFromJS(input.JSValue())
 }
 
 func NewTransitionEvent(_type string, transitionEventInitDict *TransitionEventInit) (_result *TransitionEvent) {

--- a/css/typedom/typedom.go
+++ b/css/typedom/typedom.go
@@ -7,6 +7,7 @@ package typedom
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/geometry"
 )
 
@@ -348,7 +349,7 @@ type CSSMatrixComponentOptions struct {
 	Is2D bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSMatrixComponentOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -358,15 +359,13 @@ func (_this *CSSMatrixComponentOptions) JSValue() js.Value {
 }
 
 // CSSMatrixComponentOptionsFromJS is allocating a new
-// CSSMatrixComponentOptions object and copy all values from
-// input javascript object
-func CSSMatrixComponentOptionsFromJS(value js.Wrapper) *CSSMatrixComponentOptions {
-	input := value.JSValue()
+// CSSMatrixComponentOptions object and copy all values in the value javascript object.
+func CSSMatrixComponentOptionsFromJS(value js.Value) *CSSMatrixComponentOptions {
 	var out CSSMatrixComponentOptions
 	var (
 		value0 bool // javascript: boolean {is2D Is2D is2D}
 	)
-	value0 = (input.Get("is2D")).Bool()
+	value0 = (value.Get("is2D")).Bool()
 	out.Is2D = value0
 	return &out
 }
@@ -377,7 +376,7 @@ type CSSNumericArrayEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -393,26 +392,24 @@ func (_this *CSSNumericArrayEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayEntryIteratorValueFromJS is allocating a new
-// CSSNumericArrayEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayEntryIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayEntryIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayEntryIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayEntryIteratorValueFromJS(value js.Value) *CSSNumericArrayEntryIteratorValue {
 	var out CSSNumericArrayEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -423,7 +420,7 @@ type CSSNumericArrayKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -435,18 +432,16 @@ func (_this *CSSNumericArrayKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayKeyIteratorValueFromJS is allocating a new
-// CSSNumericArrayKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayKeyIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayKeyIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayKeyIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayKeyIteratorValueFromJS(value js.Value) *CSSNumericArrayKeyIteratorValue {
 	var out CSSNumericArrayKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -457,7 +452,7 @@ type CSSNumericArrayValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -469,18 +464,16 @@ func (_this *CSSNumericArrayValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayValueIteratorValueFromJS is allocating a new
-// CSSNumericArrayValueIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayValueIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayValueIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayValueIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayValueIteratorValueFromJS(value js.Value) *CSSNumericArrayValueIteratorValue {
 	var out CSSNumericArrayValueIteratorValue
 	var (
 		value0 *CSSNumericValue // javascript: CSSNumericValue {value Value value}
 		value1 bool             // javascript: boolean {done Done done}
 	)
-	value0 = CSSNumericValueFromJS(input.Get("value"))
+	value0 = CSSNumericValueFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -497,7 +490,7 @@ type CSSNumericType struct {
 	PercentHint CSSNumericBaseType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericType) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -521,10 +514,8 @@ func (_this *CSSNumericType) JSValue() js.Value {
 }
 
 // CSSNumericTypeFromJS is allocating a new
-// CSSNumericType object and copy all values from
-// input javascript object
-func CSSNumericTypeFromJS(value js.Wrapper) *CSSNumericType {
-	input := value.JSValue()
+// CSSNumericType object and copy all values in the value javascript object.
+func CSSNumericTypeFromJS(value js.Value) *CSSNumericType {
 	var out CSSNumericType
 	var (
 		value0 int                // javascript: long {length Length length}
@@ -536,21 +527,21 @@ func CSSNumericTypeFromJS(value js.Wrapper) *CSSNumericType {
 		value6 int                // javascript: long {percent Percent percent}
 		value7 CSSNumericBaseType // javascript: CSSNumericBaseType {percentHint PercentHint percentHint}
 	)
-	value0 = (input.Get("length")).Int()
+	value0 = (value.Get("length")).Int()
 	out.Length = value0
-	value1 = (input.Get("angle")).Int()
+	value1 = (value.Get("angle")).Int()
 	out.Angle = value1
-	value2 = (input.Get("time")).Int()
+	value2 = (value.Get("time")).Int()
 	out.Time = value2
-	value3 = (input.Get("frequency")).Int()
+	value3 = (value.Get("frequency")).Int()
 	out.Frequency = value3
-	value4 = (input.Get("resolution")).Int()
+	value4 = (value.Get("resolution")).Int()
 	out.Resolution = value4
-	value5 = (input.Get("flex")).Int()
+	value5 = (value.Get("flex")).Int()
 	out.Flex = value5
-	value6 = (input.Get("percent")).Int()
+	value6 = (value.Get("percent")).Int()
 	out.Percent = value6
-	value7 = CSSNumericBaseTypeFromJS(input.Get("percentHint"))
+	value7 = CSSNumericBaseTypeFromJS(value.Get("percentHint"))
 	out.PercentHint = value7
 	return &out
 }
@@ -561,7 +552,7 @@ type CSSTransformValueEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -577,26 +568,24 @@ func (_this *CSSTransformValueEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueEntryIteratorValueFromJS is allocating a new
-// CSSTransformValueEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueEntryIteratorValueFromJS(value js.Wrapper) *CSSTransformValueEntryIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueEntryIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueEntryIteratorValueFromJS(value js.Value) *CSSTransformValueEntryIteratorValue {
 	var out CSSTransformValueEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -607,7 +596,7 @@ type CSSTransformValueKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -619,18 +608,16 @@ func (_this *CSSTransformValueKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueKeyIteratorValueFromJS is allocating a new
-// CSSTransformValueKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueKeyIteratorValueFromJS(value js.Wrapper) *CSSTransformValueKeyIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueKeyIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueKeyIteratorValueFromJS(value js.Value) *CSSTransformValueKeyIteratorValue {
 	var out CSSTransformValueKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -641,7 +628,7 @@ type CSSTransformValueValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -653,18 +640,16 @@ func (_this *CSSTransformValueValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueValueIteratorValueFromJS is allocating a new
-// CSSTransformValueValueIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueValueIteratorValueFromJS(value js.Wrapper) *CSSTransformValueValueIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueValueIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueValueIteratorValueFromJS(value js.Value) *CSSTransformValueValueIteratorValue {
 	var out CSSTransformValueValueIteratorValue
 	var (
 		value0 *CSSTransformComponent // javascript: CSSTransformComponent {value Value value}
 		value1 bool                   // javascript: boolean {done Done done}
 	)
-	value0 = CSSTransformComponentFromJS(input.Get("value"))
+	value0 = CSSTransformComponentFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -675,7 +660,7 @@ type CSSUnparsedValueEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -691,26 +676,24 @@ func (_this *CSSUnparsedValueEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueEntryIteratorValueFromJS is allocating a new
-// CSSUnparsedValueEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueEntryIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueEntryIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueEntryIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueEntryIteratorValueFromJS(value js.Value) *CSSUnparsedValueEntryIteratorValue {
 	var out CSSUnparsedValueEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -721,7 +704,7 @@ type CSSUnparsedValueKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -733,18 +716,16 @@ func (_this *CSSUnparsedValueKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueKeyIteratorValueFromJS is allocating a new
-// CSSUnparsedValueKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueKeyIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueKeyIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueKeyIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueKeyIteratorValueFromJS(value js.Value) *CSSUnparsedValueKeyIteratorValue {
 	var out CSSUnparsedValueKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -755,7 +736,7 @@ type CSSUnparsedValueValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -767,18 +748,16 @@ func (_this *CSSUnparsedValueValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueValueIteratorValueFromJS is allocating a new
-// CSSUnparsedValueValueIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueValueIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueValueIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueValueIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueValueIteratorValueFromJS(value js.Value) *CSSUnparsedValueValueIteratorValue {
 	var out CSSUnparsedValueValueIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -789,7 +768,7 @@ type StylePropertyMapReadOnlyEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -805,26 +784,24 @@ func (_this *StylePropertyMapReadOnlyEntryIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyEntryIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyEntryIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyEntryIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyEntryIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyEntryIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyEntryIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyEntryIteratorValue {
 	var out StylePropertyMapReadOnlyEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -835,7 +812,7 @@ type StylePropertyMapReadOnlyKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -847,18 +824,16 @@ func (_this *StylePropertyMapReadOnlyKeyIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyKeyIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyKeyIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyKeyIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyKeyIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyKeyIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyKeyIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyKeyIteratorValue {
 	var out StylePropertyMapReadOnlyKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -869,7 +844,7 @@ type StylePropertyMapReadOnlyValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -885,26 +860,24 @@ func (_this *StylePropertyMapReadOnlyValueIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyValueIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyValueIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyValueIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyValueIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyValueIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyValueIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyValueIteratorValue {
 	var out StylePropertyMapReadOnlyValueIteratorValue
 	var (
 		value0 []*CSSStyleValue // javascript: sequence<CSSStyleValue> {value Value value}
 		value1 bool             // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]*CSSStyleValue, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *CSSStyleValue
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = CSSStyleValueFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -914,15 +887,19 @@ type CSSImageValue struct {
 	CSSStyleValue
 }
 
-// CSSImageValueFromJS is casting a js.Wrapper into CSSImageValue.
-func CSSImageValueFromJS(value js.Wrapper) *CSSImageValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSImageValueFromJS is casting a js.Value into CSSImageValue.
+func CSSImageValueFromJS(value js.Value) *CSSImageValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSImageValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSImageValueFromJS is casting from something that holds a js.Value into CSSImageValue.
+func CSSImageValueFromWrapper(input core.Wrapper) *CSSImageValue {
+	return CSSImageValueFromJS(input.JSValue())
 }
 
 // class: CSSKeywordValue
@@ -930,15 +907,19 @@ type CSSKeywordValue struct {
 	CSSStyleValue
 }
 
-// CSSKeywordValueFromJS is casting a js.Wrapper into CSSKeywordValue.
-func CSSKeywordValueFromJS(value js.Wrapper) *CSSKeywordValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeywordValueFromJS is casting a js.Value into CSSKeywordValue.
+func CSSKeywordValueFromJS(value js.Value) *CSSKeywordValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeywordValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeywordValueFromJS is casting from something that holds a js.Value into CSSKeywordValue.
+func CSSKeywordValueFromWrapper(input core.Wrapper) *CSSKeywordValue {
+	return CSSKeywordValueFromJS(input.JSValue())
 }
 
 func NewCSSKeywordValue(value string) (_result *CSSKeywordValue) {
@@ -980,15 +961,19 @@ type CSSMathClamp struct {
 	CSSMathValue
 }
 
-// CSSMathClampFromJS is casting a js.Wrapper into CSSMathClamp.
-func CSSMathClampFromJS(value js.Wrapper) *CSSMathClamp {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathClampFromJS is casting a js.Value into CSSMathClamp.
+func CSSMathClampFromJS(value js.Value) *CSSMathClamp {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathClamp{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathClampFromJS is casting from something that holds a js.Value into CSSMathClamp.
+func CSSMathClampFromWrapper(input core.Wrapper) *CSSMathClamp {
+	return CSSMathClampFromJS(input.JSValue())
 }
 
 func NewCSSMathClamp(min *Union, val *Union, max *Union) (_result *CSSMathClamp) {
@@ -1047,15 +1032,19 @@ type CSSMathInvert struct {
 	CSSMathValue
 }
 
-// CSSMathInvertFromJS is casting a js.Wrapper into CSSMathInvert.
-func CSSMathInvertFromJS(value js.Wrapper) *CSSMathInvert {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathInvertFromJS is casting a js.Value into CSSMathInvert.
+func CSSMathInvertFromJS(value js.Value) *CSSMathInvert {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathInvert{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathInvertFromJS is casting from something that holds a js.Value into CSSMathInvert.
+func CSSMathInvertFromWrapper(input core.Wrapper) *CSSMathInvert {
+	return CSSMathInvertFromJS(input.JSValue())
 }
 
 func NewCSSMathInvert(arg *Union) (_result *CSSMathInvert) {
@@ -1090,15 +1079,19 @@ type CSSMathMax struct {
 	CSSMathValue
 }
 
-// CSSMathMaxFromJS is casting a js.Wrapper into CSSMathMax.
-func CSSMathMaxFromJS(value js.Wrapper) *CSSMathMax {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathMaxFromJS is casting a js.Value into CSSMathMax.
+func CSSMathMaxFromJS(value js.Value) *CSSMathMax {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathMax{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathMaxFromJS is casting from something that holds a js.Value into CSSMathMax.
+func CSSMathMaxFromWrapper(input core.Wrapper) *CSSMathMax {
+	return CSSMathMaxFromJS(input.JSValue())
 }
 
 func NewCSSMathMax(args ...*Union) (_result *CSSMathMax) {
@@ -1135,15 +1128,19 @@ type CSSMathMin struct {
 	CSSMathValue
 }
 
-// CSSMathMinFromJS is casting a js.Wrapper into CSSMathMin.
-func CSSMathMinFromJS(value js.Wrapper) *CSSMathMin {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathMinFromJS is casting a js.Value into CSSMathMin.
+func CSSMathMinFromJS(value js.Value) *CSSMathMin {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathMin{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathMinFromJS is casting from something that holds a js.Value into CSSMathMin.
+func CSSMathMinFromWrapper(input core.Wrapper) *CSSMathMin {
+	return CSSMathMinFromJS(input.JSValue())
 }
 
 func NewCSSMathMin(args ...*Union) (_result *CSSMathMin) {
@@ -1180,15 +1177,19 @@ type CSSMathNegate struct {
 	CSSMathValue
 }
 
-// CSSMathNegateFromJS is casting a js.Wrapper into CSSMathNegate.
-func CSSMathNegateFromJS(value js.Wrapper) *CSSMathNegate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathNegateFromJS is casting a js.Value into CSSMathNegate.
+func CSSMathNegateFromJS(value js.Value) *CSSMathNegate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathNegate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathNegateFromJS is casting from something that holds a js.Value into CSSMathNegate.
+func CSSMathNegateFromWrapper(input core.Wrapper) *CSSMathNegate {
+	return CSSMathNegateFromJS(input.JSValue())
 }
 
 func NewCSSMathNegate(arg *Union) (_result *CSSMathNegate) {
@@ -1223,15 +1224,19 @@ type CSSMathProduct struct {
 	CSSMathValue
 }
 
-// CSSMathProductFromJS is casting a js.Wrapper into CSSMathProduct.
-func CSSMathProductFromJS(value js.Wrapper) *CSSMathProduct {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathProductFromJS is casting a js.Value into CSSMathProduct.
+func CSSMathProductFromJS(value js.Value) *CSSMathProduct {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathProduct{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathProductFromJS is casting from something that holds a js.Value into CSSMathProduct.
+func CSSMathProductFromWrapper(input core.Wrapper) *CSSMathProduct {
+	return CSSMathProductFromJS(input.JSValue())
 }
 
 func NewCSSMathProduct(args ...*Union) (_result *CSSMathProduct) {
@@ -1268,15 +1273,19 @@ type CSSMathSum struct {
 	CSSMathValue
 }
 
-// CSSMathSumFromJS is casting a js.Wrapper into CSSMathSum.
-func CSSMathSumFromJS(value js.Wrapper) *CSSMathSum {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathSumFromJS is casting a js.Value into CSSMathSum.
+func CSSMathSumFromJS(value js.Value) *CSSMathSum {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathSum{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathSumFromJS is casting from something that holds a js.Value into CSSMathSum.
+func CSSMathSumFromWrapper(input core.Wrapper) *CSSMathSum {
+	return CSSMathSumFromJS(input.JSValue())
 }
 
 func NewCSSMathSum(args ...*Union) (_result *CSSMathSum) {
@@ -1313,15 +1322,19 @@ type CSSMathValue struct {
 	CSSNumericValue
 }
 
-// CSSMathValueFromJS is casting a js.Wrapper into CSSMathValue.
-func CSSMathValueFromJS(value js.Wrapper) *CSSMathValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathValueFromJS is casting a js.Value into CSSMathValue.
+func CSSMathValueFromJS(value js.Value) *CSSMathValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathValueFromJS is casting from something that holds a js.Value into CSSMathValue.
+func CSSMathValueFromWrapper(input core.Wrapper) *CSSMathValue {
+	return CSSMathValueFromJS(input.JSValue())
 }
 
 // Operator returning attribute 'operator' with
@@ -1338,15 +1351,19 @@ type CSSMatrixComponent struct {
 	CSSTransformComponent
 }
 
-// CSSMatrixComponentFromJS is casting a js.Wrapper into CSSMatrixComponent.
-func CSSMatrixComponentFromJS(value js.Wrapper) *CSSMatrixComponent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMatrixComponentFromJS is casting a js.Value into CSSMatrixComponent.
+func CSSMatrixComponentFromJS(value js.Value) *CSSMatrixComponent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMatrixComponent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMatrixComponentFromJS is casting from something that holds a js.Value into CSSMatrixComponent.
+func CSSMatrixComponentFromWrapper(input core.Wrapper) *CSSMatrixComponent {
+	return CSSMatrixComponentFromJS(input.JSValue())
 }
 
 func NewCSSMatrixComponent(matrix *geometry.DOMMatrixReadOnly, options *CSSMatrixComponentOptions) (_result *CSSMatrixComponent) {
@@ -1398,15 +1415,19 @@ func (_this *CSSNumericArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayFromJS is casting a js.Wrapper into CSSNumericArray.
-func CSSNumericArrayFromJS(value js.Wrapper) *CSSNumericArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayFromJS is casting a js.Value into CSSNumericArray.
+func CSSNumericArrayFromJS(value js.Value) *CSSNumericArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayFromJS is casting from something that holds a js.Value into CSSNumericArray.
+func CSSNumericArrayFromWrapper(input core.Wrapper) *CSSNumericArray {
+	return CSSNumericArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1511,15 +1532,19 @@ func (_this *CSSNumericArrayEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayEntryIteratorFromJS is casting a js.Wrapper into CSSNumericArrayEntryIterator.
-func CSSNumericArrayEntryIteratorFromJS(value js.Wrapper) *CSSNumericArrayEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayEntryIteratorFromJS is casting a js.Value into CSSNumericArrayEntryIterator.
+func CSSNumericArrayEntryIteratorFromJS(value js.Value) *CSSNumericArrayEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayEntryIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayEntryIterator.
+func CSSNumericArrayEntryIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayEntryIterator {
+	return CSSNumericArrayEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayEntryIterator) Next() (_result *CSSNumericArrayEntryIteratorValue) {
@@ -1546,15 +1571,19 @@ func (_this *CSSNumericArrayKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayKeyIteratorFromJS is casting a js.Wrapper into CSSNumericArrayKeyIterator.
-func CSSNumericArrayKeyIteratorFromJS(value js.Wrapper) *CSSNumericArrayKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayKeyIteratorFromJS is casting a js.Value into CSSNumericArrayKeyIterator.
+func CSSNumericArrayKeyIteratorFromJS(value js.Value) *CSSNumericArrayKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayKeyIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayKeyIterator.
+func CSSNumericArrayKeyIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayKeyIterator {
+	return CSSNumericArrayKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayKeyIterator) Next() (_result *CSSNumericArrayKeyIteratorValue) {
@@ -1581,15 +1610,19 @@ func (_this *CSSNumericArrayValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayValueIteratorFromJS is casting a js.Wrapper into CSSNumericArrayValueIterator.
-func CSSNumericArrayValueIteratorFromJS(value js.Wrapper) *CSSNumericArrayValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayValueIteratorFromJS is casting a js.Value into CSSNumericArrayValueIterator.
+func CSSNumericArrayValueIteratorFromJS(value js.Value) *CSSNumericArrayValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayValueIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayValueIterator.
+func CSSNumericArrayValueIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayValueIterator {
+	return CSSNumericArrayValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayValueIterator) Next() (_result *CSSNumericArrayValueIteratorValue) {
@@ -1611,15 +1644,19 @@ type CSSNumericValue struct {
 	CSSStyleValue
 }
 
-// CSSNumericValueFromJS is casting a js.Wrapper into CSSNumericValue.
-func CSSNumericValueFromJS(value js.Wrapper) *CSSNumericValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericValueFromJS is casting a js.Value into CSSNumericValue.
+func CSSNumericValueFromJS(value js.Value) *CSSNumericValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericValueFromJS is casting from something that holds a js.Value into CSSNumericValue.
+func CSSNumericValueFromWrapper(input core.Wrapper) *CSSNumericValue {
+	return CSSNumericValueFromJS(input.JSValue())
 }
 
 func Parse(cssText string) (_result *CSSNumericValue) {
@@ -1829,15 +1866,19 @@ type CSSPerspective struct {
 	CSSTransformComponent
 }
 
-// CSSPerspectiveFromJS is casting a js.Wrapper into CSSPerspective.
-func CSSPerspectiveFromJS(value js.Wrapper) *CSSPerspective {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPerspectiveFromJS is casting a js.Value into CSSPerspective.
+func CSSPerspectiveFromJS(value js.Value) *CSSPerspective {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPerspective{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPerspectiveFromJS is casting from something that holds a js.Value into CSSPerspective.
+func CSSPerspectiveFromWrapper(input core.Wrapper) *CSSPerspective {
+	return CSSPerspectiveFromJS(input.JSValue())
 }
 
 func NewCSSPerspective(length *CSSNumericValue) (_result *CSSPerspective) {
@@ -1879,15 +1920,19 @@ type CSSRotate struct {
 	CSSTransformComponent
 }
 
-// CSSRotateFromJS is casting a js.Wrapper into CSSRotate.
-func CSSRotateFromJS(value js.Wrapper) *CSSRotate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRotateFromJS is casting a js.Value into CSSRotate.
+func CSSRotateFromJS(value js.Value) *CSSRotate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRotate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRotateFromJS is casting from something that holds a js.Value into CSSRotate.
+func CSSRotateFromWrapper(input core.Wrapper) *CSSRotate {
+	return CSSRotateFromJS(input.JSValue())
 }
 
 func NewCSSRotate(x *Union, y *Union, z *Union, angle *CSSNumericValue) (_result *CSSRotate) {
@@ -1986,15 +2031,19 @@ type CSSScale struct {
 	CSSTransformComponent
 }
 
-// CSSScaleFromJS is casting a js.Wrapper into CSSScale.
-func CSSScaleFromJS(value js.Wrapper) *CSSScale {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSScaleFromJS is casting a js.Value into CSSScale.
+func CSSScaleFromJS(value js.Value) *CSSScale {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSScale{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSScaleFromJS is casting from something that holds a js.Value into CSSScale.
+func CSSScaleFromWrapper(input core.Wrapper) *CSSScale {
+	return CSSScaleFromJS(input.JSValue())
 }
 
 func NewCSSScale(x *Union, y *Union, z *Union) (_result *CSSScale) {
@@ -2076,15 +2125,19 @@ type CSSSkew struct {
 	CSSTransformComponent
 }
 
-// CSSSkewFromJS is casting a js.Wrapper into CSSSkew.
-func CSSSkewFromJS(value js.Wrapper) *CSSSkew {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewFromJS is casting a js.Value into CSSSkew.
+func CSSSkewFromJS(value js.Value) *CSSSkew {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkew{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewFromJS is casting from something that holds a js.Value into CSSSkew.
+func CSSSkewFromWrapper(input core.Wrapper) *CSSSkew {
+	return CSSSkewFromJS(input.JSValue())
 }
 
 func NewCSSSkew(ax *CSSNumericValue, ay *CSSNumericValue) (_result *CSSSkew) {
@@ -2145,15 +2198,19 @@ type CSSSkewX struct {
 	CSSTransformComponent
 }
 
-// CSSSkewXFromJS is casting a js.Wrapper into CSSSkewX.
-func CSSSkewXFromJS(value js.Wrapper) *CSSSkewX {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewXFromJS is casting a js.Value into CSSSkewX.
+func CSSSkewXFromJS(value js.Value) *CSSSkewX {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkewX{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewXFromJS is casting from something that holds a js.Value into CSSSkewX.
+func CSSSkewXFromWrapper(input core.Wrapper) *CSSSkewX {
+	return CSSSkewXFromJS(input.JSValue())
 }
 
 func NewCSSSkewX(ax *CSSNumericValue) (_result *CSSSkewX) {
@@ -2195,15 +2252,19 @@ type CSSSkewY struct {
 	CSSTransformComponent
 }
 
-// CSSSkewYFromJS is casting a js.Wrapper into CSSSkewY.
-func CSSSkewYFromJS(value js.Wrapper) *CSSSkewY {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewYFromJS is casting a js.Value into CSSSkewY.
+func CSSSkewYFromJS(value js.Value) *CSSSkewY {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkewY{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewYFromJS is casting from something that holds a js.Value into CSSSkewY.
+func CSSSkewYFromWrapper(input core.Wrapper) *CSSSkewY {
+	return CSSSkewYFromJS(input.JSValue())
 }
 
 func NewCSSSkewY(ay *CSSNumericValue) (_result *CSSSkewY) {
@@ -2250,15 +2311,19 @@ func (_this *CSSStyleValue) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSStyleValueFromJS is casting a js.Wrapper into CSSStyleValue.
-func CSSStyleValueFromJS(value js.Wrapper) *CSSStyleValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleValueFromJS is casting a js.Value into CSSStyleValue.
+func CSSStyleValueFromJS(value js.Value) *CSSStyleValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleValueFromJS is casting from something that holds a js.Value into CSSStyleValue.
+func CSSStyleValueFromWrapper(input core.Wrapper) *CSSStyleValue {
+	return CSSStyleValueFromJS(input.JSValue())
 }
 
 func Parse2(property string, cssText string) (_result *CSSStyleValue) {
@@ -2337,15 +2402,19 @@ func (_this *CSSTransformComponent) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformComponentFromJS is casting a js.Wrapper into CSSTransformComponent.
-func CSSTransformComponentFromJS(value js.Wrapper) *CSSTransformComponent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformComponentFromJS is casting a js.Value into CSSTransformComponent.
+func CSSTransformComponentFromJS(value js.Value) *CSSTransformComponent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformComponent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformComponentFromJS is casting from something that holds a js.Value into CSSTransformComponent.
+func CSSTransformComponentFromWrapper(input core.Wrapper) *CSSTransformComponent {
+	return CSSTransformComponentFromJS(input.JSValue())
 }
 
 // Is2D returning attribute 'is2D' with
@@ -2397,15 +2466,19 @@ type CSSTransformValue struct {
 	CSSStyleValue
 }
 
-// CSSTransformValueFromJS is casting a js.Wrapper into CSSTransformValue.
-func CSSTransformValueFromJS(value js.Wrapper) *CSSTransformValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueFromJS is casting a js.Value into CSSTransformValue.
+func CSSTransformValueFromJS(value js.Value) *CSSTransformValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueFromJS is casting from something that holds a js.Value into CSSTransformValue.
+func CSSTransformValueFromWrapper(input core.Wrapper) *CSSTransformValue {
+	return CSSTransformValueFromJS(input.JSValue())
 }
 
 func NewCSSTransformValue(transforms []*CSSTransformComponent) (_result *CSSTransformValue) {
@@ -2575,15 +2648,19 @@ func (_this *CSSTransformValueEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueEntryIteratorFromJS is casting a js.Wrapper into CSSTransformValueEntryIterator.
-func CSSTransformValueEntryIteratorFromJS(value js.Wrapper) *CSSTransformValueEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueEntryIteratorFromJS is casting a js.Value into CSSTransformValueEntryIterator.
+func CSSTransformValueEntryIteratorFromJS(value js.Value) *CSSTransformValueEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueEntryIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueEntryIterator.
+func CSSTransformValueEntryIteratorFromWrapper(input core.Wrapper) *CSSTransformValueEntryIterator {
+	return CSSTransformValueEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueEntryIterator) Next() (_result *CSSTransformValueEntryIteratorValue) {
@@ -2610,15 +2687,19 @@ func (_this *CSSTransformValueKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueKeyIteratorFromJS is casting a js.Wrapper into CSSTransformValueKeyIterator.
-func CSSTransformValueKeyIteratorFromJS(value js.Wrapper) *CSSTransformValueKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueKeyIteratorFromJS is casting a js.Value into CSSTransformValueKeyIterator.
+func CSSTransformValueKeyIteratorFromJS(value js.Value) *CSSTransformValueKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueKeyIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueKeyIterator.
+func CSSTransformValueKeyIteratorFromWrapper(input core.Wrapper) *CSSTransformValueKeyIterator {
+	return CSSTransformValueKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueKeyIterator) Next() (_result *CSSTransformValueKeyIteratorValue) {
@@ -2645,15 +2726,19 @@ func (_this *CSSTransformValueValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueValueIteratorFromJS is casting a js.Wrapper into CSSTransformValueValueIterator.
-func CSSTransformValueValueIteratorFromJS(value js.Wrapper) *CSSTransformValueValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueValueIteratorFromJS is casting a js.Value into CSSTransformValueValueIterator.
+func CSSTransformValueValueIteratorFromJS(value js.Value) *CSSTransformValueValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueValueIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueValueIterator.
+func CSSTransformValueValueIteratorFromWrapper(input core.Wrapper) *CSSTransformValueValueIterator {
+	return CSSTransformValueValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueValueIterator) Next() (_result *CSSTransformValueValueIteratorValue) {
@@ -2675,15 +2760,19 @@ type CSSTranslate struct {
 	CSSTransformComponent
 }
 
-// CSSTranslateFromJS is casting a js.Wrapper into CSSTranslate.
-func CSSTranslateFromJS(value js.Wrapper) *CSSTranslate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTranslateFromJS is casting a js.Value into CSSTranslate.
+func CSSTranslateFromJS(value js.Value) *CSSTranslate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTranslate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTranslateFromJS is casting from something that holds a js.Value into CSSTranslate.
+func CSSTranslateFromWrapper(input core.Wrapper) *CSSTranslate {
+	return CSSTranslateFromJS(input.JSValue())
 }
 
 func NewCSSTranslate(x *CSSNumericValue, y *CSSNumericValue, z *CSSNumericValue) (_result *CSSTranslate) {
@@ -2765,15 +2854,19 @@ type CSSUnitValue struct {
 	CSSNumericValue
 }
 
-// CSSUnitValueFromJS is casting a js.Wrapper into CSSUnitValue.
-func CSSUnitValueFromJS(value js.Wrapper) *CSSUnitValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnitValueFromJS is casting a js.Value into CSSUnitValue.
+func CSSUnitValueFromJS(value js.Value) *CSSUnitValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnitValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnitValueFromJS is casting from something that holds a js.Value into CSSUnitValue.
+func CSSUnitValueFromWrapper(input core.Wrapper) *CSSUnitValue {
+	return CSSUnitValueFromJS(input.JSValue())
 }
 
 func NewCSSUnitValue(value float64, unit string) (_result *CSSUnitValue) {
@@ -2827,15 +2920,19 @@ type CSSUnparsedValue struct {
 	CSSStyleValue
 }
 
-// CSSUnparsedValueFromJS is casting a js.Wrapper into CSSUnparsedValue.
-func CSSUnparsedValueFromJS(value js.Wrapper) *CSSUnparsedValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueFromJS is casting a js.Value into CSSUnparsedValue.
+func CSSUnparsedValueFromJS(value js.Value) *CSSUnparsedValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueFromJS is casting from something that holds a js.Value into CSSUnparsedValue.
+func CSSUnparsedValueFromWrapper(input core.Wrapper) *CSSUnparsedValue {
+	return CSSUnparsedValueFromJS(input.JSValue())
 }
 
 func NewCSSUnparsedValue(members []*Union) (_result *CSSUnparsedValue) {
@@ -2982,15 +3079,19 @@ func (_this *CSSUnparsedValueEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueEntryIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueEntryIterator.
-func CSSUnparsedValueEntryIteratorFromJS(value js.Wrapper) *CSSUnparsedValueEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueEntryIteratorFromJS is casting a js.Value into CSSUnparsedValueEntryIterator.
+func CSSUnparsedValueEntryIteratorFromJS(value js.Value) *CSSUnparsedValueEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueEntryIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueEntryIterator.
+func CSSUnparsedValueEntryIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueEntryIterator {
+	return CSSUnparsedValueEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueEntryIterator) Next() (_result *CSSUnparsedValueEntryIteratorValue) {
@@ -3017,15 +3118,19 @@ func (_this *CSSUnparsedValueKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueKeyIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueKeyIterator.
-func CSSUnparsedValueKeyIteratorFromJS(value js.Wrapper) *CSSUnparsedValueKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueKeyIteratorFromJS is casting a js.Value into CSSUnparsedValueKeyIterator.
+func CSSUnparsedValueKeyIteratorFromJS(value js.Value) *CSSUnparsedValueKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueKeyIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueKeyIterator.
+func CSSUnparsedValueKeyIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueKeyIterator {
+	return CSSUnparsedValueKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueKeyIterator) Next() (_result *CSSUnparsedValueKeyIteratorValue) {
@@ -3052,15 +3157,19 @@ func (_this *CSSUnparsedValueValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueValueIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueValueIterator.
-func CSSUnparsedValueValueIteratorFromJS(value js.Wrapper) *CSSUnparsedValueValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueValueIteratorFromJS is casting a js.Value into CSSUnparsedValueValueIterator.
+func CSSUnparsedValueValueIteratorFromJS(value js.Value) *CSSUnparsedValueValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueValueIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueValueIterator.
+func CSSUnparsedValueValueIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueValueIterator {
+	return CSSUnparsedValueValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueValueIterator) Next() (_result *CSSUnparsedValueValueIteratorValue) {
@@ -3087,15 +3196,19 @@ func (_this *CSSVariableReferenceValue) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSVariableReferenceValueFromJS is casting a js.Wrapper into CSSVariableReferenceValue.
-func CSSVariableReferenceValueFromJS(value js.Wrapper) *CSSVariableReferenceValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSVariableReferenceValueFromJS is casting a js.Value into CSSVariableReferenceValue.
+func CSSVariableReferenceValueFromJS(value js.Value) *CSSVariableReferenceValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSVariableReferenceValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSVariableReferenceValueFromJS is casting from something that holds a js.Value into CSSVariableReferenceValue.
+func CSSVariableReferenceValueFromWrapper(input core.Wrapper) *CSSVariableReferenceValue {
+	return CSSVariableReferenceValueFromJS(input.JSValue())
 }
 
 func NewCSSVariableReferenceValue(variable string, fallback *CSSUnparsedValue) (_result *CSSVariableReferenceValue) {
@@ -3153,15 +3266,19 @@ type StylePropertyMap struct {
 	StylePropertyMapReadOnly
 }
 
-// StylePropertyMapFromJS is casting a js.Wrapper into StylePropertyMap.
-func StylePropertyMapFromJS(value js.Wrapper) *StylePropertyMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapFromJS is casting a js.Value into StylePropertyMap.
+func StylePropertyMapFromJS(value js.Value) *StylePropertyMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapFromJS is casting from something that holds a js.Value into StylePropertyMap.
+func StylePropertyMapFromWrapper(input core.Wrapper) *StylePropertyMap {
+	return StylePropertyMapFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMap) Set(property string, values ...*Union) {
@@ -3229,15 +3346,19 @@ func (_this *StylePropertyMapReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyFromJS is casting a js.Wrapper into StylePropertyMapReadOnly.
-func StylePropertyMapReadOnlyFromJS(value js.Wrapper) *StylePropertyMapReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyFromJS is casting a js.Value into StylePropertyMapReadOnly.
+func StylePropertyMapReadOnlyFromJS(value js.Value) *StylePropertyMapReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnly.
+func StylePropertyMapReadOnlyFromWrapper(input core.Wrapper) *StylePropertyMapReadOnly {
+	return StylePropertyMapReadOnlyFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -3384,15 +3505,19 @@ func (_this *StylePropertyMapReadOnlyEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyEntryIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyEntryIterator.
-func StylePropertyMapReadOnlyEntryIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyEntryIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyEntryIterator.
+func StylePropertyMapReadOnlyEntryIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyEntryIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyEntryIterator.
+func StylePropertyMapReadOnlyEntryIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyEntryIterator {
+	return StylePropertyMapReadOnlyEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyEntryIterator) Next() (_result *StylePropertyMapReadOnlyEntryIteratorValue) {
@@ -3419,15 +3544,19 @@ func (_this *StylePropertyMapReadOnlyKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyKeyIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyKeyIterator.
-func StylePropertyMapReadOnlyKeyIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyKeyIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyKeyIterator.
+func StylePropertyMapReadOnlyKeyIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyKeyIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyKeyIterator.
+func StylePropertyMapReadOnlyKeyIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyKeyIterator {
+	return StylePropertyMapReadOnlyKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyKeyIterator) Next() (_result *StylePropertyMapReadOnlyKeyIteratorValue) {
@@ -3454,15 +3583,19 @@ func (_this *StylePropertyMapReadOnlyValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyValueIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyValueIterator.
-func StylePropertyMapReadOnlyValueIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyValueIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyValueIterator.
+func StylePropertyMapReadOnlyValueIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyValueIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyValueIterator.
+func StylePropertyMapReadOnlyValueIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyValueIterator {
+	return StylePropertyMapReadOnlyValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyValueIterator) Next() (_result *StylePropertyMapReadOnlyValueIteratorValue) {

--- a/css/typedom/typedom_js.go
+++ b/css/typedom/typedom_js.go
@@ -5,6 +5,7 @@ package typedom
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/geometry"
 )
 
@@ -346,7 +347,7 @@ type CSSMatrixComponentOptions struct {
 	Is2D bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSMatrixComponentOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -356,15 +357,13 @@ func (_this *CSSMatrixComponentOptions) JSValue() js.Value {
 }
 
 // CSSMatrixComponentOptionsFromJS is allocating a new
-// CSSMatrixComponentOptions object and copy all values from
-// input javascript object
-func CSSMatrixComponentOptionsFromJS(value js.Wrapper) *CSSMatrixComponentOptions {
-	input := value.JSValue()
+// CSSMatrixComponentOptions object and copy all values in the value javascript object.
+func CSSMatrixComponentOptionsFromJS(value js.Value) *CSSMatrixComponentOptions {
 	var out CSSMatrixComponentOptions
 	var (
 		value0 bool // javascript: boolean {is2D Is2D is2D}
 	)
-	value0 = (input.Get("is2D")).Bool()
+	value0 = (value.Get("is2D")).Bool()
 	out.Is2D = value0
 	return &out
 }
@@ -375,7 +374,7 @@ type CSSNumericArrayEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -391,26 +390,24 @@ func (_this *CSSNumericArrayEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayEntryIteratorValueFromJS is allocating a new
-// CSSNumericArrayEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayEntryIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayEntryIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayEntryIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayEntryIteratorValueFromJS(value js.Value) *CSSNumericArrayEntryIteratorValue {
 	var out CSSNumericArrayEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -421,7 +418,7 @@ type CSSNumericArrayKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -433,18 +430,16 @@ func (_this *CSSNumericArrayKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayKeyIteratorValueFromJS is allocating a new
-// CSSNumericArrayKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayKeyIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayKeyIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayKeyIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayKeyIteratorValueFromJS(value js.Value) *CSSNumericArrayKeyIteratorValue {
 	var out CSSNumericArrayKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -455,7 +450,7 @@ type CSSNumericArrayValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericArrayValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -467,18 +462,16 @@ func (_this *CSSNumericArrayValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSNumericArrayValueIteratorValueFromJS is allocating a new
-// CSSNumericArrayValueIteratorValue object and copy all values from
-// input javascript object
-func CSSNumericArrayValueIteratorValueFromJS(value js.Wrapper) *CSSNumericArrayValueIteratorValue {
-	input := value.JSValue()
+// CSSNumericArrayValueIteratorValue object and copy all values in the value javascript object.
+func CSSNumericArrayValueIteratorValueFromJS(value js.Value) *CSSNumericArrayValueIteratorValue {
 	var out CSSNumericArrayValueIteratorValue
 	var (
 		value0 *CSSNumericValue // javascript: CSSNumericValue {value Value value}
 		value1 bool             // javascript: boolean {done Done done}
 	)
-	value0 = CSSNumericValueFromJS(input.Get("value"))
+	value0 = CSSNumericValueFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -495,7 +488,7 @@ type CSSNumericType struct {
 	PercentHint CSSNumericBaseType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSNumericType) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -519,10 +512,8 @@ func (_this *CSSNumericType) JSValue() js.Value {
 }
 
 // CSSNumericTypeFromJS is allocating a new
-// CSSNumericType object and copy all values from
-// input javascript object
-func CSSNumericTypeFromJS(value js.Wrapper) *CSSNumericType {
-	input := value.JSValue()
+// CSSNumericType object and copy all values in the value javascript object.
+func CSSNumericTypeFromJS(value js.Value) *CSSNumericType {
 	var out CSSNumericType
 	var (
 		value0 int                // javascript: long {length Length length}
@@ -534,21 +525,21 @@ func CSSNumericTypeFromJS(value js.Wrapper) *CSSNumericType {
 		value6 int                // javascript: long {percent Percent percent}
 		value7 CSSNumericBaseType // javascript: CSSNumericBaseType {percentHint PercentHint percentHint}
 	)
-	value0 = (input.Get("length")).Int()
+	value0 = (value.Get("length")).Int()
 	out.Length = value0
-	value1 = (input.Get("angle")).Int()
+	value1 = (value.Get("angle")).Int()
 	out.Angle = value1
-	value2 = (input.Get("time")).Int()
+	value2 = (value.Get("time")).Int()
 	out.Time = value2
-	value3 = (input.Get("frequency")).Int()
+	value3 = (value.Get("frequency")).Int()
 	out.Frequency = value3
-	value4 = (input.Get("resolution")).Int()
+	value4 = (value.Get("resolution")).Int()
 	out.Resolution = value4
-	value5 = (input.Get("flex")).Int()
+	value5 = (value.Get("flex")).Int()
 	out.Flex = value5
-	value6 = (input.Get("percent")).Int()
+	value6 = (value.Get("percent")).Int()
 	out.Percent = value6
-	value7 = CSSNumericBaseTypeFromJS(input.Get("percentHint"))
+	value7 = CSSNumericBaseTypeFromJS(value.Get("percentHint"))
 	out.PercentHint = value7
 	return &out
 }
@@ -559,7 +550,7 @@ type CSSTransformValueEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -575,26 +566,24 @@ func (_this *CSSTransformValueEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueEntryIteratorValueFromJS is allocating a new
-// CSSTransformValueEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueEntryIteratorValueFromJS(value js.Wrapper) *CSSTransformValueEntryIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueEntryIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueEntryIteratorValueFromJS(value js.Value) *CSSTransformValueEntryIteratorValue {
 	var out CSSTransformValueEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -605,7 +594,7 @@ type CSSTransformValueKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -617,18 +606,16 @@ func (_this *CSSTransformValueKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueKeyIteratorValueFromJS is allocating a new
-// CSSTransformValueKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueKeyIteratorValueFromJS(value js.Wrapper) *CSSTransformValueKeyIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueKeyIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueKeyIteratorValueFromJS(value js.Value) *CSSTransformValueKeyIteratorValue {
 	var out CSSTransformValueKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -639,7 +626,7 @@ type CSSTransformValueValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSTransformValueValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -651,18 +638,16 @@ func (_this *CSSTransformValueValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSTransformValueValueIteratorValueFromJS is allocating a new
-// CSSTransformValueValueIteratorValue object and copy all values from
-// input javascript object
-func CSSTransformValueValueIteratorValueFromJS(value js.Wrapper) *CSSTransformValueValueIteratorValue {
-	input := value.JSValue()
+// CSSTransformValueValueIteratorValue object and copy all values in the value javascript object.
+func CSSTransformValueValueIteratorValueFromJS(value js.Value) *CSSTransformValueValueIteratorValue {
 	var out CSSTransformValueValueIteratorValue
 	var (
 		value0 *CSSTransformComponent // javascript: CSSTransformComponent {value Value value}
 		value1 bool                   // javascript: boolean {done Done done}
 	)
-	value0 = CSSTransformComponentFromJS(input.Get("value"))
+	value0 = CSSTransformComponentFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -673,7 +658,7 @@ type CSSUnparsedValueEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -689,26 +674,24 @@ func (_this *CSSUnparsedValueEntryIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueEntryIteratorValueFromJS is allocating a new
-// CSSUnparsedValueEntryIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueEntryIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueEntryIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueEntryIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueEntryIteratorValueFromJS(value js.Value) *CSSUnparsedValueEntryIteratorValue {
 	var out CSSUnparsedValueEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -719,7 +702,7 @@ type CSSUnparsedValueKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -731,18 +714,16 @@ func (_this *CSSUnparsedValueKeyIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueKeyIteratorValueFromJS is allocating a new
-// CSSUnparsedValueKeyIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueKeyIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueKeyIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueKeyIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueKeyIteratorValueFromJS(value js.Value) *CSSUnparsedValueKeyIteratorValue {
 	var out CSSUnparsedValueKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -753,7 +734,7 @@ type CSSUnparsedValueValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CSSUnparsedValueValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -765,18 +746,16 @@ func (_this *CSSUnparsedValueValueIteratorValue) JSValue() js.Value {
 }
 
 // CSSUnparsedValueValueIteratorValueFromJS is allocating a new
-// CSSUnparsedValueValueIteratorValue object and copy all values from
-// input javascript object
-func CSSUnparsedValueValueIteratorValueFromJS(value js.Wrapper) *CSSUnparsedValueValueIteratorValue {
-	input := value.JSValue()
+// CSSUnparsedValueValueIteratorValue object and copy all values in the value javascript object.
+func CSSUnparsedValueValueIteratorValueFromJS(value js.Value) *CSSUnparsedValueValueIteratorValue {
 	var out CSSUnparsedValueValueIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -787,7 +766,7 @@ type StylePropertyMapReadOnlyEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -803,26 +782,24 @@ func (_this *StylePropertyMapReadOnlyEntryIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyEntryIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyEntryIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyEntryIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyEntryIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyEntryIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyEntryIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyEntryIteratorValue {
 	var out StylePropertyMapReadOnlyEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -833,7 +810,7 @@ type StylePropertyMapReadOnlyKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -845,18 +822,16 @@ func (_this *StylePropertyMapReadOnlyKeyIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyKeyIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyKeyIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyKeyIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyKeyIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyKeyIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyKeyIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyKeyIteratorValue {
 	var out StylePropertyMapReadOnlyKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -867,7 +842,7 @@ type StylePropertyMapReadOnlyValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StylePropertyMapReadOnlyValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -883,26 +858,24 @@ func (_this *StylePropertyMapReadOnlyValueIteratorValue) JSValue() js.Value {
 }
 
 // StylePropertyMapReadOnlyValueIteratorValueFromJS is allocating a new
-// StylePropertyMapReadOnlyValueIteratorValue object and copy all values from
-// input javascript object
-func StylePropertyMapReadOnlyValueIteratorValueFromJS(value js.Wrapper) *StylePropertyMapReadOnlyValueIteratorValue {
-	input := value.JSValue()
+// StylePropertyMapReadOnlyValueIteratorValue object and copy all values in the value javascript object.
+func StylePropertyMapReadOnlyValueIteratorValueFromJS(value js.Value) *StylePropertyMapReadOnlyValueIteratorValue {
 	var out StylePropertyMapReadOnlyValueIteratorValue
 	var (
 		value0 []*CSSStyleValue // javascript: sequence<CSSStyleValue> {value Value value}
 		value1 bool             // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]*CSSStyleValue, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *CSSStyleValue
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = CSSStyleValueFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -912,15 +885,19 @@ type CSSImageValue struct {
 	CSSStyleValue
 }
 
-// CSSImageValueFromJS is casting a js.Wrapper into CSSImageValue.
-func CSSImageValueFromJS(value js.Wrapper) *CSSImageValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSImageValueFromJS is casting a js.Value into CSSImageValue.
+func CSSImageValueFromJS(value js.Value) *CSSImageValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSImageValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSImageValueFromJS is casting from something that holds a js.Value into CSSImageValue.
+func CSSImageValueFromWrapper(input core.Wrapper) *CSSImageValue {
+	return CSSImageValueFromJS(input.JSValue())
 }
 
 // class: CSSKeywordValue
@@ -928,15 +905,19 @@ type CSSKeywordValue struct {
 	CSSStyleValue
 }
 
-// CSSKeywordValueFromJS is casting a js.Wrapper into CSSKeywordValue.
-func CSSKeywordValueFromJS(value js.Wrapper) *CSSKeywordValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSKeywordValueFromJS is casting a js.Value into CSSKeywordValue.
+func CSSKeywordValueFromJS(value js.Value) *CSSKeywordValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSKeywordValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSKeywordValueFromJS is casting from something that holds a js.Value into CSSKeywordValue.
+func CSSKeywordValueFromWrapper(input core.Wrapper) *CSSKeywordValue {
+	return CSSKeywordValueFromJS(input.JSValue())
 }
 
 func NewCSSKeywordValue(value string) (_result *CSSKeywordValue) {
@@ -978,15 +959,19 @@ type CSSMathClamp struct {
 	CSSMathValue
 }
 
-// CSSMathClampFromJS is casting a js.Wrapper into CSSMathClamp.
-func CSSMathClampFromJS(value js.Wrapper) *CSSMathClamp {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathClampFromJS is casting a js.Value into CSSMathClamp.
+func CSSMathClampFromJS(value js.Value) *CSSMathClamp {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathClamp{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathClampFromJS is casting from something that holds a js.Value into CSSMathClamp.
+func CSSMathClampFromWrapper(input core.Wrapper) *CSSMathClamp {
+	return CSSMathClampFromJS(input.JSValue())
 }
 
 func NewCSSMathClamp(min *Union, val *Union, max *Union) (_result *CSSMathClamp) {
@@ -1045,15 +1030,19 @@ type CSSMathInvert struct {
 	CSSMathValue
 }
 
-// CSSMathInvertFromJS is casting a js.Wrapper into CSSMathInvert.
-func CSSMathInvertFromJS(value js.Wrapper) *CSSMathInvert {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathInvertFromJS is casting a js.Value into CSSMathInvert.
+func CSSMathInvertFromJS(value js.Value) *CSSMathInvert {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathInvert{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathInvertFromJS is casting from something that holds a js.Value into CSSMathInvert.
+func CSSMathInvertFromWrapper(input core.Wrapper) *CSSMathInvert {
+	return CSSMathInvertFromJS(input.JSValue())
 }
 
 func NewCSSMathInvert(arg *Union) (_result *CSSMathInvert) {
@@ -1088,15 +1077,19 @@ type CSSMathMax struct {
 	CSSMathValue
 }
 
-// CSSMathMaxFromJS is casting a js.Wrapper into CSSMathMax.
-func CSSMathMaxFromJS(value js.Wrapper) *CSSMathMax {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathMaxFromJS is casting a js.Value into CSSMathMax.
+func CSSMathMaxFromJS(value js.Value) *CSSMathMax {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathMax{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathMaxFromJS is casting from something that holds a js.Value into CSSMathMax.
+func CSSMathMaxFromWrapper(input core.Wrapper) *CSSMathMax {
+	return CSSMathMaxFromJS(input.JSValue())
 }
 
 func NewCSSMathMax(args ...*Union) (_result *CSSMathMax) {
@@ -1133,15 +1126,19 @@ type CSSMathMin struct {
 	CSSMathValue
 }
 
-// CSSMathMinFromJS is casting a js.Wrapper into CSSMathMin.
-func CSSMathMinFromJS(value js.Wrapper) *CSSMathMin {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathMinFromJS is casting a js.Value into CSSMathMin.
+func CSSMathMinFromJS(value js.Value) *CSSMathMin {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathMin{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathMinFromJS is casting from something that holds a js.Value into CSSMathMin.
+func CSSMathMinFromWrapper(input core.Wrapper) *CSSMathMin {
+	return CSSMathMinFromJS(input.JSValue())
 }
 
 func NewCSSMathMin(args ...*Union) (_result *CSSMathMin) {
@@ -1178,15 +1175,19 @@ type CSSMathNegate struct {
 	CSSMathValue
 }
 
-// CSSMathNegateFromJS is casting a js.Wrapper into CSSMathNegate.
-func CSSMathNegateFromJS(value js.Wrapper) *CSSMathNegate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathNegateFromJS is casting a js.Value into CSSMathNegate.
+func CSSMathNegateFromJS(value js.Value) *CSSMathNegate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathNegate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathNegateFromJS is casting from something that holds a js.Value into CSSMathNegate.
+func CSSMathNegateFromWrapper(input core.Wrapper) *CSSMathNegate {
+	return CSSMathNegateFromJS(input.JSValue())
 }
 
 func NewCSSMathNegate(arg *Union) (_result *CSSMathNegate) {
@@ -1221,15 +1222,19 @@ type CSSMathProduct struct {
 	CSSMathValue
 }
 
-// CSSMathProductFromJS is casting a js.Wrapper into CSSMathProduct.
-func CSSMathProductFromJS(value js.Wrapper) *CSSMathProduct {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathProductFromJS is casting a js.Value into CSSMathProduct.
+func CSSMathProductFromJS(value js.Value) *CSSMathProduct {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathProduct{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathProductFromJS is casting from something that holds a js.Value into CSSMathProduct.
+func CSSMathProductFromWrapper(input core.Wrapper) *CSSMathProduct {
+	return CSSMathProductFromJS(input.JSValue())
 }
 
 func NewCSSMathProduct(args ...*Union) (_result *CSSMathProduct) {
@@ -1266,15 +1271,19 @@ type CSSMathSum struct {
 	CSSMathValue
 }
 
-// CSSMathSumFromJS is casting a js.Wrapper into CSSMathSum.
-func CSSMathSumFromJS(value js.Wrapper) *CSSMathSum {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathSumFromJS is casting a js.Value into CSSMathSum.
+func CSSMathSumFromJS(value js.Value) *CSSMathSum {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathSum{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathSumFromJS is casting from something that holds a js.Value into CSSMathSum.
+func CSSMathSumFromWrapper(input core.Wrapper) *CSSMathSum {
+	return CSSMathSumFromJS(input.JSValue())
 }
 
 func NewCSSMathSum(args ...*Union) (_result *CSSMathSum) {
@@ -1311,15 +1320,19 @@ type CSSMathValue struct {
 	CSSNumericValue
 }
 
-// CSSMathValueFromJS is casting a js.Wrapper into CSSMathValue.
-func CSSMathValueFromJS(value js.Wrapper) *CSSMathValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMathValueFromJS is casting a js.Value into CSSMathValue.
+func CSSMathValueFromJS(value js.Value) *CSSMathValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMathValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMathValueFromJS is casting from something that holds a js.Value into CSSMathValue.
+func CSSMathValueFromWrapper(input core.Wrapper) *CSSMathValue {
+	return CSSMathValueFromJS(input.JSValue())
 }
 
 // Operator returning attribute 'operator' with
@@ -1336,15 +1349,19 @@ type CSSMatrixComponent struct {
 	CSSTransformComponent
 }
 
-// CSSMatrixComponentFromJS is casting a js.Wrapper into CSSMatrixComponent.
-func CSSMatrixComponentFromJS(value js.Wrapper) *CSSMatrixComponent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSMatrixComponentFromJS is casting a js.Value into CSSMatrixComponent.
+func CSSMatrixComponentFromJS(value js.Value) *CSSMatrixComponent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSMatrixComponent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSMatrixComponentFromJS is casting from something that holds a js.Value into CSSMatrixComponent.
+func CSSMatrixComponentFromWrapper(input core.Wrapper) *CSSMatrixComponent {
+	return CSSMatrixComponentFromJS(input.JSValue())
 }
 
 func NewCSSMatrixComponent(matrix *geometry.DOMMatrixReadOnly, options *CSSMatrixComponentOptions) (_result *CSSMatrixComponent) {
@@ -1396,15 +1413,19 @@ func (_this *CSSNumericArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayFromJS is casting a js.Wrapper into CSSNumericArray.
-func CSSNumericArrayFromJS(value js.Wrapper) *CSSNumericArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayFromJS is casting a js.Value into CSSNumericArray.
+func CSSNumericArrayFromJS(value js.Value) *CSSNumericArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayFromJS is casting from something that holds a js.Value into CSSNumericArray.
+func CSSNumericArrayFromWrapper(input core.Wrapper) *CSSNumericArray {
+	return CSSNumericArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1509,15 +1530,19 @@ func (_this *CSSNumericArrayEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayEntryIteratorFromJS is casting a js.Wrapper into CSSNumericArrayEntryIterator.
-func CSSNumericArrayEntryIteratorFromJS(value js.Wrapper) *CSSNumericArrayEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayEntryIteratorFromJS is casting a js.Value into CSSNumericArrayEntryIterator.
+func CSSNumericArrayEntryIteratorFromJS(value js.Value) *CSSNumericArrayEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayEntryIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayEntryIterator.
+func CSSNumericArrayEntryIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayEntryIterator {
+	return CSSNumericArrayEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayEntryIterator) Next() (_result *CSSNumericArrayEntryIteratorValue) {
@@ -1544,15 +1569,19 @@ func (_this *CSSNumericArrayKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayKeyIteratorFromJS is casting a js.Wrapper into CSSNumericArrayKeyIterator.
-func CSSNumericArrayKeyIteratorFromJS(value js.Wrapper) *CSSNumericArrayKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayKeyIteratorFromJS is casting a js.Value into CSSNumericArrayKeyIterator.
+func CSSNumericArrayKeyIteratorFromJS(value js.Value) *CSSNumericArrayKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayKeyIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayKeyIterator.
+func CSSNumericArrayKeyIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayKeyIterator {
+	return CSSNumericArrayKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayKeyIterator) Next() (_result *CSSNumericArrayKeyIteratorValue) {
@@ -1579,15 +1608,19 @@ func (_this *CSSNumericArrayValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSNumericArrayValueIteratorFromJS is casting a js.Wrapper into CSSNumericArrayValueIterator.
-func CSSNumericArrayValueIteratorFromJS(value js.Wrapper) *CSSNumericArrayValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericArrayValueIteratorFromJS is casting a js.Value into CSSNumericArrayValueIterator.
+func CSSNumericArrayValueIteratorFromJS(value js.Value) *CSSNumericArrayValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericArrayValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericArrayValueIteratorFromJS is casting from something that holds a js.Value into CSSNumericArrayValueIterator.
+func CSSNumericArrayValueIteratorFromWrapper(input core.Wrapper) *CSSNumericArrayValueIterator {
+	return CSSNumericArrayValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSNumericArrayValueIterator) Next() (_result *CSSNumericArrayValueIteratorValue) {
@@ -1609,15 +1642,19 @@ type CSSNumericValue struct {
 	CSSStyleValue
 }
 
-// CSSNumericValueFromJS is casting a js.Wrapper into CSSNumericValue.
-func CSSNumericValueFromJS(value js.Wrapper) *CSSNumericValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSNumericValueFromJS is casting a js.Value into CSSNumericValue.
+func CSSNumericValueFromJS(value js.Value) *CSSNumericValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSNumericValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSNumericValueFromJS is casting from something that holds a js.Value into CSSNumericValue.
+func CSSNumericValueFromWrapper(input core.Wrapper) *CSSNumericValue {
+	return CSSNumericValueFromJS(input.JSValue())
 }
 
 func Parse(cssText string) (_result *CSSNumericValue) {
@@ -1827,15 +1864,19 @@ type CSSPerspective struct {
 	CSSTransformComponent
 }
 
-// CSSPerspectiveFromJS is casting a js.Wrapper into CSSPerspective.
-func CSSPerspectiveFromJS(value js.Wrapper) *CSSPerspective {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSPerspectiveFromJS is casting a js.Value into CSSPerspective.
+func CSSPerspectiveFromJS(value js.Value) *CSSPerspective {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSPerspective{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSPerspectiveFromJS is casting from something that holds a js.Value into CSSPerspective.
+func CSSPerspectiveFromWrapper(input core.Wrapper) *CSSPerspective {
+	return CSSPerspectiveFromJS(input.JSValue())
 }
 
 func NewCSSPerspective(length *CSSNumericValue) (_result *CSSPerspective) {
@@ -1877,15 +1918,19 @@ type CSSRotate struct {
 	CSSTransformComponent
 }
 
-// CSSRotateFromJS is casting a js.Wrapper into CSSRotate.
-func CSSRotateFromJS(value js.Wrapper) *CSSRotate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSRotateFromJS is casting a js.Value into CSSRotate.
+func CSSRotateFromJS(value js.Value) *CSSRotate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSRotate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSRotateFromJS is casting from something that holds a js.Value into CSSRotate.
+func CSSRotateFromWrapper(input core.Wrapper) *CSSRotate {
+	return CSSRotateFromJS(input.JSValue())
 }
 
 func NewCSSRotate(x *Union, y *Union, z *Union, angle *CSSNumericValue) (_result *CSSRotate) {
@@ -1984,15 +2029,19 @@ type CSSScale struct {
 	CSSTransformComponent
 }
 
-// CSSScaleFromJS is casting a js.Wrapper into CSSScale.
-func CSSScaleFromJS(value js.Wrapper) *CSSScale {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSScaleFromJS is casting a js.Value into CSSScale.
+func CSSScaleFromJS(value js.Value) *CSSScale {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSScale{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSScaleFromJS is casting from something that holds a js.Value into CSSScale.
+func CSSScaleFromWrapper(input core.Wrapper) *CSSScale {
+	return CSSScaleFromJS(input.JSValue())
 }
 
 func NewCSSScale(x *Union, y *Union, z *Union) (_result *CSSScale) {
@@ -2074,15 +2123,19 @@ type CSSSkew struct {
 	CSSTransformComponent
 }
 
-// CSSSkewFromJS is casting a js.Wrapper into CSSSkew.
-func CSSSkewFromJS(value js.Wrapper) *CSSSkew {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewFromJS is casting a js.Value into CSSSkew.
+func CSSSkewFromJS(value js.Value) *CSSSkew {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkew{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewFromJS is casting from something that holds a js.Value into CSSSkew.
+func CSSSkewFromWrapper(input core.Wrapper) *CSSSkew {
+	return CSSSkewFromJS(input.JSValue())
 }
 
 func NewCSSSkew(ax *CSSNumericValue, ay *CSSNumericValue) (_result *CSSSkew) {
@@ -2143,15 +2196,19 @@ type CSSSkewX struct {
 	CSSTransformComponent
 }
 
-// CSSSkewXFromJS is casting a js.Wrapper into CSSSkewX.
-func CSSSkewXFromJS(value js.Wrapper) *CSSSkewX {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewXFromJS is casting a js.Value into CSSSkewX.
+func CSSSkewXFromJS(value js.Value) *CSSSkewX {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkewX{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewXFromJS is casting from something that holds a js.Value into CSSSkewX.
+func CSSSkewXFromWrapper(input core.Wrapper) *CSSSkewX {
+	return CSSSkewXFromJS(input.JSValue())
 }
 
 func NewCSSSkewX(ax *CSSNumericValue) (_result *CSSSkewX) {
@@ -2193,15 +2250,19 @@ type CSSSkewY struct {
 	CSSTransformComponent
 }
 
-// CSSSkewYFromJS is casting a js.Wrapper into CSSSkewY.
-func CSSSkewYFromJS(value js.Wrapper) *CSSSkewY {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSSkewYFromJS is casting a js.Value into CSSSkewY.
+func CSSSkewYFromJS(value js.Value) *CSSSkewY {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSSkewY{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSSkewYFromJS is casting from something that holds a js.Value into CSSSkewY.
+func CSSSkewYFromWrapper(input core.Wrapper) *CSSSkewY {
+	return CSSSkewYFromJS(input.JSValue())
 }
 
 func NewCSSSkewY(ay *CSSNumericValue) (_result *CSSSkewY) {
@@ -2248,15 +2309,19 @@ func (_this *CSSStyleValue) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSStyleValueFromJS is casting a js.Wrapper into CSSStyleValue.
-func CSSStyleValueFromJS(value js.Wrapper) *CSSStyleValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSStyleValueFromJS is casting a js.Value into CSSStyleValue.
+func CSSStyleValueFromJS(value js.Value) *CSSStyleValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSStyleValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSStyleValueFromJS is casting from something that holds a js.Value into CSSStyleValue.
+func CSSStyleValueFromWrapper(input core.Wrapper) *CSSStyleValue {
+	return CSSStyleValueFromJS(input.JSValue())
 }
 
 func Parse2(property string, cssText string) (_result *CSSStyleValue) {
@@ -2335,15 +2400,19 @@ func (_this *CSSTransformComponent) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformComponentFromJS is casting a js.Wrapper into CSSTransformComponent.
-func CSSTransformComponentFromJS(value js.Wrapper) *CSSTransformComponent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformComponentFromJS is casting a js.Value into CSSTransformComponent.
+func CSSTransformComponentFromJS(value js.Value) *CSSTransformComponent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformComponent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformComponentFromJS is casting from something that holds a js.Value into CSSTransformComponent.
+func CSSTransformComponentFromWrapper(input core.Wrapper) *CSSTransformComponent {
+	return CSSTransformComponentFromJS(input.JSValue())
 }
 
 // Is2D returning attribute 'is2D' with
@@ -2395,15 +2464,19 @@ type CSSTransformValue struct {
 	CSSStyleValue
 }
 
-// CSSTransformValueFromJS is casting a js.Wrapper into CSSTransformValue.
-func CSSTransformValueFromJS(value js.Wrapper) *CSSTransformValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueFromJS is casting a js.Value into CSSTransformValue.
+func CSSTransformValueFromJS(value js.Value) *CSSTransformValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueFromJS is casting from something that holds a js.Value into CSSTransformValue.
+func CSSTransformValueFromWrapper(input core.Wrapper) *CSSTransformValue {
+	return CSSTransformValueFromJS(input.JSValue())
 }
 
 func NewCSSTransformValue(transforms []*CSSTransformComponent) (_result *CSSTransformValue) {
@@ -2573,15 +2646,19 @@ func (_this *CSSTransformValueEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueEntryIteratorFromJS is casting a js.Wrapper into CSSTransformValueEntryIterator.
-func CSSTransformValueEntryIteratorFromJS(value js.Wrapper) *CSSTransformValueEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueEntryIteratorFromJS is casting a js.Value into CSSTransformValueEntryIterator.
+func CSSTransformValueEntryIteratorFromJS(value js.Value) *CSSTransformValueEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueEntryIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueEntryIterator.
+func CSSTransformValueEntryIteratorFromWrapper(input core.Wrapper) *CSSTransformValueEntryIterator {
+	return CSSTransformValueEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueEntryIterator) Next() (_result *CSSTransformValueEntryIteratorValue) {
@@ -2608,15 +2685,19 @@ func (_this *CSSTransformValueKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueKeyIteratorFromJS is casting a js.Wrapper into CSSTransformValueKeyIterator.
-func CSSTransformValueKeyIteratorFromJS(value js.Wrapper) *CSSTransformValueKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueKeyIteratorFromJS is casting a js.Value into CSSTransformValueKeyIterator.
+func CSSTransformValueKeyIteratorFromJS(value js.Value) *CSSTransformValueKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueKeyIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueKeyIterator.
+func CSSTransformValueKeyIteratorFromWrapper(input core.Wrapper) *CSSTransformValueKeyIterator {
+	return CSSTransformValueKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueKeyIterator) Next() (_result *CSSTransformValueKeyIteratorValue) {
@@ -2643,15 +2724,19 @@ func (_this *CSSTransformValueValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSTransformValueValueIteratorFromJS is casting a js.Wrapper into CSSTransformValueValueIterator.
-func CSSTransformValueValueIteratorFromJS(value js.Wrapper) *CSSTransformValueValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTransformValueValueIteratorFromJS is casting a js.Value into CSSTransformValueValueIterator.
+func CSSTransformValueValueIteratorFromJS(value js.Value) *CSSTransformValueValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTransformValueValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTransformValueValueIteratorFromJS is casting from something that holds a js.Value into CSSTransformValueValueIterator.
+func CSSTransformValueValueIteratorFromWrapper(input core.Wrapper) *CSSTransformValueValueIterator {
+	return CSSTransformValueValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSTransformValueValueIterator) Next() (_result *CSSTransformValueValueIteratorValue) {
@@ -2673,15 +2758,19 @@ type CSSTranslate struct {
 	CSSTransformComponent
 }
 
-// CSSTranslateFromJS is casting a js.Wrapper into CSSTranslate.
-func CSSTranslateFromJS(value js.Wrapper) *CSSTranslate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSTranslateFromJS is casting a js.Value into CSSTranslate.
+func CSSTranslateFromJS(value js.Value) *CSSTranslate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSTranslate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSTranslateFromJS is casting from something that holds a js.Value into CSSTranslate.
+func CSSTranslateFromWrapper(input core.Wrapper) *CSSTranslate {
+	return CSSTranslateFromJS(input.JSValue())
 }
 
 func NewCSSTranslate(x *CSSNumericValue, y *CSSNumericValue, z *CSSNumericValue) (_result *CSSTranslate) {
@@ -2763,15 +2852,19 @@ type CSSUnitValue struct {
 	CSSNumericValue
 }
 
-// CSSUnitValueFromJS is casting a js.Wrapper into CSSUnitValue.
-func CSSUnitValueFromJS(value js.Wrapper) *CSSUnitValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnitValueFromJS is casting a js.Value into CSSUnitValue.
+func CSSUnitValueFromJS(value js.Value) *CSSUnitValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnitValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnitValueFromJS is casting from something that holds a js.Value into CSSUnitValue.
+func CSSUnitValueFromWrapper(input core.Wrapper) *CSSUnitValue {
+	return CSSUnitValueFromJS(input.JSValue())
 }
 
 func NewCSSUnitValue(value float64, unit string) (_result *CSSUnitValue) {
@@ -2825,15 +2918,19 @@ type CSSUnparsedValue struct {
 	CSSStyleValue
 }
 
-// CSSUnparsedValueFromJS is casting a js.Wrapper into CSSUnparsedValue.
-func CSSUnparsedValueFromJS(value js.Wrapper) *CSSUnparsedValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueFromJS is casting a js.Value into CSSUnparsedValue.
+func CSSUnparsedValueFromJS(value js.Value) *CSSUnparsedValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueFromJS is casting from something that holds a js.Value into CSSUnparsedValue.
+func CSSUnparsedValueFromWrapper(input core.Wrapper) *CSSUnparsedValue {
+	return CSSUnparsedValueFromJS(input.JSValue())
 }
 
 func NewCSSUnparsedValue(members []*Union) (_result *CSSUnparsedValue) {
@@ -2980,15 +3077,19 @@ func (_this *CSSUnparsedValueEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueEntryIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueEntryIterator.
-func CSSUnparsedValueEntryIteratorFromJS(value js.Wrapper) *CSSUnparsedValueEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueEntryIteratorFromJS is casting a js.Value into CSSUnparsedValueEntryIterator.
+func CSSUnparsedValueEntryIteratorFromJS(value js.Value) *CSSUnparsedValueEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueEntryIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueEntryIterator.
+func CSSUnparsedValueEntryIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueEntryIterator {
+	return CSSUnparsedValueEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueEntryIterator) Next() (_result *CSSUnparsedValueEntryIteratorValue) {
@@ -3015,15 +3116,19 @@ func (_this *CSSUnparsedValueKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueKeyIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueKeyIterator.
-func CSSUnparsedValueKeyIteratorFromJS(value js.Wrapper) *CSSUnparsedValueKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueKeyIteratorFromJS is casting a js.Value into CSSUnparsedValueKeyIterator.
+func CSSUnparsedValueKeyIteratorFromJS(value js.Value) *CSSUnparsedValueKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueKeyIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueKeyIterator.
+func CSSUnparsedValueKeyIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueKeyIterator {
+	return CSSUnparsedValueKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueKeyIterator) Next() (_result *CSSUnparsedValueKeyIteratorValue) {
@@ -3050,15 +3155,19 @@ func (_this *CSSUnparsedValueValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSUnparsedValueValueIteratorFromJS is casting a js.Wrapper into CSSUnparsedValueValueIterator.
-func CSSUnparsedValueValueIteratorFromJS(value js.Wrapper) *CSSUnparsedValueValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSUnparsedValueValueIteratorFromJS is casting a js.Value into CSSUnparsedValueValueIterator.
+func CSSUnparsedValueValueIteratorFromJS(value js.Value) *CSSUnparsedValueValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSUnparsedValueValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSUnparsedValueValueIteratorFromJS is casting from something that holds a js.Value into CSSUnparsedValueValueIterator.
+func CSSUnparsedValueValueIteratorFromWrapper(input core.Wrapper) *CSSUnparsedValueValueIterator {
+	return CSSUnparsedValueValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *CSSUnparsedValueValueIterator) Next() (_result *CSSUnparsedValueValueIteratorValue) {
@@ -3085,15 +3194,19 @@ func (_this *CSSVariableReferenceValue) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CSSVariableReferenceValueFromJS is casting a js.Wrapper into CSSVariableReferenceValue.
-func CSSVariableReferenceValueFromJS(value js.Wrapper) *CSSVariableReferenceValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CSSVariableReferenceValueFromJS is casting a js.Value into CSSVariableReferenceValue.
+func CSSVariableReferenceValueFromJS(value js.Value) *CSSVariableReferenceValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CSSVariableReferenceValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CSSVariableReferenceValueFromJS is casting from something that holds a js.Value into CSSVariableReferenceValue.
+func CSSVariableReferenceValueFromWrapper(input core.Wrapper) *CSSVariableReferenceValue {
+	return CSSVariableReferenceValueFromJS(input.JSValue())
 }
 
 func NewCSSVariableReferenceValue(variable string, fallback *CSSUnparsedValue) (_result *CSSVariableReferenceValue) {
@@ -3151,15 +3264,19 @@ type StylePropertyMap struct {
 	StylePropertyMapReadOnly
 }
 
-// StylePropertyMapFromJS is casting a js.Wrapper into StylePropertyMap.
-func StylePropertyMapFromJS(value js.Wrapper) *StylePropertyMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapFromJS is casting a js.Value into StylePropertyMap.
+func StylePropertyMapFromJS(value js.Value) *StylePropertyMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapFromJS is casting from something that holds a js.Value into StylePropertyMap.
+func StylePropertyMapFromWrapper(input core.Wrapper) *StylePropertyMap {
+	return StylePropertyMapFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMap) Set(property string, values ...*Union) {
@@ -3227,15 +3344,19 @@ func (_this *StylePropertyMapReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyFromJS is casting a js.Wrapper into StylePropertyMapReadOnly.
-func StylePropertyMapReadOnlyFromJS(value js.Wrapper) *StylePropertyMapReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyFromJS is casting a js.Value into StylePropertyMapReadOnly.
+func StylePropertyMapReadOnlyFromJS(value js.Value) *StylePropertyMapReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnly.
+func StylePropertyMapReadOnlyFromWrapper(input core.Wrapper) *StylePropertyMapReadOnly {
+	return StylePropertyMapReadOnlyFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -3382,15 +3503,19 @@ func (_this *StylePropertyMapReadOnlyEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyEntryIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyEntryIterator.
-func StylePropertyMapReadOnlyEntryIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyEntryIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyEntryIterator.
+func StylePropertyMapReadOnlyEntryIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyEntryIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyEntryIterator.
+func StylePropertyMapReadOnlyEntryIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyEntryIterator {
+	return StylePropertyMapReadOnlyEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyEntryIterator) Next() (_result *StylePropertyMapReadOnlyEntryIteratorValue) {
@@ -3417,15 +3542,19 @@ func (_this *StylePropertyMapReadOnlyKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyKeyIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyKeyIterator.
-func StylePropertyMapReadOnlyKeyIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyKeyIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyKeyIterator.
+func StylePropertyMapReadOnlyKeyIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyKeyIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyKeyIterator.
+func StylePropertyMapReadOnlyKeyIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyKeyIterator {
+	return StylePropertyMapReadOnlyKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyKeyIterator) Next() (_result *StylePropertyMapReadOnlyKeyIteratorValue) {
@@ -3452,15 +3581,19 @@ func (_this *StylePropertyMapReadOnlyValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StylePropertyMapReadOnlyValueIteratorFromJS is casting a js.Wrapper into StylePropertyMapReadOnlyValueIterator.
-func StylePropertyMapReadOnlyValueIteratorFromJS(value js.Wrapper) *StylePropertyMapReadOnlyValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StylePropertyMapReadOnlyValueIteratorFromJS is casting a js.Value into StylePropertyMapReadOnlyValueIterator.
+func StylePropertyMapReadOnlyValueIteratorFromJS(value js.Value) *StylePropertyMapReadOnlyValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StylePropertyMapReadOnlyValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StylePropertyMapReadOnlyValueIteratorFromJS is casting from something that holds a js.Value into StylePropertyMapReadOnlyValueIterator.
+func StylePropertyMapReadOnlyValueIteratorFromWrapper(input core.Wrapper) *StylePropertyMapReadOnlyValueIterator {
+	return StylePropertyMapReadOnlyValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *StylePropertyMapReadOnlyValueIterator) Next() (_result *StylePropertyMapReadOnlyValueIteratorValue) {

--- a/device/battery/battery.go
+++ b/device/battery/battery.go
@@ -7,6 +7,7 @@ package battery
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -127,15 +128,19 @@ type BatteryManager struct {
 	domcore.EventTarget
 }
 
-// BatteryManagerFromJS is casting a js.Wrapper into BatteryManager.
-func BatteryManagerFromJS(value js.Wrapper) *BatteryManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BatteryManagerFromJS is casting a js.Value into BatteryManager.
+func BatteryManagerFromJS(value js.Value) *BatteryManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BatteryManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BatteryManagerFromJS is casting from something that holds a js.Value into BatteryManager.
+func BatteryManagerFromWrapper(input core.Wrapper) *BatteryManager {
+	return BatteryManagerFromJS(input.JSValue())
 }
 
 // Charging returning attribute 'charging' with
@@ -306,15 +311,19 @@ func (_this *PromiseBatteryManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBatteryManagerFromJS is casting a js.Wrapper into PromiseBatteryManager.
-func PromiseBatteryManagerFromJS(value js.Wrapper) *PromiseBatteryManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBatteryManagerFromJS is casting a js.Value into PromiseBatteryManager.
+func PromiseBatteryManagerFromJS(value js.Value) *PromiseBatteryManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBatteryManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBatteryManagerFromJS is casting from something that holds a js.Value into PromiseBatteryManager.
+func PromiseBatteryManagerFromWrapper(input core.Wrapper) *PromiseBatteryManager {
+	return PromiseBatteryManagerFromJS(input.JSValue())
 }
 
 func (_this *PromiseBatteryManager) Then(onFulfilled *PromiseBatteryManagerOnFulfilled, onRejected *PromiseBatteryManagerOnRejected) (_result *PromiseBatteryManager) {

--- a/device/battery/battery_js.go
+++ b/device/battery/battery_js.go
@@ -5,6 +5,7 @@ package battery
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -125,15 +126,19 @@ type BatteryManager struct {
 	domcore.EventTarget
 }
 
-// BatteryManagerFromJS is casting a js.Wrapper into BatteryManager.
-func BatteryManagerFromJS(value js.Wrapper) *BatteryManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BatteryManagerFromJS is casting a js.Value into BatteryManager.
+func BatteryManagerFromJS(value js.Value) *BatteryManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BatteryManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BatteryManagerFromJS is casting from something that holds a js.Value into BatteryManager.
+func BatteryManagerFromWrapper(input core.Wrapper) *BatteryManager {
+	return BatteryManagerFromJS(input.JSValue())
 }
 
 // Charging returning attribute 'charging' with
@@ -304,15 +309,19 @@ func (_this *PromiseBatteryManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBatteryManagerFromJS is casting a js.Wrapper into PromiseBatteryManager.
-func PromiseBatteryManagerFromJS(value js.Wrapper) *PromiseBatteryManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBatteryManagerFromJS is casting a js.Value into PromiseBatteryManager.
+func PromiseBatteryManagerFromJS(value js.Value) *PromiseBatteryManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBatteryManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBatteryManagerFromJS is casting from something that holds a js.Value into PromiseBatteryManager.
+func PromiseBatteryManagerFromWrapper(input core.Wrapper) *PromiseBatteryManager {
+	return PromiseBatteryManagerFromJS(input.JSValue())
 }
 
 func (_this *PromiseBatteryManager) Then(onFulfilled *PromiseBatteryManagerOnFulfilled, onRejected *PromiseBatteryManagerOnRejected) (_result *PromiseBatteryManager) {

--- a/device/gamepad/gamepad.go
+++ b/device/gamepad/gamepad.go
@@ -7,6 +7,7 @@ package gamepad
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -88,7 +89,7 @@ type GamepadEventInit struct {
 	Gamepad    *Gamepad
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GamepadEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -104,10 +105,8 @@ func (_this *GamepadEventInit) JSValue() js.Value {
 }
 
 // GamepadEventInitFromJS is allocating a new
-// GamepadEventInit object and copy all values from
-// input javascript object
-func GamepadEventInitFromJS(value js.Wrapper) *GamepadEventInit {
-	input := value.JSValue()
+// GamepadEventInit object and copy all values in the value javascript object.
+func GamepadEventInitFromJS(value js.Value) *GamepadEventInit {
 	var out GamepadEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -115,13 +114,13 @@ func GamepadEventInitFromJS(value js.Wrapper) *GamepadEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 *Gamepad // javascript: Gamepad {gamepad Gamepad gamepad}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = GamepadFromJS(input.Get("gamepad"))
+	value3 = GamepadFromJS(value.Get("gamepad"))
 	out.Gamepad = value3
 	return &out
 }
@@ -136,15 +135,19 @@ func (_this *Gamepad) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GamepadFromJS is casting a js.Wrapper into Gamepad.
-func GamepadFromJS(value js.Wrapper) *Gamepad {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadFromJS is casting a js.Value into Gamepad.
+func GamepadFromJS(value js.Value) *Gamepad {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Gamepad{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadFromJS is casting from something that holds a js.Value into Gamepad.
+func GamepadFromWrapper(input core.Wrapper) *Gamepad {
+	return GamepadFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -229,15 +232,19 @@ func (_this *GamepadButton) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GamepadButtonFromJS is casting a js.Wrapper into GamepadButton.
-func GamepadButtonFromJS(value js.Wrapper) *GamepadButton {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadButtonFromJS is casting a js.Value into GamepadButton.
+func GamepadButtonFromJS(value js.Value) *GamepadButton {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GamepadButton{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadButtonFromJS is casting from something that holds a js.Value into GamepadButton.
+func GamepadButtonFromWrapper(input core.Wrapper) *GamepadButton {
+	return GamepadButtonFromJS(input.JSValue())
 }
 
 // Pressed returning attribute 'pressed' with
@@ -272,15 +279,19 @@ type GamepadEvent struct {
 	domcore.Event
 }
 
-// GamepadEventFromJS is casting a js.Wrapper into GamepadEvent.
-func GamepadEventFromJS(value js.Wrapper) *GamepadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadEventFromJS is casting a js.Value into GamepadEvent.
+func GamepadEventFromJS(value js.Value) *GamepadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GamepadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadEventFromJS is casting from something that holds a js.Value into GamepadEvent.
+func GamepadEventFromWrapper(input core.Wrapper) *GamepadEvent {
+	return GamepadEventFromJS(input.JSValue())
 }
 
 func NewGamepadEvent(_type string, eventInitDict *GamepadEventInit) (_result *GamepadEvent) {

--- a/device/gamepad/gamepad_js.go
+++ b/device/gamepad/gamepad_js.go
@@ -5,6 +5,7 @@ package gamepad
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -86,7 +87,7 @@ type GamepadEventInit struct {
 	Gamepad    *Gamepad
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GamepadEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -102,10 +103,8 @@ func (_this *GamepadEventInit) JSValue() js.Value {
 }
 
 // GamepadEventInitFromJS is allocating a new
-// GamepadEventInit object and copy all values from
-// input javascript object
-func GamepadEventInitFromJS(value js.Wrapper) *GamepadEventInit {
-	input := value.JSValue()
+// GamepadEventInit object and copy all values in the value javascript object.
+func GamepadEventInitFromJS(value js.Value) *GamepadEventInit {
 	var out GamepadEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -113,13 +112,13 @@ func GamepadEventInitFromJS(value js.Wrapper) *GamepadEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 *Gamepad // javascript: Gamepad {gamepad Gamepad gamepad}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = GamepadFromJS(input.Get("gamepad"))
+	value3 = GamepadFromJS(value.Get("gamepad"))
 	out.Gamepad = value3
 	return &out
 }
@@ -134,15 +133,19 @@ func (_this *Gamepad) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GamepadFromJS is casting a js.Wrapper into Gamepad.
-func GamepadFromJS(value js.Wrapper) *Gamepad {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadFromJS is casting a js.Value into Gamepad.
+func GamepadFromJS(value js.Value) *Gamepad {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Gamepad{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadFromJS is casting from something that holds a js.Value into Gamepad.
+func GamepadFromWrapper(input core.Wrapper) *Gamepad {
+	return GamepadFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -227,15 +230,19 @@ func (_this *GamepadButton) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GamepadButtonFromJS is casting a js.Wrapper into GamepadButton.
-func GamepadButtonFromJS(value js.Wrapper) *GamepadButton {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadButtonFromJS is casting a js.Value into GamepadButton.
+func GamepadButtonFromJS(value js.Value) *GamepadButton {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GamepadButton{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadButtonFromJS is casting from something that holds a js.Value into GamepadButton.
+func GamepadButtonFromWrapper(input core.Wrapper) *GamepadButton {
+	return GamepadButtonFromJS(input.JSValue())
 }
 
 // Pressed returning attribute 'pressed' with
@@ -270,15 +277,19 @@ type GamepadEvent struct {
 	domcore.Event
 }
 
-// GamepadEventFromJS is casting a js.Wrapper into GamepadEvent.
-func GamepadEventFromJS(value js.Wrapper) *GamepadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GamepadEventFromJS is casting a js.Value into GamepadEvent.
+func GamepadEventFromJS(value js.Value) *GamepadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GamepadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GamepadEventFromJS is casting from something that holds a js.Value into GamepadEvent.
+func GamepadEventFromWrapper(input core.Wrapper) *GamepadEvent {
+	return GamepadEventFromJS(input.JSValue())
 }
 
 func NewGamepadEvent(_type string, eventInitDict *GamepadEventInit) (_result *GamepadEvent) {

--- a/device/inputcapabilities/inputcapabilities.go
+++ b/device/inputcapabilities/inputcapabilities.go
@@ -6,6 +6,10 @@ package inputcapabilities
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -37,7 +41,7 @@ type InputDeviceCapabilitiesInit struct {
 	PointerMovementScrolls bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputDeviceCapabilitiesInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -49,18 +53,16 @@ func (_this *InputDeviceCapabilitiesInit) JSValue() js.Value {
 }
 
 // InputDeviceCapabilitiesInitFromJS is allocating a new
-// InputDeviceCapabilitiesInit object and copy all values from
-// input javascript object
-func InputDeviceCapabilitiesInitFromJS(value js.Wrapper) *InputDeviceCapabilitiesInit {
-	input := value.JSValue()
+// InputDeviceCapabilitiesInit object and copy all values in the value javascript object.
+func InputDeviceCapabilitiesInitFromJS(value js.Value) *InputDeviceCapabilitiesInit {
 	var out InputDeviceCapabilitiesInit
 	var (
 		value0 bool // javascript: boolean {firesTouchEvents FiresTouchEvents firesTouchEvents}
 		value1 bool // javascript: boolean {pointerMovementScrolls PointerMovementScrolls pointerMovementScrolls}
 	)
-	value0 = (input.Get("firesTouchEvents")).Bool()
+	value0 = (value.Get("firesTouchEvents")).Bool()
 	out.FiresTouchEvents = value0
-	value1 = (input.Get("pointerMovementScrolls")).Bool()
+	value1 = (value.Get("pointerMovementScrolls")).Bool()
 	out.PointerMovementScrolls = value1
 	return &out
 }
@@ -75,15 +77,19 @@ func (_this *InputDeviceCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputDeviceCapabilitiesFromJS is casting a js.Wrapper into InputDeviceCapabilities.
-func InputDeviceCapabilitiesFromJS(value js.Wrapper) *InputDeviceCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputDeviceCapabilitiesFromJS is casting a js.Value into InputDeviceCapabilities.
+func InputDeviceCapabilitiesFromJS(value js.Value) *InputDeviceCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputDeviceCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputDeviceCapabilitiesFromJS is casting from something that holds a js.Value into InputDeviceCapabilities.
+func InputDeviceCapabilitiesFromWrapper(input core.Wrapper) *InputDeviceCapabilities {
+	return InputDeviceCapabilitiesFromJS(input.JSValue())
 }
 
 func NewInputDeviceCapabilities(deviceInitDict *InputDeviceCapabilitiesInit) (_result *InputDeviceCapabilities) {

--- a/device/inputcapabilities/inputcapabilities_js.go
+++ b/device/inputcapabilities/inputcapabilities_js.go
@@ -4,6 +4,10 @@ package inputcapabilities
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -35,7 +39,7 @@ type InputDeviceCapabilitiesInit struct {
 	PointerMovementScrolls bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputDeviceCapabilitiesInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -47,18 +51,16 @@ func (_this *InputDeviceCapabilitiesInit) JSValue() js.Value {
 }
 
 // InputDeviceCapabilitiesInitFromJS is allocating a new
-// InputDeviceCapabilitiesInit object and copy all values from
-// input javascript object
-func InputDeviceCapabilitiesInitFromJS(value js.Wrapper) *InputDeviceCapabilitiesInit {
-	input := value.JSValue()
+// InputDeviceCapabilitiesInit object and copy all values in the value javascript object.
+func InputDeviceCapabilitiesInitFromJS(value js.Value) *InputDeviceCapabilitiesInit {
 	var out InputDeviceCapabilitiesInit
 	var (
 		value0 bool // javascript: boolean {firesTouchEvents FiresTouchEvents firesTouchEvents}
 		value1 bool // javascript: boolean {pointerMovementScrolls PointerMovementScrolls pointerMovementScrolls}
 	)
-	value0 = (input.Get("firesTouchEvents")).Bool()
+	value0 = (value.Get("firesTouchEvents")).Bool()
 	out.FiresTouchEvents = value0
-	value1 = (input.Get("pointerMovementScrolls")).Bool()
+	value1 = (value.Get("pointerMovementScrolls")).Bool()
 	out.PointerMovementScrolls = value1
 	return &out
 }
@@ -73,15 +75,19 @@ func (_this *InputDeviceCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputDeviceCapabilitiesFromJS is casting a js.Wrapper into InputDeviceCapabilities.
-func InputDeviceCapabilitiesFromJS(value js.Wrapper) *InputDeviceCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputDeviceCapabilitiesFromJS is casting a js.Value into InputDeviceCapabilities.
+func InputDeviceCapabilitiesFromJS(value js.Value) *InputDeviceCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputDeviceCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputDeviceCapabilitiesFromJS is casting from something that holds a js.Value into InputDeviceCapabilities.
+func InputDeviceCapabilitiesFromWrapper(input core.Wrapper) *InputDeviceCapabilities {
+	return InputDeviceCapabilitiesFromJS(input.JSValue())
 }
 
 func NewInputDeviceCapabilities(deviceInitDict *InputDeviceCapabilitiesInit) (_result *InputDeviceCapabilities) {

--- a/device/keyboard/keyboard.go
+++ b/device/keyboard/keyboard.go
@@ -7,6 +7,7 @@ package keyboard
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -177,7 +178,7 @@ type LayoutMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -193,26 +194,24 @@ func (_this *LayoutMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapEntryIteratorValueFromJS is allocating a new
-// LayoutMapEntryIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapEntryIteratorValueFromJS(value js.Wrapper) *LayoutMapEntryIteratorValue {
-	input := value.JSValue()
+// LayoutMapEntryIteratorValue object and copy all values in the value javascript object.
+func LayoutMapEntryIteratorValueFromJS(value js.Value) *LayoutMapEntryIteratorValue {
 	var out LayoutMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -223,7 +222,7 @@ type LayoutMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -235,18 +234,16 @@ func (_this *LayoutMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapKeyIteratorValueFromJS is allocating a new
-// LayoutMapKeyIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapKeyIteratorValueFromJS(value js.Wrapper) *LayoutMapKeyIteratorValue {
-	input := value.JSValue()
+// LayoutMapKeyIteratorValue object and copy all values in the value javascript object.
+func LayoutMapKeyIteratorValueFromJS(value js.Value) *LayoutMapKeyIteratorValue {
 	var out LayoutMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -257,7 +254,7 @@ type LayoutMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -269,18 +266,16 @@ func (_this *LayoutMapValueIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapValueIteratorValueFromJS is allocating a new
-// LayoutMapValueIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapValueIteratorValueFromJS(value js.Wrapper) *LayoutMapValueIteratorValue {
-	input := value.JSValue()
+// LayoutMapValueIteratorValue object and copy all values in the value javascript object.
+func LayoutMapValueIteratorValueFromJS(value js.Value) *LayoutMapValueIteratorValue {
 	var out LayoutMapValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -295,15 +290,19 @@ func (_this *Keyboard) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// KeyboardFromJS is casting a js.Wrapper into Keyboard.
-func KeyboardFromJS(value js.Wrapper) *Keyboard {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyboardFromJS is casting a js.Value into Keyboard.
+func KeyboardFromJS(value js.Value) *Keyboard {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Keyboard{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyboardFromJS is casting from something that holds a js.Value into Keyboard.
+func KeyboardFromWrapper(input core.Wrapper) *Keyboard {
+	return KeyboardFromJS(input.JSValue())
 }
 
 func (_this *Keyboard) Lock(keyCodes []string) (_result *javascript.PromiseVoid) {
@@ -362,15 +361,19 @@ func (_this *LayoutMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapFromJS is casting a js.Wrapper into LayoutMap.
-func LayoutMapFromJS(value js.Wrapper) *LayoutMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapFromJS is casting a js.Value into LayoutMap.
+func LayoutMapFromJS(value js.Value) *LayoutMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapFromJS is casting from something that holds a js.Value into LayoutMap.
+func LayoutMapFromWrapper(input core.Wrapper) *LayoutMap {
+	return LayoutMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -495,15 +498,19 @@ func (_this *LayoutMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapEntryIteratorFromJS is casting a js.Wrapper into LayoutMapEntryIterator.
-func LayoutMapEntryIteratorFromJS(value js.Wrapper) *LayoutMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapEntryIteratorFromJS is casting a js.Value into LayoutMapEntryIterator.
+func LayoutMapEntryIteratorFromJS(value js.Value) *LayoutMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapEntryIteratorFromJS is casting from something that holds a js.Value into LayoutMapEntryIterator.
+func LayoutMapEntryIteratorFromWrapper(input core.Wrapper) *LayoutMapEntryIterator {
+	return LayoutMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapEntryIterator) Next() (_result *LayoutMapEntryIteratorValue) {
@@ -530,15 +537,19 @@ func (_this *LayoutMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapKeyIteratorFromJS is casting a js.Wrapper into LayoutMapKeyIterator.
-func LayoutMapKeyIteratorFromJS(value js.Wrapper) *LayoutMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapKeyIteratorFromJS is casting a js.Value into LayoutMapKeyIterator.
+func LayoutMapKeyIteratorFromJS(value js.Value) *LayoutMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapKeyIteratorFromJS is casting from something that holds a js.Value into LayoutMapKeyIterator.
+func LayoutMapKeyIteratorFromWrapper(input core.Wrapper) *LayoutMapKeyIterator {
+	return LayoutMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapKeyIterator) Next() (_result *LayoutMapKeyIteratorValue) {
@@ -565,15 +576,19 @@ func (_this *LayoutMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapValueIteratorFromJS is casting a js.Wrapper into LayoutMapValueIterator.
-func LayoutMapValueIteratorFromJS(value js.Wrapper) *LayoutMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapValueIteratorFromJS is casting a js.Value into LayoutMapValueIterator.
+func LayoutMapValueIteratorFromJS(value js.Value) *LayoutMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapValueIteratorFromJS is casting from something that holds a js.Value into LayoutMapValueIterator.
+func LayoutMapValueIteratorFromWrapper(input core.Wrapper) *LayoutMapValueIterator {
+	return LayoutMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapValueIterator) Next() (_result *LayoutMapValueIteratorValue) {
@@ -600,15 +615,19 @@ func (_this *PromiseLayoutMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseLayoutMapFromJS is casting a js.Wrapper into PromiseLayoutMap.
-func PromiseLayoutMapFromJS(value js.Wrapper) *PromiseLayoutMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseLayoutMapFromJS is casting a js.Value into PromiseLayoutMap.
+func PromiseLayoutMapFromJS(value js.Value) *PromiseLayoutMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseLayoutMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseLayoutMapFromJS is casting from something that holds a js.Value into PromiseLayoutMap.
+func PromiseLayoutMapFromWrapper(input core.Wrapper) *PromiseLayoutMap {
+	return PromiseLayoutMapFromJS(input.JSValue())
 }
 
 func (_this *PromiseLayoutMap) Then(onFulfilled *PromiseLayoutMapOnFulfilled, onRejected *PromiseLayoutMapOnRejected) (_result *PromiseLayoutMap) {

--- a/device/keyboard/keyboard_js.go
+++ b/device/keyboard/keyboard_js.go
@@ -5,6 +5,7 @@ package keyboard
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -175,7 +176,7 @@ type LayoutMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -191,26 +192,24 @@ func (_this *LayoutMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapEntryIteratorValueFromJS is allocating a new
-// LayoutMapEntryIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapEntryIteratorValueFromJS(value js.Wrapper) *LayoutMapEntryIteratorValue {
-	input := value.JSValue()
+// LayoutMapEntryIteratorValue object and copy all values in the value javascript object.
+func LayoutMapEntryIteratorValueFromJS(value js.Value) *LayoutMapEntryIteratorValue {
 	var out LayoutMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -221,7 +220,7 @@ type LayoutMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -233,18 +232,16 @@ func (_this *LayoutMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapKeyIteratorValueFromJS is allocating a new
-// LayoutMapKeyIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapKeyIteratorValueFromJS(value js.Wrapper) *LayoutMapKeyIteratorValue {
-	input := value.JSValue()
+// LayoutMapKeyIteratorValue object and copy all values in the value javascript object.
+func LayoutMapKeyIteratorValueFromJS(value js.Value) *LayoutMapKeyIteratorValue {
 	var out LayoutMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -255,7 +252,7 @@ type LayoutMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayoutMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -267,18 +264,16 @@ func (_this *LayoutMapValueIteratorValue) JSValue() js.Value {
 }
 
 // LayoutMapValueIteratorValueFromJS is allocating a new
-// LayoutMapValueIteratorValue object and copy all values from
-// input javascript object
-func LayoutMapValueIteratorValueFromJS(value js.Wrapper) *LayoutMapValueIteratorValue {
-	input := value.JSValue()
+// LayoutMapValueIteratorValue object and copy all values in the value javascript object.
+func LayoutMapValueIteratorValueFromJS(value js.Value) *LayoutMapValueIteratorValue {
 	var out LayoutMapValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -293,15 +288,19 @@ func (_this *Keyboard) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// KeyboardFromJS is casting a js.Wrapper into Keyboard.
-func KeyboardFromJS(value js.Wrapper) *Keyboard {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyboardFromJS is casting a js.Value into Keyboard.
+func KeyboardFromJS(value js.Value) *Keyboard {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Keyboard{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyboardFromJS is casting from something that holds a js.Value into Keyboard.
+func KeyboardFromWrapper(input core.Wrapper) *Keyboard {
+	return KeyboardFromJS(input.JSValue())
 }
 
 func (_this *Keyboard) Lock(keyCodes []string) (_result *javascript.PromiseVoid) {
@@ -360,15 +359,19 @@ func (_this *LayoutMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapFromJS is casting a js.Wrapper into LayoutMap.
-func LayoutMapFromJS(value js.Wrapper) *LayoutMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapFromJS is casting a js.Value into LayoutMap.
+func LayoutMapFromJS(value js.Value) *LayoutMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapFromJS is casting from something that holds a js.Value into LayoutMap.
+func LayoutMapFromWrapper(input core.Wrapper) *LayoutMap {
+	return LayoutMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -493,15 +496,19 @@ func (_this *LayoutMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapEntryIteratorFromJS is casting a js.Wrapper into LayoutMapEntryIterator.
-func LayoutMapEntryIteratorFromJS(value js.Wrapper) *LayoutMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapEntryIteratorFromJS is casting a js.Value into LayoutMapEntryIterator.
+func LayoutMapEntryIteratorFromJS(value js.Value) *LayoutMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapEntryIteratorFromJS is casting from something that holds a js.Value into LayoutMapEntryIterator.
+func LayoutMapEntryIteratorFromWrapper(input core.Wrapper) *LayoutMapEntryIterator {
+	return LayoutMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapEntryIterator) Next() (_result *LayoutMapEntryIteratorValue) {
@@ -528,15 +535,19 @@ func (_this *LayoutMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapKeyIteratorFromJS is casting a js.Wrapper into LayoutMapKeyIterator.
-func LayoutMapKeyIteratorFromJS(value js.Wrapper) *LayoutMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapKeyIteratorFromJS is casting a js.Value into LayoutMapKeyIterator.
+func LayoutMapKeyIteratorFromJS(value js.Value) *LayoutMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapKeyIteratorFromJS is casting from something that holds a js.Value into LayoutMapKeyIterator.
+func LayoutMapKeyIteratorFromWrapper(input core.Wrapper) *LayoutMapKeyIterator {
+	return LayoutMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapKeyIterator) Next() (_result *LayoutMapKeyIteratorValue) {
@@ -563,15 +574,19 @@ func (_this *LayoutMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LayoutMapValueIteratorFromJS is casting a js.Wrapper into LayoutMapValueIterator.
-func LayoutMapValueIteratorFromJS(value js.Wrapper) *LayoutMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LayoutMapValueIteratorFromJS is casting a js.Value into LayoutMapValueIterator.
+func LayoutMapValueIteratorFromJS(value js.Value) *LayoutMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LayoutMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LayoutMapValueIteratorFromJS is casting from something that holds a js.Value into LayoutMapValueIterator.
+func LayoutMapValueIteratorFromWrapper(input core.Wrapper) *LayoutMapValueIterator {
+	return LayoutMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *LayoutMapValueIterator) Next() (_result *LayoutMapValueIteratorValue) {
@@ -598,15 +613,19 @@ func (_this *PromiseLayoutMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseLayoutMapFromJS is casting a js.Wrapper into PromiseLayoutMap.
-func PromiseLayoutMapFromJS(value js.Wrapper) *PromiseLayoutMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseLayoutMapFromJS is casting a js.Value into PromiseLayoutMap.
+func PromiseLayoutMapFromJS(value js.Value) *PromiseLayoutMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseLayoutMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseLayoutMapFromJS is casting from something that holds a js.Value into PromiseLayoutMap.
+func PromiseLayoutMapFromWrapper(input core.Wrapper) *PromiseLayoutMap {
+	return PromiseLayoutMapFromJS(input.JSValue())
 }
 
 func (_this *PromiseLayoutMap) Then(onFulfilled *PromiseLayoutMapOnFulfilled, onRejected *PromiseLayoutMapOnRejected) (_result *PromiseLayoutMap) {

--- a/device/sensor/sensor.go
+++ b/device/sensor/sensor.go
@@ -7,6 +7,7 @@ package sensor
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -323,7 +324,7 @@ type AbsoluteOrientationReadingValues struct {
 	Quaternion *javascript.FrozenArray
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AbsoluteOrientationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -333,16 +334,14 @@ func (_this *AbsoluteOrientationReadingValues) JSValue() js.Value {
 }
 
 // AbsoluteOrientationReadingValuesFromJS is allocating a new
-// AbsoluteOrientationReadingValues object and copy all values from
-// input javascript object
-func AbsoluteOrientationReadingValuesFromJS(value js.Wrapper) *AbsoluteOrientationReadingValues {
-	input := value.JSValue()
+// AbsoluteOrientationReadingValues object and copy all values in the value javascript object.
+func AbsoluteOrientationReadingValuesFromJS(value js.Value) *AbsoluteOrientationReadingValues {
 	var out AbsoluteOrientationReadingValues
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {quaternion Quaternion quaternion}
 	)
-	if input.Get("quaternion").Type() != js.TypeNull && input.Get("quaternion").Type() != js.TypeUndefined {
-		value0 = javascript.FrozenArrayFromJS(input.Get("quaternion"))
+	if value.Get("quaternion").Type() != js.TypeNull && value.Get("quaternion").Type() != js.TypeUndefined {
+		value0 = javascript.FrozenArrayFromJS(value.Get("quaternion"))
 	}
 	out.Quaternion = value0
 	return &out
@@ -355,7 +354,7 @@ type AccelerometerReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AccelerometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -387,28 +386,26 @@ func (_this *AccelerometerReadingValues) JSValue() js.Value {
 }
 
 // AccelerometerReadingValuesFromJS is allocating a new
-// AccelerometerReadingValues object and copy all values from
-// input javascript object
-func AccelerometerReadingValuesFromJS(value js.Wrapper) *AccelerometerReadingValues {
-	input := value.JSValue()
+// AccelerometerReadingValues object and copy all values in the value javascript object.
+func AccelerometerReadingValuesFromJS(value js.Value) *AccelerometerReadingValues {
 	var out AccelerometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -421,7 +418,7 @@ type AccelerometerSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AccelerometerSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -433,18 +430,16 @@ func (_this *AccelerometerSensorOptions) JSValue() js.Value {
 }
 
 // AccelerometerSensorOptionsFromJS is allocating a new
-// AccelerometerSensorOptions object and copy all values from
-// input javascript object
-func AccelerometerSensorOptionsFromJS(value js.Wrapper) *AccelerometerSensorOptions {
-	input := value.JSValue()
+// AccelerometerSensorOptions object and copy all values in the value javascript object.
+func AccelerometerSensorOptionsFromJS(value js.Value) *AccelerometerSensorOptions {
 	var out AccelerometerSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -454,7 +449,7 @@ type AmbientLightReadingValues struct {
 	Illuminance *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AmbientLightReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -470,16 +465,14 @@ func (_this *AmbientLightReadingValues) JSValue() js.Value {
 }
 
 // AmbientLightReadingValuesFromJS is allocating a new
-// AmbientLightReadingValues object and copy all values from
-// input javascript object
-func AmbientLightReadingValuesFromJS(value js.Wrapper) *AmbientLightReadingValues {
-	input := value.JSValue()
+// AmbientLightReadingValues object and copy all values in the value javascript object.
+func AmbientLightReadingValuesFromJS(value js.Value) *AmbientLightReadingValues {
 	var out AmbientLightReadingValues
 	var (
 		value0 *float64 // javascript: double {illuminance Illuminance illuminance}
 	)
-	if input.Get("illuminance").Type() != js.TypeNull && input.Get("illuminance").Type() != js.TypeUndefined {
-		__tmp := (input.Get("illuminance")).Float()
+	if value.Get("illuminance").Type() != js.TypeNull && value.Get("illuminance").Type() != js.TypeUndefined {
+		__tmp := (value.Get("illuminance")).Float()
 		value0 = &__tmp
 	}
 	out.Illuminance = value0
@@ -493,7 +486,7 @@ type DeviceAccelerationInit struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceAccelerationInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -525,28 +518,26 @@ func (_this *DeviceAccelerationInit) JSValue() js.Value {
 }
 
 // DeviceAccelerationInitFromJS is allocating a new
-// DeviceAccelerationInit object and copy all values from
-// input javascript object
-func DeviceAccelerationInitFromJS(value js.Wrapper) *DeviceAccelerationInit {
-	input := value.JSValue()
+// DeviceAccelerationInit object and copy all values in the value javascript object.
+func DeviceAccelerationInitFromJS(value js.Value) *DeviceAccelerationInit {
 	var out DeviceAccelerationInit
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -564,7 +555,7 @@ type DeviceMotionEventInit struct {
 	Interval                     float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceMotionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -586,10 +577,8 @@ func (_this *DeviceMotionEventInit) JSValue() js.Value {
 }
 
 // DeviceMotionEventInitFromJS is allocating a new
-// DeviceMotionEventInit object and copy all values from
-// input javascript object
-func DeviceMotionEventInitFromJS(value js.Wrapper) *DeviceMotionEventInit {
-	input := value.JSValue()
+// DeviceMotionEventInit object and copy all values in the value javascript object.
+func DeviceMotionEventInitFromJS(value js.Value) *DeviceMotionEventInit {
 	var out DeviceMotionEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -600,25 +589,25 @@ func DeviceMotionEventInitFromJS(value js.Wrapper) *DeviceMotionEventInit {
 		value5 *DeviceRotationRateInit // javascript: DeviceRotationRateInit {rotationRate RotationRate rotationRate}
 		value6 float64                 // javascript: double {interval Interval interval}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("acceleration").Type() != js.TypeNull && input.Get("acceleration").Type() != js.TypeUndefined {
-		value3 = DeviceAccelerationInitFromJS(input.Get("acceleration"))
+	if value.Get("acceleration").Type() != js.TypeNull && value.Get("acceleration").Type() != js.TypeUndefined {
+		value3 = DeviceAccelerationInitFromJS(value.Get("acceleration"))
 	}
 	out.Acceleration = value3
-	if input.Get("accelerationIncludingGravity").Type() != js.TypeNull && input.Get("accelerationIncludingGravity").Type() != js.TypeUndefined {
-		value4 = DeviceAccelerationInitFromJS(input.Get("accelerationIncludingGravity"))
+	if value.Get("accelerationIncludingGravity").Type() != js.TypeNull && value.Get("accelerationIncludingGravity").Type() != js.TypeUndefined {
+		value4 = DeviceAccelerationInitFromJS(value.Get("accelerationIncludingGravity"))
 	}
 	out.AccelerationIncludingGravity = value4
-	if input.Get("rotationRate").Type() != js.TypeNull && input.Get("rotationRate").Type() != js.TypeUndefined {
-		value5 = DeviceRotationRateInitFromJS(input.Get("rotationRate"))
+	if value.Get("rotationRate").Type() != js.TypeNull && value.Get("rotationRate").Type() != js.TypeUndefined {
+		value5 = DeviceRotationRateInitFromJS(value.Get("rotationRate"))
 	}
 	out.RotationRate = value5
-	value6 = (input.Get("interval")).Float()
+	value6 = (value.Get("interval")).Float()
 	out.Interval = value6
 	return &out
 }
@@ -634,7 +623,7 @@ type DeviceOrientationEventInit struct {
 	Absolute   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceOrientationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -674,10 +663,8 @@ func (_this *DeviceOrientationEventInit) JSValue() js.Value {
 }
 
 // DeviceOrientationEventInitFromJS is allocating a new
-// DeviceOrientationEventInit object and copy all values from
-// input javascript object
-func DeviceOrientationEventInitFromJS(value js.Wrapper) *DeviceOrientationEventInit {
-	input := value.JSValue()
+// DeviceOrientationEventInit object and copy all values in the value javascript object.
+func DeviceOrientationEventInitFromJS(value js.Value) *DeviceOrientationEventInit {
 	var out DeviceOrientationEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -688,28 +675,28 @@ func DeviceOrientationEventInitFromJS(value js.Wrapper) *DeviceOrientationEventI
 		value5 *float64 // javascript: double {gamma Gamma gamma}
 		value6 bool     // javascript: boolean {absolute Absolute absolute}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("alpha").Type() != js.TypeNull && input.Get("alpha").Type() != js.TypeUndefined {
-		__tmp := (input.Get("alpha")).Float()
+	if value.Get("alpha").Type() != js.TypeNull && value.Get("alpha").Type() != js.TypeUndefined {
+		__tmp := (value.Get("alpha")).Float()
 		value3 = &__tmp
 	}
 	out.Alpha = value3
-	if input.Get("beta").Type() != js.TypeNull && input.Get("beta").Type() != js.TypeUndefined {
-		__tmp := (input.Get("beta")).Float()
+	if value.Get("beta").Type() != js.TypeNull && value.Get("beta").Type() != js.TypeUndefined {
+		__tmp := (value.Get("beta")).Float()
 		value4 = &__tmp
 	}
 	out.Beta = value4
-	if input.Get("gamma").Type() != js.TypeNull && input.Get("gamma").Type() != js.TypeUndefined {
-		__tmp := (input.Get("gamma")).Float()
+	if value.Get("gamma").Type() != js.TypeNull && value.Get("gamma").Type() != js.TypeUndefined {
+		__tmp := (value.Get("gamma")).Float()
 		value5 = &__tmp
 	}
 	out.Gamma = value5
-	value6 = (input.Get("absolute")).Bool()
+	value6 = (value.Get("absolute")).Bool()
 	out.Absolute = value6
 	return &out
 }
@@ -721,7 +708,7 @@ type DeviceRotationRateInit struct {
 	Gamma *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceRotationRateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -753,28 +740,26 @@ func (_this *DeviceRotationRateInit) JSValue() js.Value {
 }
 
 // DeviceRotationRateInitFromJS is allocating a new
-// DeviceRotationRateInit object and copy all values from
-// input javascript object
-func DeviceRotationRateInitFromJS(value js.Wrapper) *DeviceRotationRateInit {
-	input := value.JSValue()
+// DeviceRotationRateInit object and copy all values in the value javascript object.
+func DeviceRotationRateInitFromJS(value js.Value) *DeviceRotationRateInit {
 	var out DeviceRotationRateInit
 	var (
 		value0 *float64 // javascript: double {alpha Alpha alpha}
 		value1 *float64 // javascript: double {beta Beta beta}
 		value2 *float64 // javascript: double {gamma Gamma gamma}
 	)
-	if input.Get("alpha").Type() != js.TypeNull && input.Get("alpha").Type() != js.TypeUndefined {
-		__tmp := (input.Get("alpha")).Float()
+	if value.Get("alpha").Type() != js.TypeNull && value.Get("alpha").Type() != js.TypeUndefined {
+		__tmp := (value.Get("alpha")).Float()
 		value0 = &__tmp
 	}
 	out.Alpha = value0
-	if input.Get("beta").Type() != js.TypeNull && input.Get("beta").Type() != js.TypeUndefined {
-		__tmp := (input.Get("beta")).Float()
+	if value.Get("beta").Type() != js.TypeNull && value.Get("beta").Type() != js.TypeUndefined {
+		__tmp := (value.Get("beta")).Float()
 		value1 = &__tmp
 	}
 	out.Beta = value1
-	if input.Get("gamma").Type() != js.TypeNull && input.Get("gamma").Type() != js.TypeUndefined {
-		__tmp := (input.Get("gamma")).Float()
+	if value.Get("gamma").Type() != js.TypeNull && value.Get("gamma").Type() != js.TypeUndefined {
+		__tmp := (value.Get("gamma")).Float()
 		value2 = &__tmp
 	}
 	out.Gamma = value2
@@ -792,7 +777,7 @@ type GeolocationReadingValues struct {
 	Speed            *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -856,10 +841,8 @@ func (_this *GeolocationReadingValues) JSValue() js.Value {
 }
 
 // GeolocationReadingValuesFromJS is allocating a new
-// GeolocationReadingValues object and copy all values from
-// input javascript object
-func GeolocationReadingValuesFromJS(value js.Wrapper) *GeolocationReadingValues {
-	input := value.JSValue()
+// GeolocationReadingValues object and copy all values in the value javascript object.
+func GeolocationReadingValuesFromJS(value js.Value) *GeolocationReadingValues {
 	var out GeolocationReadingValues
 	var (
 		value0 *float64 // javascript: double {latitude Latitude latitude}
@@ -870,38 +853,38 @@ func GeolocationReadingValuesFromJS(value js.Wrapper) *GeolocationReadingValues 
 		value5 *float64 // javascript: double {heading Heading heading}
 		value6 *float64 // javascript: double {speed Speed speed}
 	)
-	if input.Get("latitude").Type() != js.TypeNull && input.Get("latitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("latitude")).Float()
+	if value.Get("latitude").Type() != js.TypeNull && value.Get("latitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("latitude")).Float()
 		value0 = &__tmp
 	}
 	out.Latitude = value0
-	if input.Get("longitude").Type() != js.TypeNull && input.Get("longitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("longitude")).Float()
+	if value.Get("longitude").Type() != js.TypeNull && value.Get("longitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("longitude")).Float()
 		value1 = &__tmp
 	}
 	out.Longitude = value1
-	if input.Get("altitude").Type() != js.TypeNull && input.Get("altitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitude")).Float()
+	if value.Get("altitude").Type() != js.TypeNull && value.Get("altitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitude")).Float()
 		value2 = &__tmp
 	}
 	out.Altitude = value2
-	if input.Get("accuracy").Type() != js.TypeNull && input.Get("accuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("accuracy")).Float()
+	if value.Get("accuracy").Type() != js.TypeNull && value.Get("accuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("accuracy")).Float()
 		value3 = &__tmp
 	}
 	out.Accuracy = value3
-	if input.Get("altitudeAccuracy").Type() != js.TypeNull && input.Get("altitudeAccuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitudeAccuracy")).Float()
+	if value.Get("altitudeAccuracy").Type() != js.TypeNull && value.Get("altitudeAccuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitudeAccuracy")).Float()
 		value4 = &__tmp
 	}
 	out.AltitudeAccuracy = value4
-	if input.Get("heading").Type() != js.TypeNull && input.Get("heading").Type() != js.TypeUndefined {
-		__tmp := (input.Get("heading")).Float()
+	if value.Get("heading").Type() != js.TypeNull && value.Get("heading").Type() != js.TypeUndefined {
+		__tmp := (value.Get("heading")).Float()
 		value5 = &__tmp
 	}
 	out.Heading = value5
-	if input.Get("speed").Type() != js.TypeNull && input.Get("speed").Type() != js.TypeUndefined {
-		__tmp := (input.Get("speed")).Float()
+	if value.Get("speed").Type() != js.TypeNull && value.Get("speed").Type() != js.TypeUndefined {
+		__tmp := (value.Get("speed")).Float()
 		value6 = &__tmp
 	}
 	out.Speed = value6
@@ -913,7 +896,7 @@ type GeolocationSensorOptions struct {
 	Frequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -923,15 +906,13 @@ func (_this *GeolocationSensorOptions) JSValue() js.Value {
 }
 
 // GeolocationSensorOptionsFromJS is allocating a new
-// GeolocationSensorOptions object and copy all values from
-// input javascript object
-func GeolocationSensorOptionsFromJS(value js.Wrapper) *GeolocationSensorOptions {
-	input := value.JSValue()
+// GeolocationSensorOptions object and copy all values in the value javascript object.
+func GeolocationSensorOptionsFromJS(value js.Value) *GeolocationSensorOptions {
 	var out GeolocationSensorOptions
 	var (
 		value0 float64 // javascript: double {frequency Frequency frequency}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
 	return &out
 }
@@ -948,7 +929,7 @@ type GeolocationSensorReading struct {
 	Speed            *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationSensorReading) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1020,10 +1001,8 @@ func (_this *GeolocationSensorReading) JSValue() js.Value {
 }
 
 // GeolocationSensorReadingFromJS is allocating a new
-// GeolocationSensorReading object and copy all values from
-// input javascript object
-func GeolocationSensorReadingFromJS(value js.Wrapper) *GeolocationSensorReading {
-	input := value.JSValue()
+// GeolocationSensorReading object and copy all values in the value javascript object.
+func GeolocationSensorReadingFromJS(value js.Value) *GeolocationSensorReading {
 	var out GeolocationSensorReading
 	var (
 		value0 *float64 // javascript: double {timestamp Timestamp timestamp}
@@ -1035,43 +1014,43 @@ func GeolocationSensorReadingFromJS(value js.Wrapper) *GeolocationSensorReading 
 		value6 *float64 // javascript: double {heading Heading heading}
 		value7 *float64 // javascript: double {speed Speed speed}
 	)
-	if input.Get("timestamp").Type() != js.TypeNull && input.Get("timestamp").Type() != js.TypeUndefined {
-		__tmp := (input.Get("timestamp")).Float()
+	if value.Get("timestamp").Type() != js.TypeNull && value.Get("timestamp").Type() != js.TypeUndefined {
+		__tmp := (value.Get("timestamp")).Float()
 		value0 = &__tmp
 	}
 	out.Timestamp = value0
-	if input.Get("latitude").Type() != js.TypeNull && input.Get("latitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("latitude")).Float()
+	if value.Get("latitude").Type() != js.TypeNull && value.Get("latitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("latitude")).Float()
 		value1 = &__tmp
 	}
 	out.Latitude = value1
-	if input.Get("longitude").Type() != js.TypeNull && input.Get("longitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("longitude")).Float()
+	if value.Get("longitude").Type() != js.TypeNull && value.Get("longitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("longitude")).Float()
 		value2 = &__tmp
 	}
 	out.Longitude = value2
-	if input.Get("altitude").Type() != js.TypeNull && input.Get("altitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitude")).Float()
+	if value.Get("altitude").Type() != js.TypeNull && value.Get("altitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitude")).Float()
 		value3 = &__tmp
 	}
 	out.Altitude = value3
-	if input.Get("accuracy").Type() != js.TypeNull && input.Get("accuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("accuracy")).Float()
+	if value.Get("accuracy").Type() != js.TypeNull && value.Get("accuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("accuracy")).Float()
 		value4 = &__tmp
 	}
 	out.Accuracy = value4
-	if input.Get("altitudeAccuracy").Type() != js.TypeNull && input.Get("altitudeAccuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitudeAccuracy")).Float()
+	if value.Get("altitudeAccuracy").Type() != js.TypeNull && value.Get("altitudeAccuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitudeAccuracy")).Float()
 		value5 = &__tmp
 	}
 	out.AltitudeAccuracy = value5
-	if input.Get("heading").Type() != js.TypeNull && input.Get("heading").Type() != js.TypeUndefined {
-		__tmp := (input.Get("heading")).Float()
+	if value.Get("heading").Type() != js.TypeNull && value.Get("heading").Type() != js.TypeUndefined {
+		__tmp := (value.Get("heading")).Float()
 		value6 = &__tmp
 	}
 	out.Heading = value6
-	if input.Get("speed").Type() != js.TypeNull && input.Get("speed").Type() != js.TypeUndefined {
-		__tmp := (input.Get("speed")).Float()
+	if value.Get("speed").Type() != js.TypeNull && value.Get("speed").Type() != js.TypeUndefined {
+		__tmp := (value.Get("speed")).Float()
 		value7 = &__tmp
 	}
 	out.Speed = value7
@@ -1085,7 +1064,7 @@ type GravityReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GravityReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1117,28 +1096,26 @@ func (_this *GravityReadingValues) JSValue() js.Value {
 }
 
 // GravityReadingValuesFromJS is allocating a new
-// GravityReadingValues object and copy all values from
-// input javascript object
-func GravityReadingValuesFromJS(value js.Wrapper) *GravityReadingValues {
-	input := value.JSValue()
+// GravityReadingValues object and copy all values in the value javascript object.
+func GravityReadingValuesFromJS(value js.Value) *GravityReadingValues {
 	var out GravityReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1152,7 +1129,7 @@ type GyroscopeReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GyroscopeReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1184,28 +1161,26 @@ func (_this *GyroscopeReadingValues) JSValue() js.Value {
 }
 
 // GyroscopeReadingValuesFromJS is allocating a new
-// GyroscopeReadingValues object and copy all values from
-// input javascript object
-func GyroscopeReadingValuesFromJS(value js.Wrapper) *GyroscopeReadingValues {
-	input := value.JSValue()
+// GyroscopeReadingValues object and copy all values in the value javascript object.
+func GyroscopeReadingValuesFromJS(value js.Value) *GyroscopeReadingValues {
 	var out GyroscopeReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1218,7 +1193,7 @@ type GyroscopeSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GyroscopeSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1230,18 +1205,16 @@ func (_this *GyroscopeSensorOptions) JSValue() js.Value {
 }
 
 // GyroscopeSensorOptionsFromJS is allocating a new
-// GyroscopeSensorOptions object and copy all values from
-// input javascript object
-func GyroscopeSensorOptionsFromJS(value js.Wrapper) *GyroscopeSensorOptions {
-	input := value.JSValue()
+// GyroscopeSensorOptions object and copy all values in the value javascript object.
+func GyroscopeSensorOptionsFromJS(value js.Value) *GyroscopeSensorOptions {
 	var out GyroscopeSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1253,7 +1226,7 @@ type LinearAccelerationReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LinearAccelerationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1285,28 +1258,26 @@ func (_this *LinearAccelerationReadingValues) JSValue() js.Value {
 }
 
 // LinearAccelerationReadingValuesFromJS is allocating a new
-// LinearAccelerationReadingValues object and copy all values from
-// input javascript object
-func LinearAccelerationReadingValuesFromJS(value js.Wrapper) *LinearAccelerationReadingValues {
-	input := value.JSValue()
+// LinearAccelerationReadingValues object and copy all values in the value javascript object.
+func LinearAccelerationReadingValuesFromJS(value js.Value) *LinearAccelerationReadingValues {
 	var out LinearAccelerationReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1320,7 +1291,7 @@ type MagnetometerReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MagnetometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1352,28 +1323,26 @@ func (_this *MagnetometerReadingValues) JSValue() js.Value {
 }
 
 // MagnetometerReadingValuesFromJS is allocating a new
-// MagnetometerReadingValues object and copy all values from
-// input javascript object
-func MagnetometerReadingValuesFromJS(value js.Wrapper) *MagnetometerReadingValues {
-	input := value.JSValue()
+// MagnetometerReadingValues object and copy all values in the value javascript object.
+func MagnetometerReadingValuesFromJS(value js.Value) *MagnetometerReadingValues {
 	var out MagnetometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1386,7 +1355,7 @@ type MagnetometerSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MagnetometerSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1398,18 +1367,16 @@ func (_this *MagnetometerSensorOptions) JSValue() js.Value {
 }
 
 // MagnetometerSensorOptionsFromJS is allocating a new
-// MagnetometerSensorOptions object and copy all values from
-// input javascript object
-func MagnetometerSensorOptionsFromJS(value js.Wrapper) *MagnetometerSensorOptions {
-	input := value.JSValue()
+// MagnetometerSensorOptions object and copy all values in the value javascript object.
+func MagnetometerSensorOptionsFromJS(value js.Value) *MagnetometerSensorOptions {
 	var out MagnetometerSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1421,7 +1388,7 @@ type MockSensor struct {
 	RequestedSamplingFrequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1435,21 +1402,19 @@ func (_this *MockSensor) JSValue() js.Value {
 }
 
 // MockSensorFromJS is allocating a new
-// MockSensor object and copy all values from
-// input javascript object
-func MockSensorFromJS(value js.Wrapper) *MockSensor {
-	input := value.JSValue()
+// MockSensor object and copy all values in the value javascript object.
+func MockSensorFromJS(value js.Value) *MockSensor {
 	var out MockSensor
 	var (
 		value0 float64 // javascript: double {maxSamplingFrequency MaxSamplingFrequency maxSamplingFrequency}
 		value1 float64 // javascript: double {minSamplingFrequency MinSamplingFrequency minSamplingFrequency}
 		value2 float64 // javascript: double {requestedSamplingFrequency RequestedSamplingFrequency requestedSamplingFrequency}
 	)
-	value0 = (input.Get("maxSamplingFrequency")).Float()
+	value0 = (value.Get("maxSamplingFrequency")).Float()
 	out.MaxSamplingFrequency = value0
-	value1 = (input.Get("minSamplingFrequency")).Float()
+	value1 = (value.Get("minSamplingFrequency")).Float()
 	out.MinSamplingFrequency = value1
-	value2 = (input.Get("requestedSamplingFrequency")).Float()
+	value2 = (value.Get("requestedSamplingFrequency")).Float()
 	out.RequestedSamplingFrequency = value2
 	return &out
 }
@@ -1462,7 +1427,7 @@ type MockSensorConfiguration struct {
 	MinSamplingFrequency *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensorConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1490,10 +1455,8 @@ func (_this *MockSensorConfiguration) JSValue() js.Value {
 }
 
 // MockSensorConfigurationFromJS is allocating a new
-// MockSensorConfiguration object and copy all values from
-// input javascript object
-func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
-	input := value.JSValue()
+// MockSensorConfiguration object and copy all values in the value javascript object.
+func MockSensorConfigurationFromJS(value js.Value) *MockSensorConfiguration {
 	var out MockSensorConfiguration
 	var (
 		value0 MockSensorType // javascript: MockSensorType {mockSensorType MockSensorType mockSensorType}
@@ -1501,17 +1464,17 @@ func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
 		value2 *float64       // javascript: double {maxSamplingFrequency MaxSamplingFrequency maxSamplingFrequency}
 		value3 *float64       // javascript: double {minSamplingFrequency MinSamplingFrequency minSamplingFrequency}
 	)
-	value0 = MockSensorTypeFromJS(input.Get("mockSensorType"))
+	value0 = MockSensorTypeFromJS(value.Get("mockSensorType"))
 	out.MockSensorType = value0
-	value1 = (input.Get("connected")).Bool()
+	value1 = (value.Get("connected")).Bool()
 	out.Connected = value1
-	if input.Get("maxSamplingFrequency").Type() != js.TypeNull && input.Get("maxSamplingFrequency").Type() != js.TypeUndefined {
-		__tmp := (input.Get("maxSamplingFrequency")).Float()
+	if value.Get("maxSamplingFrequency").Type() != js.TypeNull && value.Get("maxSamplingFrequency").Type() != js.TypeUndefined {
+		__tmp := (value.Get("maxSamplingFrequency")).Float()
 		value2 = &__tmp
 	}
 	out.MaxSamplingFrequency = value2
-	if input.Get("minSamplingFrequency").Type() != js.TypeNull && input.Get("minSamplingFrequency").Type() != js.TypeUndefined {
-		__tmp := (input.Get("minSamplingFrequency")).Float()
+	if value.Get("minSamplingFrequency").Type() != js.TypeNull && value.Get("minSamplingFrequency").Type() != js.TypeUndefined {
+		__tmp := (value.Get("minSamplingFrequency")).Float()
 		value3 = &__tmp
 	}
 	out.MinSamplingFrequency = value3
@@ -1522,7 +1485,7 @@ func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
 type MockSensorReadingValues struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensorReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1530,9 +1493,8 @@ func (_this *MockSensorReadingValues) JSValue() js.Value {
 }
 
 // MockSensorReadingValuesFromJS is allocating a new
-// MockSensorReadingValues object and copy all values from
-// input javascript object
-func MockSensorReadingValuesFromJS(value js.Wrapper) *MockSensorReadingValues {
+// MockSensorReadingValues object and copy all values in the value javascript object.
+func MockSensorReadingValuesFromJS(value js.Value) *MockSensorReadingValues {
 	var out MockSensorReadingValues
 	var ()
 	return &out
@@ -1544,7 +1506,7 @@ type OrientationSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OrientationSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1556,18 +1518,16 @@ func (_this *OrientationSensorOptions) JSValue() js.Value {
 }
 
 // OrientationSensorOptionsFromJS is allocating a new
-// OrientationSensorOptions object and copy all values from
-// input javascript object
-func OrientationSensorOptionsFromJS(value js.Wrapper) *OrientationSensorOptions {
-	input := value.JSValue()
+// OrientationSensorOptions object and copy all values in the value javascript object.
+func OrientationSensorOptionsFromJS(value js.Value) *OrientationSensorOptions {
 	var out OrientationSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1579,7 +1539,7 @@ type PositionOptions struct {
 	MaximumAge         uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PositionOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1593,21 +1553,19 @@ func (_this *PositionOptions) JSValue() js.Value {
 }
 
 // PositionOptionsFromJS is allocating a new
-// PositionOptions object and copy all values from
-// input javascript object
-func PositionOptionsFromJS(value js.Wrapper) *PositionOptions {
-	input := value.JSValue()
+// PositionOptions object and copy all values in the value javascript object.
+func PositionOptionsFromJS(value js.Value) *PositionOptions {
 	var out PositionOptions
 	var (
 		value0 bool // javascript: boolean {enableHighAccuracy EnableHighAccuracy enableHighAccuracy}
 		value1 uint // javascript: unsigned long {timeout Timeout timeout}
 		value2 uint // javascript: unsigned long {maximumAge MaximumAge maximumAge}
 	)
-	value0 = (input.Get("enableHighAccuracy")).Bool()
+	value0 = (value.Get("enableHighAccuracy")).Bool()
 	out.EnableHighAccuracy = value0
-	value1 = (uint)((input.Get("timeout")).Int())
+	value1 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value1
-	value2 = (uint)((input.Get("maximumAge")).Int())
+	value2 = (uint)((value.Get("maximumAge")).Int())
 	out.MaximumAge = value2
 	return &out
 }
@@ -1619,7 +1577,7 @@ type ProximityReadingValues struct {
 	Near     *bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ProximityReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1651,28 +1609,26 @@ func (_this *ProximityReadingValues) JSValue() js.Value {
 }
 
 // ProximityReadingValuesFromJS is allocating a new
-// ProximityReadingValues object and copy all values from
-// input javascript object
-func ProximityReadingValuesFromJS(value js.Wrapper) *ProximityReadingValues {
-	input := value.JSValue()
+// ProximityReadingValues object and copy all values in the value javascript object.
+func ProximityReadingValuesFromJS(value js.Value) *ProximityReadingValues {
 	var out ProximityReadingValues
 	var (
 		value0 *float64 // javascript: double {distance Distance distance}
 		value1 *float64 // javascript: double {max Max max}
 		value2 *bool    // javascript: boolean {near Near near}
 	)
-	if input.Get("distance").Type() != js.TypeNull && input.Get("distance").Type() != js.TypeUndefined {
-		__tmp := (input.Get("distance")).Float()
+	if value.Get("distance").Type() != js.TypeNull && value.Get("distance").Type() != js.TypeUndefined {
+		__tmp := (value.Get("distance")).Float()
 		value0 = &__tmp
 	}
 	out.Distance = value0
-	if input.Get("max").Type() != js.TypeNull && input.Get("max").Type() != js.TypeUndefined {
-		__tmp := (input.Get("max")).Float()
+	if value.Get("max").Type() != js.TypeNull && value.Get("max").Type() != js.TypeUndefined {
+		__tmp := (value.Get("max")).Float()
 		value1 = &__tmp
 	}
 	out.Max = value1
-	if input.Get("near").Type() != js.TypeNull && input.Get("near").Type() != js.TypeUndefined {
-		__tmp := (input.Get("near")).Bool()
+	if value.Get("near").Type() != js.TypeNull && value.Get("near").Type() != js.TypeUndefined {
+		__tmp := (value.Get("near")).Bool()
 		value2 = &__tmp
 	}
 	out.Near = value2
@@ -1685,7 +1641,7 @@ type ReadOptions struct {
 	Signal    *domcore.AbortSignal
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReadOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1697,19 +1653,17 @@ func (_this *ReadOptions) JSValue() js.Value {
 }
 
 // ReadOptionsFromJS is allocating a new
-// ReadOptions object and copy all values from
-// input javascript object
-func ReadOptionsFromJS(value js.Wrapper) *ReadOptions {
-	input := value.JSValue()
+// ReadOptions object and copy all values in the value javascript object.
+func ReadOptionsFromJS(value js.Value) *ReadOptions {
 	var out ReadOptions
 	var (
 		value0 float64              // javascript: double {frequency Frequency frequency}
 		value1 *domcore.AbortSignal // javascript: AbortSignal {signal Signal signal}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value1 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value1 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value1
 	return &out
@@ -1720,7 +1674,7 @@ type RelativeOrientationReadingValues struct {
 	Quaternion *javascript.FrozenArray
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RelativeOrientationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1730,16 +1684,14 @@ func (_this *RelativeOrientationReadingValues) JSValue() js.Value {
 }
 
 // RelativeOrientationReadingValuesFromJS is allocating a new
-// RelativeOrientationReadingValues object and copy all values from
-// input javascript object
-func RelativeOrientationReadingValuesFromJS(value js.Wrapper) *RelativeOrientationReadingValues {
-	input := value.JSValue()
+// RelativeOrientationReadingValues object and copy all values in the value javascript object.
+func RelativeOrientationReadingValuesFromJS(value js.Value) *RelativeOrientationReadingValues {
 	var out RelativeOrientationReadingValues
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {quaternion Quaternion quaternion}
 	)
-	if input.Get("quaternion").Type() != js.TypeNull && input.Get("quaternion").Type() != js.TypeUndefined {
-		value0 = javascript.FrozenArrayFromJS(input.Get("quaternion"))
+	if value.Get("quaternion").Type() != js.TypeNull && value.Get("quaternion").Type() != js.TypeUndefined {
+		value0 = javascript.FrozenArrayFromJS(value.Get("quaternion"))
 	}
 	out.Quaternion = value0
 	return &out
@@ -1753,7 +1705,7 @@ type SensorErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SensorErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1769,10 +1721,8 @@ func (_this *SensorErrorEventInit) JSValue() js.Value {
 }
 
 // SensorErrorEventInitFromJS is allocating a new
-// SensorErrorEventInit object and copy all values from
-// input javascript object
-func SensorErrorEventInitFromJS(value js.Wrapper) *SensorErrorEventInit {
-	input := value.JSValue()
+// SensorErrorEventInit object and copy all values in the value javascript object.
+func SensorErrorEventInitFromJS(value js.Value) *SensorErrorEventInit {
 	var out SensorErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -1780,13 +1730,13 @@ func SensorErrorEventInitFromJS(value js.Wrapper) *SensorErrorEventInit {
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -1796,7 +1746,7 @@ type SensorOptions struct {
 	Frequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1806,15 +1756,13 @@ func (_this *SensorOptions) JSValue() js.Value {
 }
 
 // SensorOptionsFromJS is allocating a new
-// SensorOptions object and copy all values from
-// input javascript object
-func SensorOptionsFromJS(value js.Wrapper) *SensorOptions {
-	input := value.JSValue()
+// SensorOptions object and copy all values in the value javascript object.
+func SensorOptionsFromJS(value js.Value) *SensorOptions {
 	var out SensorOptions
 	var (
 		value0 float64 // javascript: double {frequency Frequency frequency}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
 	return &out
 }
@@ -1829,7 +1777,7 @@ type UncalibratedMagnetometerReadingValues struct {
 	ZBias *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *UncalibratedMagnetometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1885,10 +1833,8 @@ func (_this *UncalibratedMagnetometerReadingValues) JSValue() js.Value {
 }
 
 // UncalibratedMagnetometerReadingValuesFromJS is allocating a new
-// UncalibratedMagnetometerReadingValues object and copy all values from
-// input javascript object
-func UncalibratedMagnetometerReadingValuesFromJS(value js.Wrapper) *UncalibratedMagnetometerReadingValues {
-	input := value.JSValue()
+// UncalibratedMagnetometerReadingValues object and copy all values in the value javascript object.
+func UncalibratedMagnetometerReadingValuesFromJS(value js.Value) *UncalibratedMagnetometerReadingValues {
 	var out UncalibratedMagnetometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
@@ -1898,33 +1844,33 @@ func UncalibratedMagnetometerReadingValuesFromJS(value js.Wrapper) *Uncalibrated
 		value4 *float64 // javascript: double {yBias YBias yBias}
 		value5 *float64 // javascript: double {zBias ZBias zBias}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
-	if input.Get("xBias").Type() != js.TypeNull && input.Get("xBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("xBias")).Float()
+	if value.Get("xBias").Type() != js.TypeNull && value.Get("xBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("xBias")).Float()
 		value3 = &__tmp
 	}
 	out.XBias = value3
-	if input.Get("yBias").Type() != js.TypeNull && input.Get("yBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("yBias")).Float()
+	if value.Get("yBias").Type() != js.TypeNull && value.Get("yBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("yBias")).Float()
 		value4 = &__tmp
 	}
 	out.YBias = value4
-	if input.Get("zBias").Type() != js.TypeNull && input.Get("zBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("zBias")).Float()
+	if value.Get("zBias").Type() != js.TypeNull && value.Get("zBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("zBias")).Float()
 		value5 = &__tmp
 	}
 	out.ZBias = value5
@@ -1936,15 +1882,19 @@ type AbsoluteOrientationSensor struct {
 	OrientationSensor
 }
 
-// AbsoluteOrientationSensorFromJS is casting a js.Wrapper into AbsoluteOrientationSensor.
-func AbsoluteOrientationSensorFromJS(value js.Wrapper) *AbsoluteOrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbsoluteOrientationSensorFromJS is casting a js.Value into AbsoluteOrientationSensor.
+func AbsoluteOrientationSensorFromJS(value js.Value) *AbsoluteOrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbsoluteOrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbsoluteOrientationSensorFromJS is casting from something that holds a js.Value into AbsoluteOrientationSensor.
+func AbsoluteOrientationSensorFromWrapper(input core.Wrapper) *AbsoluteOrientationSensor {
+	return AbsoluteOrientationSensorFromJS(input.JSValue())
 }
 
 func NewAbsoluteOrientationSensor(sensorOptions *OrientationSensorOptions) (_result *AbsoluteOrientationSensor) {
@@ -1972,15 +1922,19 @@ type Accelerometer struct {
 	Sensor
 }
 
-// AccelerometerFromJS is casting a js.Wrapper into Accelerometer.
-func AccelerometerFromJS(value js.Wrapper) *Accelerometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AccelerometerFromJS is casting a js.Value into Accelerometer.
+func AccelerometerFromJS(value js.Value) *Accelerometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Accelerometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AccelerometerFromJS is casting from something that holds a js.Value into Accelerometer.
+func AccelerometerFromWrapper(input core.Wrapper) *Accelerometer {
+	return AccelerometerFromJS(input.JSValue())
 }
 
 func NewAccelerometer(options *AccelerometerSensorOptions) (_result *Accelerometer) {
@@ -2044,15 +1998,19 @@ type AmbientLightSensor struct {
 	Sensor
 }
 
-// AmbientLightSensorFromJS is casting a js.Wrapper into AmbientLightSensor.
-func AmbientLightSensorFromJS(value js.Wrapper) *AmbientLightSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AmbientLightSensorFromJS is casting a js.Value into AmbientLightSensor.
+func AmbientLightSensorFromJS(value js.Value) *AmbientLightSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AmbientLightSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AmbientLightSensorFromJS is casting from something that holds a js.Value into AmbientLightSensor.
+func AmbientLightSensorFromWrapper(input core.Wrapper) *AmbientLightSensor {
+	return AmbientLightSensorFromJS(input.JSValue())
 }
 
 func NewAmbientLightSensor(sensorOptions *SensorOptions) (_result *AmbientLightSensor) {
@@ -2097,15 +2055,19 @@ func (_this *Coordinates) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CoordinatesFromJS is casting a js.Wrapper into Coordinates.
-func CoordinatesFromJS(value js.Wrapper) *Coordinates {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CoordinatesFromJS is casting a js.Value into Coordinates.
+func CoordinatesFromJS(value js.Value) *Coordinates {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Coordinates{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CoordinatesFromJS is casting from something that holds a js.Value into Coordinates.
+func CoordinatesFromWrapper(input core.Wrapper) *Coordinates {
+	return CoordinatesFromJS(input.JSValue())
 }
 
 // Latitude returning attribute 'latitude' with
@@ -2193,15 +2155,19 @@ func (_this *DeviceAcceleration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeviceAccelerationFromJS is casting a js.Wrapper into DeviceAcceleration.
-func DeviceAccelerationFromJS(value js.Wrapper) *DeviceAcceleration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceAccelerationFromJS is casting a js.Value into DeviceAcceleration.
+func DeviceAccelerationFromJS(value js.Value) *DeviceAcceleration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceAcceleration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceAccelerationFromJS is casting from something that holds a js.Value into DeviceAcceleration.
+func DeviceAccelerationFromWrapper(input core.Wrapper) *DeviceAcceleration {
+	return DeviceAccelerationFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -2245,15 +2211,19 @@ type DeviceMotionEvent struct {
 	domcore.Event
 }
 
-// DeviceMotionEventFromJS is casting a js.Wrapper into DeviceMotionEvent.
-func DeviceMotionEventFromJS(value js.Wrapper) *DeviceMotionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceMotionEventFromJS is casting a js.Value into DeviceMotionEvent.
+func DeviceMotionEventFromJS(value js.Value) *DeviceMotionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceMotionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceMotionEventFromJS is casting from something that holds a js.Value into DeviceMotionEvent.
+func DeviceMotionEventFromWrapper(input core.Wrapper) *DeviceMotionEvent {
+	return DeviceMotionEventFromJS(input.JSValue())
 }
 
 func NewDeviceMotionEvent(_type string, eventInitDict *DeviceMotionEventInit) (_result *DeviceMotionEvent) {
@@ -2326,15 +2296,19 @@ type DeviceOrientationEvent struct {
 	domcore.Event
 }
 
-// DeviceOrientationEventFromJS is casting a js.Wrapper into DeviceOrientationEvent.
-func DeviceOrientationEventFromJS(value js.Wrapper) *DeviceOrientationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceOrientationEventFromJS is casting a js.Value into DeviceOrientationEvent.
+func DeviceOrientationEventFromJS(value js.Value) *DeviceOrientationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceOrientationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceOrientationEventFromJS is casting from something that holds a js.Value into DeviceOrientationEvent.
+func DeviceOrientationEventFromWrapper(input core.Wrapper) *DeviceOrientationEvent {
+	return DeviceOrientationEventFromJS(input.JSValue())
 }
 
 func NewDeviceOrientationEvent(_type string, eventInitDict *DeviceOrientationEventInit) (_result *DeviceOrientationEvent) {
@@ -2415,15 +2389,19 @@ func (_this *DeviceRotationRate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeviceRotationRateFromJS is casting a js.Wrapper into DeviceRotationRate.
-func DeviceRotationRateFromJS(value js.Wrapper) *DeviceRotationRate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceRotationRateFromJS is casting a js.Value into DeviceRotationRate.
+func DeviceRotationRateFromJS(value js.Value) *DeviceRotationRate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceRotationRate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceRotationRateFromJS is casting from something that holds a js.Value into DeviceRotationRate.
+func DeviceRotationRateFromWrapper(input core.Wrapper) *DeviceRotationRate {
+	return DeviceRotationRateFromJS(input.JSValue())
 }
 
 // Alpha returning attribute 'alpha' with
@@ -2472,15 +2450,19 @@ func (_this *Geolocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GeolocationFromJS is casting a js.Wrapper into Geolocation.
-func GeolocationFromJS(value js.Wrapper) *Geolocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GeolocationFromJS is casting a js.Value into Geolocation.
+func GeolocationFromJS(value js.Value) *Geolocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Geolocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GeolocationFromJS is casting from something that holds a js.Value into Geolocation.
+func GeolocationFromWrapper(input core.Wrapper) *Geolocation {
+	return GeolocationFromJS(input.JSValue())
 }
 
 func (_this *Geolocation) GetCurrentPosition(successCallback *PositionCallback, errorCallback *PositionErrorCallback, options *PositionOptions) {
@@ -2577,15 +2559,19 @@ type GeolocationSensor struct {
 	Sensor
 }
 
-// GeolocationSensorFromJS is casting a js.Wrapper into GeolocationSensor.
-func GeolocationSensorFromJS(value js.Wrapper) *GeolocationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GeolocationSensorFromJS is casting a js.Value into GeolocationSensor.
+func GeolocationSensorFromJS(value js.Value) *GeolocationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GeolocationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GeolocationSensorFromJS is casting from something that holds a js.Value into GeolocationSensor.
+func GeolocationSensorFromWrapper(input core.Wrapper) *GeolocationSensor {
+	return GeolocationSensorFromJS(input.JSValue())
 }
 
 func Read(readOptions *ReadOptions) (_result *PromiseGeolocationSensorReading) {
@@ -2718,15 +2704,19 @@ type GravitySensor struct {
 	Accelerometer
 }
 
-// GravitySensorFromJS is casting a js.Wrapper into GravitySensor.
-func GravitySensorFromJS(value js.Wrapper) *GravitySensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GravitySensorFromJS is casting a js.Value into GravitySensor.
+func GravitySensorFromJS(value js.Value) *GravitySensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GravitySensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GravitySensorFromJS is casting from something that holds a js.Value into GravitySensor.
+func GravitySensorFromWrapper(input core.Wrapper) *GravitySensor {
+	return GravitySensorFromJS(input.JSValue())
 }
 
 func NewGravitySensor(options *AccelerometerSensorOptions) (_result *GravitySensor) {
@@ -2754,15 +2744,19 @@ type Gyroscope struct {
 	Sensor
 }
 
-// GyroscopeFromJS is casting a js.Wrapper into Gyroscope.
-func GyroscopeFromJS(value js.Wrapper) *Gyroscope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GyroscopeFromJS is casting a js.Value into Gyroscope.
+func GyroscopeFromJS(value js.Value) *Gyroscope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Gyroscope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GyroscopeFromJS is casting from something that holds a js.Value into Gyroscope.
+func GyroscopeFromWrapper(input core.Wrapper) *Gyroscope {
+	return GyroscopeFromJS(input.JSValue())
 }
 
 func NewGyroscope(sensorOptions *GyroscopeSensorOptions) (_result *Gyroscope) {
@@ -2826,15 +2820,19 @@ type LinearAccelerationSensor struct {
 	Accelerometer
 }
 
-// LinearAccelerationSensorFromJS is casting a js.Wrapper into LinearAccelerationSensor.
-func LinearAccelerationSensorFromJS(value js.Wrapper) *LinearAccelerationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LinearAccelerationSensorFromJS is casting a js.Value into LinearAccelerationSensor.
+func LinearAccelerationSensorFromJS(value js.Value) *LinearAccelerationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LinearAccelerationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LinearAccelerationSensorFromJS is casting from something that holds a js.Value into LinearAccelerationSensor.
+func LinearAccelerationSensorFromWrapper(input core.Wrapper) *LinearAccelerationSensor {
+	return LinearAccelerationSensorFromJS(input.JSValue())
 }
 
 func NewLinearAccelerationSensor(options *AccelerometerSensorOptions) (_result *LinearAccelerationSensor) {
@@ -2862,15 +2860,19 @@ type Magnetometer struct {
 	Sensor
 }
 
-// MagnetometerFromJS is casting a js.Wrapper into Magnetometer.
-func MagnetometerFromJS(value js.Wrapper) *Magnetometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MagnetometerFromJS is casting a js.Value into Magnetometer.
+func MagnetometerFromJS(value js.Value) *Magnetometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Magnetometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MagnetometerFromJS is casting from something that holds a js.Value into Magnetometer.
+func MagnetometerFromWrapper(input core.Wrapper) *Magnetometer {
+	return MagnetometerFromJS(input.JSValue())
 }
 
 func NewMagnetometer(sensorOptions *MagnetometerSensorOptions) (_result *Magnetometer) {
@@ -2934,15 +2936,19 @@ type OrientationSensor struct {
 	Sensor
 }
 
-// OrientationSensorFromJS is casting a js.Wrapper into OrientationSensor.
-func OrientationSensorFromJS(value js.Wrapper) *OrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OrientationSensorFromJS is casting a js.Value into OrientationSensor.
+func OrientationSensorFromJS(value js.Value) *OrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OrientationSensorFromJS is casting from something that holds a js.Value into OrientationSensor.
+func OrientationSensorFromWrapper(input core.Wrapper) *OrientationSensor {
+	return OrientationSensorFromJS(input.JSValue())
 }
 
 // Quaternion returning attribute 'quaternion' with
@@ -2978,15 +2984,19 @@ func (_this *Position) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PositionFromJS is casting a js.Wrapper into Position.
-func PositionFromJS(value js.Wrapper) *Position {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PositionFromJS is casting a js.Value into Position.
+func PositionFromJS(value js.Value) *Position {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Position{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PositionFromJS is casting from something that holds a js.Value into Position.
+func PositionFromWrapper(input core.Wrapper) *Position {
+	return PositionFromJS(input.JSValue())
 }
 
 // Coords returning attribute 'coords' with
@@ -3017,15 +3027,19 @@ func (_this *PositionError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PositionErrorFromJS is casting a js.Wrapper into PositionError.
-func PositionErrorFromJS(value js.Wrapper) *PositionError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PositionErrorFromJS is casting a js.Value into PositionError.
+func PositionErrorFromJS(value js.Value) *PositionError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PositionError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PositionErrorFromJS is casting from something that holds a js.Value into PositionError.
+func PositionErrorFromWrapper(input core.Wrapper) *PositionError {
+	return PositionErrorFromJS(input.JSValue())
 }
 
 const (
@@ -3062,15 +3076,19 @@ func (_this *PromiseGeolocationSensorReading) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseGeolocationSensorReadingFromJS is casting a js.Wrapper into PromiseGeolocationSensorReading.
-func PromiseGeolocationSensorReadingFromJS(value js.Wrapper) *PromiseGeolocationSensorReading {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseGeolocationSensorReadingFromJS is casting a js.Value into PromiseGeolocationSensorReading.
+func PromiseGeolocationSensorReadingFromJS(value js.Value) *PromiseGeolocationSensorReading {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseGeolocationSensorReading{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseGeolocationSensorReadingFromJS is casting from something that holds a js.Value into PromiseGeolocationSensorReading.
+func PromiseGeolocationSensorReadingFromWrapper(input core.Wrapper) *PromiseGeolocationSensorReading {
+	return PromiseGeolocationSensorReadingFromJS(input.JSValue())
 }
 
 func (_this *PromiseGeolocationSensorReading) Then(onFulfilled *PromiseGeolocationSensorReadingOnFulfilled, onRejected *PromiseGeolocationSensorReadingOnRejected) (_result *PromiseGeolocationSensorReading) {
@@ -3162,15 +3180,19 @@ type ProximitySensor struct {
 	Sensor
 }
 
-// ProximitySensorFromJS is casting a js.Wrapper into ProximitySensor.
-func ProximitySensorFromJS(value js.Wrapper) *ProximitySensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProximitySensorFromJS is casting a js.Value into ProximitySensor.
+func ProximitySensorFromJS(value js.Value) *ProximitySensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProximitySensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProximitySensorFromJS is casting from something that holds a js.Value into ProximitySensor.
+func ProximitySensorFromWrapper(input core.Wrapper) *ProximitySensor {
+	return ProximitySensorFromJS(input.JSValue())
 }
 
 func NewProximitySensor(sensorOptions *SensorOptions) (_result *ProximitySensor) {
@@ -3234,15 +3256,19 @@ type RelativeOrientationSensor struct {
 	OrientationSensor
 }
 
-// RelativeOrientationSensorFromJS is casting a js.Wrapper into RelativeOrientationSensor.
-func RelativeOrientationSensorFromJS(value js.Wrapper) *RelativeOrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RelativeOrientationSensorFromJS is casting a js.Value into RelativeOrientationSensor.
+func RelativeOrientationSensorFromJS(value js.Value) *RelativeOrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RelativeOrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RelativeOrientationSensorFromJS is casting from something that holds a js.Value into RelativeOrientationSensor.
+func RelativeOrientationSensorFromWrapper(input core.Wrapper) *RelativeOrientationSensor {
+	return RelativeOrientationSensorFromJS(input.JSValue())
 }
 
 func NewRelativeOrientationSensor(sensorOptions *OrientationSensorOptions) (_result *RelativeOrientationSensor) {
@@ -3270,15 +3296,19 @@ type Sensor struct {
 	domcore.EventTarget
 }
 
-// SensorFromJS is casting a js.Wrapper into Sensor.
-func SensorFromJS(value js.Wrapper) *Sensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SensorFromJS is casting a js.Value into Sensor.
+func SensorFromJS(value js.Value) *Sensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SensorFromJS is casting from something that holds a js.Value into Sensor.
+func SensorFromWrapper(input core.Wrapper) *Sensor {
+	return SensorFromJS(input.JSValue())
 }
 
 // Activated returning attribute 'activated' with
@@ -3443,15 +3473,19 @@ type SensorErrorEvent struct {
 	domcore.Event
 }
 
-// SensorErrorEventFromJS is casting a js.Wrapper into SensorErrorEvent.
-func SensorErrorEventFromJS(value js.Wrapper) *SensorErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SensorErrorEventFromJS is casting a js.Value into SensorErrorEvent.
+func SensorErrorEventFromJS(value js.Value) *SensorErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SensorErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SensorErrorEventFromJS is casting from something that holds a js.Value into SensorErrorEvent.
+func SensorErrorEventFromWrapper(input core.Wrapper) *SensorErrorEvent {
+	return SensorErrorEventFromJS(input.JSValue())
 }
 
 func NewSensorErrorEvent(_type string, errorEventInitDict *SensorErrorEventInit) (_result *SensorErrorEvent) {
@@ -3489,15 +3523,19 @@ type UncalibratedMagnetometer struct {
 	Sensor
 }
 
-// UncalibratedMagnetometerFromJS is casting a js.Wrapper into UncalibratedMagnetometer.
-func UncalibratedMagnetometerFromJS(value js.Wrapper) *UncalibratedMagnetometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UncalibratedMagnetometerFromJS is casting a js.Value into UncalibratedMagnetometer.
+func UncalibratedMagnetometerFromJS(value js.Value) *UncalibratedMagnetometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UncalibratedMagnetometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UncalibratedMagnetometerFromJS is casting from something that holds a js.Value into UncalibratedMagnetometer.
+func UncalibratedMagnetometerFromWrapper(input core.Wrapper) *UncalibratedMagnetometer {
+	return UncalibratedMagnetometerFromJS(input.JSValue())
 }
 
 func NewUncalibratedMagnetometer(sensorOptions *MagnetometerSensorOptions) (_result *UncalibratedMagnetometer) {

--- a/device/sensor/sensor_js.go
+++ b/device/sensor/sensor_js.go
@@ -5,6 +5,7 @@ package sensor
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -321,7 +322,7 @@ type AbsoluteOrientationReadingValues struct {
 	Quaternion *javascript.FrozenArray
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AbsoluteOrientationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -331,16 +332,14 @@ func (_this *AbsoluteOrientationReadingValues) JSValue() js.Value {
 }
 
 // AbsoluteOrientationReadingValuesFromJS is allocating a new
-// AbsoluteOrientationReadingValues object and copy all values from
-// input javascript object
-func AbsoluteOrientationReadingValuesFromJS(value js.Wrapper) *AbsoluteOrientationReadingValues {
-	input := value.JSValue()
+// AbsoluteOrientationReadingValues object and copy all values in the value javascript object.
+func AbsoluteOrientationReadingValuesFromJS(value js.Value) *AbsoluteOrientationReadingValues {
 	var out AbsoluteOrientationReadingValues
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {quaternion Quaternion quaternion}
 	)
-	if input.Get("quaternion").Type() != js.TypeNull && input.Get("quaternion").Type() != js.TypeUndefined {
-		value0 = javascript.FrozenArrayFromJS(input.Get("quaternion"))
+	if value.Get("quaternion").Type() != js.TypeNull && value.Get("quaternion").Type() != js.TypeUndefined {
+		value0 = javascript.FrozenArrayFromJS(value.Get("quaternion"))
 	}
 	out.Quaternion = value0
 	return &out
@@ -353,7 +352,7 @@ type AccelerometerReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AccelerometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -385,28 +384,26 @@ func (_this *AccelerometerReadingValues) JSValue() js.Value {
 }
 
 // AccelerometerReadingValuesFromJS is allocating a new
-// AccelerometerReadingValues object and copy all values from
-// input javascript object
-func AccelerometerReadingValuesFromJS(value js.Wrapper) *AccelerometerReadingValues {
-	input := value.JSValue()
+// AccelerometerReadingValues object and copy all values in the value javascript object.
+func AccelerometerReadingValuesFromJS(value js.Value) *AccelerometerReadingValues {
 	var out AccelerometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -419,7 +416,7 @@ type AccelerometerSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AccelerometerSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -431,18 +428,16 @@ func (_this *AccelerometerSensorOptions) JSValue() js.Value {
 }
 
 // AccelerometerSensorOptionsFromJS is allocating a new
-// AccelerometerSensorOptions object and copy all values from
-// input javascript object
-func AccelerometerSensorOptionsFromJS(value js.Wrapper) *AccelerometerSensorOptions {
-	input := value.JSValue()
+// AccelerometerSensorOptions object and copy all values in the value javascript object.
+func AccelerometerSensorOptionsFromJS(value js.Value) *AccelerometerSensorOptions {
 	var out AccelerometerSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -452,7 +447,7 @@ type AmbientLightReadingValues struct {
 	Illuminance *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AmbientLightReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -468,16 +463,14 @@ func (_this *AmbientLightReadingValues) JSValue() js.Value {
 }
 
 // AmbientLightReadingValuesFromJS is allocating a new
-// AmbientLightReadingValues object and copy all values from
-// input javascript object
-func AmbientLightReadingValuesFromJS(value js.Wrapper) *AmbientLightReadingValues {
-	input := value.JSValue()
+// AmbientLightReadingValues object and copy all values in the value javascript object.
+func AmbientLightReadingValuesFromJS(value js.Value) *AmbientLightReadingValues {
 	var out AmbientLightReadingValues
 	var (
 		value0 *float64 // javascript: double {illuminance Illuminance illuminance}
 	)
-	if input.Get("illuminance").Type() != js.TypeNull && input.Get("illuminance").Type() != js.TypeUndefined {
-		__tmp := (input.Get("illuminance")).Float()
+	if value.Get("illuminance").Type() != js.TypeNull && value.Get("illuminance").Type() != js.TypeUndefined {
+		__tmp := (value.Get("illuminance")).Float()
 		value0 = &__tmp
 	}
 	out.Illuminance = value0
@@ -491,7 +484,7 @@ type DeviceAccelerationInit struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceAccelerationInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -523,28 +516,26 @@ func (_this *DeviceAccelerationInit) JSValue() js.Value {
 }
 
 // DeviceAccelerationInitFromJS is allocating a new
-// DeviceAccelerationInit object and copy all values from
-// input javascript object
-func DeviceAccelerationInitFromJS(value js.Wrapper) *DeviceAccelerationInit {
-	input := value.JSValue()
+// DeviceAccelerationInit object and copy all values in the value javascript object.
+func DeviceAccelerationInitFromJS(value js.Value) *DeviceAccelerationInit {
 	var out DeviceAccelerationInit
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -562,7 +553,7 @@ type DeviceMotionEventInit struct {
 	Interval                     float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceMotionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -584,10 +575,8 @@ func (_this *DeviceMotionEventInit) JSValue() js.Value {
 }
 
 // DeviceMotionEventInitFromJS is allocating a new
-// DeviceMotionEventInit object and copy all values from
-// input javascript object
-func DeviceMotionEventInitFromJS(value js.Wrapper) *DeviceMotionEventInit {
-	input := value.JSValue()
+// DeviceMotionEventInit object and copy all values in the value javascript object.
+func DeviceMotionEventInitFromJS(value js.Value) *DeviceMotionEventInit {
 	var out DeviceMotionEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -598,25 +587,25 @@ func DeviceMotionEventInitFromJS(value js.Wrapper) *DeviceMotionEventInit {
 		value5 *DeviceRotationRateInit // javascript: DeviceRotationRateInit {rotationRate RotationRate rotationRate}
 		value6 float64                 // javascript: double {interval Interval interval}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("acceleration").Type() != js.TypeNull && input.Get("acceleration").Type() != js.TypeUndefined {
-		value3 = DeviceAccelerationInitFromJS(input.Get("acceleration"))
+	if value.Get("acceleration").Type() != js.TypeNull && value.Get("acceleration").Type() != js.TypeUndefined {
+		value3 = DeviceAccelerationInitFromJS(value.Get("acceleration"))
 	}
 	out.Acceleration = value3
-	if input.Get("accelerationIncludingGravity").Type() != js.TypeNull && input.Get("accelerationIncludingGravity").Type() != js.TypeUndefined {
-		value4 = DeviceAccelerationInitFromJS(input.Get("accelerationIncludingGravity"))
+	if value.Get("accelerationIncludingGravity").Type() != js.TypeNull && value.Get("accelerationIncludingGravity").Type() != js.TypeUndefined {
+		value4 = DeviceAccelerationInitFromJS(value.Get("accelerationIncludingGravity"))
 	}
 	out.AccelerationIncludingGravity = value4
-	if input.Get("rotationRate").Type() != js.TypeNull && input.Get("rotationRate").Type() != js.TypeUndefined {
-		value5 = DeviceRotationRateInitFromJS(input.Get("rotationRate"))
+	if value.Get("rotationRate").Type() != js.TypeNull && value.Get("rotationRate").Type() != js.TypeUndefined {
+		value5 = DeviceRotationRateInitFromJS(value.Get("rotationRate"))
 	}
 	out.RotationRate = value5
-	value6 = (input.Get("interval")).Float()
+	value6 = (value.Get("interval")).Float()
 	out.Interval = value6
 	return &out
 }
@@ -632,7 +621,7 @@ type DeviceOrientationEventInit struct {
 	Absolute   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceOrientationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -672,10 +661,8 @@ func (_this *DeviceOrientationEventInit) JSValue() js.Value {
 }
 
 // DeviceOrientationEventInitFromJS is allocating a new
-// DeviceOrientationEventInit object and copy all values from
-// input javascript object
-func DeviceOrientationEventInitFromJS(value js.Wrapper) *DeviceOrientationEventInit {
-	input := value.JSValue()
+// DeviceOrientationEventInit object and copy all values in the value javascript object.
+func DeviceOrientationEventInitFromJS(value js.Value) *DeviceOrientationEventInit {
 	var out DeviceOrientationEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -686,28 +673,28 @@ func DeviceOrientationEventInitFromJS(value js.Wrapper) *DeviceOrientationEventI
 		value5 *float64 // javascript: double {gamma Gamma gamma}
 		value6 bool     // javascript: boolean {absolute Absolute absolute}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("alpha").Type() != js.TypeNull && input.Get("alpha").Type() != js.TypeUndefined {
-		__tmp := (input.Get("alpha")).Float()
+	if value.Get("alpha").Type() != js.TypeNull && value.Get("alpha").Type() != js.TypeUndefined {
+		__tmp := (value.Get("alpha")).Float()
 		value3 = &__tmp
 	}
 	out.Alpha = value3
-	if input.Get("beta").Type() != js.TypeNull && input.Get("beta").Type() != js.TypeUndefined {
-		__tmp := (input.Get("beta")).Float()
+	if value.Get("beta").Type() != js.TypeNull && value.Get("beta").Type() != js.TypeUndefined {
+		__tmp := (value.Get("beta")).Float()
 		value4 = &__tmp
 	}
 	out.Beta = value4
-	if input.Get("gamma").Type() != js.TypeNull && input.Get("gamma").Type() != js.TypeUndefined {
-		__tmp := (input.Get("gamma")).Float()
+	if value.Get("gamma").Type() != js.TypeNull && value.Get("gamma").Type() != js.TypeUndefined {
+		__tmp := (value.Get("gamma")).Float()
 		value5 = &__tmp
 	}
 	out.Gamma = value5
-	value6 = (input.Get("absolute")).Bool()
+	value6 = (value.Get("absolute")).Bool()
 	out.Absolute = value6
 	return &out
 }
@@ -719,7 +706,7 @@ type DeviceRotationRateInit struct {
 	Gamma *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DeviceRotationRateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -751,28 +738,26 @@ func (_this *DeviceRotationRateInit) JSValue() js.Value {
 }
 
 // DeviceRotationRateInitFromJS is allocating a new
-// DeviceRotationRateInit object and copy all values from
-// input javascript object
-func DeviceRotationRateInitFromJS(value js.Wrapper) *DeviceRotationRateInit {
-	input := value.JSValue()
+// DeviceRotationRateInit object and copy all values in the value javascript object.
+func DeviceRotationRateInitFromJS(value js.Value) *DeviceRotationRateInit {
 	var out DeviceRotationRateInit
 	var (
 		value0 *float64 // javascript: double {alpha Alpha alpha}
 		value1 *float64 // javascript: double {beta Beta beta}
 		value2 *float64 // javascript: double {gamma Gamma gamma}
 	)
-	if input.Get("alpha").Type() != js.TypeNull && input.Get("alpha").Type() != js.TypeUndefined {
-		__tmp := (input.Get("alpha")).Float()
+	if value.Get("alpha").Type() != js.TypeNull && value.Get("alpha").Type() != js.TypeUndefined {
+		__tmp := (value.Get("alpha")).Float()
 		value0 = &__tmp
 	}
 	out.Alpha = value0
-	if input.Get("beta").Type() != js.TypeNull && input.Get("beta").Type() != js.TypeUndefined {
-		__tmp := (input.Get("beta")).Float()
+	if value.Get("beta").Type() != js.TypeNull && value.Get("beta").Type() != js.TypeUndefined {
+		__tmp := (value.Get("beta")).Float()
 		value1 = &__tmp
 	}
 	out.Beta = value1
-	if input.Get("gamma").Type() != js.TypeNull && input.Get("gamma").Type() != js.TypeUndefined {
-		__tmp := (input.Get("gamma")).Float()
+	if value.Get("gamma").Type() != js.TypeNull && value.Get("gamma").Type() != js.TypeUndefined {
+		__tmp := (value.Get("gamma")).Float()
 		value2 = &__tmp
 	}
 	out.Gamma = value2
@@ -790,7 +775,7 @@ type GeolocationReadingValues struct {
 	Speed            *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -854,10 +839,8 @@ func (_this *GeolocationReadingValues) JSValue() js.Value {
 }
 
 // GeolocationReadingValuesFromJS is allocating a new
-// GeolocationReadingValues object and copy all values from
-// input javascript object
-func GeolocationReadingValuesFromJS(value js.Wrapper) *GeolocationReadingValues {
-	input := value.JSValue()
+// GeolocationReadingValues object and copy all values in the value javascript object.
+func GeolocationReadingValuesFromJS(value js.Value) *GeolocationReadingValues {
 	var out GeolocationReadingValues
 	var (
 		value0 *float64 // javascript: double {latitude Latitude latitude}
@@ -868,38 +851,38 @@ func GeolocationReadingValuesFromJS(value js.Wrapper) *GeolocationReadingValues 
 		value5 *float64 // javascript: double {heading Heading heading}
 		value6 *float64 // javascript: double {speed Speed speed}
 	)
-	if input.Get("latitude").Type() != js.TypeNull && input.Get("latitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("latitude")).Float()
+	if value.Get("latitude").Type() != js.TypeNull && value.Get("latitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("latitude")).Float()
 		value0 = &__tmp
 	}
 	out.Latitude = value0
-	if input.Get("longitude").Type() != js.TypeNull && input.Get("longitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("longitude")).Float()
+	if value.Get("longitude").Type() != js.TypeNull && value.Get("longitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("longitude")).Float()
 		value1 = &__tmp
 	}
 	out.Longitude = value1
-	if input.Get("altitude").Type() != js.TypeNull && input.Get("altitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitude")).Float()
+	if value.Get("altitude").Type() != js.TypeNull && value.Get("altitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitude")).Float()
 		value2 = &__tmp
 	}
 	out.Altitude = value2
-	if input.Get("accuracy").Type() != js.TypeNull && input.Get("accuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("accuracy")).Float()
+	if value.Get("accuracy").Type() != js.TypeNull && value.Get("accuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("accuracy")).Float()
 		value3 = &__tmp
 	}
 	out.Accuracy = value3
-	if input.Get("altitudeAccuracy").Type() != js.TypeNull && input.Get("altitudeAccuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitudeAccuracy")).Float()
+	if value.Get("altitudeAccuracy").Type() != js.TypeNull && value.Get("altitudeAccuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitudeAccuracy")).Float()
 		value4 = &__tmp
 	}
 	out.AltitudeAccuracy = value4
-	if input.Get("heading").Type() != js.TypeNull && input.Get("heading").Type() != js.TypeUndefined {
-		__tmp := (input.Get("heading")).Float()
+	if value.Get("heading").Type() != js.TypeNull && value.Get("heading").Type() != js.TypeUndefined {
+		__tmp := (value.Get("heading")).Float()
 		value5 = &__tmp
 	}
 	out.Heading = value5
-	if input.Get("speed").Type() != js.TypeNull && input.Get("speed").Type() != js.TypeUndefined {
-		__tmp := (input.Get("speed")).Float()
+	if value.Get("speed").Type() != js.TypeNull && value.Get("speed").Type() != js.TypeUndefined {
+		__tmp := (value.Get("speed")).Float()
 		value6 = &__tmp
 	}
 	out.Speed = value6
@@ -911,7 +894,7 @@ type GeolocationSensorOptions struct {
 	Frequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -921,15 +904,13 @@ func (_this *GeolocationSensorOptions) JSValue() js.Value {
 }
 
 // GeolocationSensorOptionsFromJS is allocating a new
-// GeolocationSensorOptions object and copy all values from
-// input javascript object
-func GeolocationSensorOptionsFromJS(value js.Wrapper) *GeolocationSensorOptions {
-	input := value.JSValue()
+// GeolocationSensorOptions object and copy all values in the value javascript object.
+func GeolocationSensorOptionsFromJS(value js.Value) *GeolocationSensorOptions {
 	var out GeolocationSensorOptions
 	var (
 		value0 float64 // javascript: double {frequency Frequency frequency}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
 	return &out
 }
@@ -946,7 +927,7 @@ type GeolocationSensorReading struct {
 	Speed            *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GeolocationSensorReading) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1018,10 +999,8 @@ func (_this *GeolocationSensorReading) JSValue() js.Value {
 }
 
 // GeolocationSensorReadingFromJS is allocating a new
-// GeolocationSensorReading object and copy all values from
-// input javascript object
-func GeolocationSensorReadingFromJS(value js.Wrapper) *GeolocationSensorReading {
-	input := value.JSValue()
+// GeolocationSensorReading object and copy all values in the value javascript object.
+func GeolocationSensorReadingFromJS(value js.Value) *GeolocationSensorReading {
 	var out GeolocationSensorReading
 	var (
 		value0 *float64 // javascript: double {timestamp Timestamp timestamp}
@@ -1033,43 +1012,43 @@ func GeolocationSensorReadingFromJS(value js.Wrapper) *GeolocationSensorReading 
 		value6 *float64 // javascript: double {heading Heading heading}
 		value7 *float64 // javascript: double {speed Speed speed}
 	)
-	if input.Get("timestamp").Type() != js.TypeNull && input.Get("timestamp").Type() != js.TypeUndefined {
-		__tmp := (input.Get("timestamp")).Float()
+	if value.Get("timestamp").Type() != js.TypeNull && value.Get("timestamp").Type() != js.TypeUndefined {
+		__tmp := (value.Get("timestamp")).Float()
 		value0 = &__tmp
 	}
 	out.Timestamp = value0
-	if input.Get("latitude").Type() != js.TypeNull && input.Get("latitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("latitude")).Float()
+	if value.Get("latitude").Type() != js.TypeNull && value.Get("latitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("latitude")).Float()
 		value1 = &__tmp
 	}
 	out.Latitude = value1
-	if input.Get("longitude").Type() != js.TypeNull && input.Get("longitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("longitude")).Float()
+	if value.Get("longitude").Type() != js.TypeNull && value.Get("longitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("longitude")).Float()
 		value2 = &__tmp
 	}
 	out.Longitude = value2
-	if input.Get("altitude").Type() != js.TypeNull && input.Get("altitude").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitude")).Float()
+	if value.Get("altitude").Type() != js.TypeNull && value.Get("altitude").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitude")).Float()
 		value3 = &__tmp
 	}
 	out.Altitude = value3
-	if input.Get("accuracy").Type() != js.TypeNull && input.Get("accuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("accuracy")).Float()
+	if value.Get("accuracy").Type() != js.TypeNull && value.Get("accuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("accuracy")).Float()
 		value4 = &__tmp
 	}
 	out.Accuracy = value4
-	if input.Get("altitudeAccuracy").Type() != js.TypeNull && input.Get("altitudeAccuracy").Type() != js.TypeUndefined {
-		__tmp := (input.Get("altitudeAccuracy")).Float()
+	if value.Get("altitudeAccuracy").Type() != js.TypeNull && value.Get("altitudeAccuracy").Type() != js.TypeUndefined {
+		__tmp := (value.Get("altitudeAccuracy")).Float()
 		value5 = &__tmp
 	}
 	out.AltitudeAccuracy = value5
-	if input.Get("heading").Type() != js.TypeNull && input.Get("heading").Type() != js.TypeUndefined {
-		__tmp := (input.Get("heading")).Float()
+	if value.Get("heading").Type() != js.TypeNull && value.Get("heading").Type() != js.TypeUndefined {
+		__tmp := (value.Get("heading")).Float()
 		value6 = &__tmp
 	}
 	out.Heading = value6
-	if input.Get("speed").Type() != js.TypeNull && input.Get("speed").Type() != js.TypeUndefined {
-		__tmp := (input.Get("speed")).Float()
+	if value.Get("speed").Type() != js.TypeNull && value.Get("speed").Type() != js.TypeUndefined {
+		__tmp := (value.Get("speed")).Float()
 		value7 = &__tmp
 	}
 	out.Speed = value7
@@ -1083,7 +1062,7 @@ type GravityReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GravityReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1115,28 +1094,26 @@ func (_this *GravityReadingValues) JSValue() js.Value {
 }
 
 // GravityReadingValuesFromJS is allocating a new
-// GravityReadingValues object and copy all values from
-// input javascript object
-func GravityReadingValuesFromJS(value js.Wrapper) *GravityReadingValues {
-	input := value.JSValue()
+// GravityReadingValues object and copy all values in the value javascript object.
+func GravityReadingValuesFromJS(value js.Value) *GravityReadingValues {
 	var out GravityReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1150,7 +1127,7 @@ type GyroscopeReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GyroscopeReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1182,28 +1159,26 @@ func (_this *GyroscopeReadingValues) JSValue() js.Value {
 }
 
 // GyroscopeReadingValuesFromJS is allocating a new
-// GyroscopeReadingValues object and copy all values from
-// input javascript object
-func GyroscopeReadingValuesFromJS(value js.Wrapper) *GyroscopeReadingValues {
-	input := value.JSValue()
+// GyroscopeReadingValues object and copy all values in the value javascript object.
+func GyroscopeReadingValuesFromJS(value js.Value) *GyroscopeReadingValues {
 	var out GyroscopeReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1216,7 +1191,7 @@ type GyroscopeSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GyroscopeSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1228,18 +1203,16 @@ func (_this *GyroscopeSensorOptions) JSValue() js.Value {
 }
 
 // GyroscopeSensorOptionsFromJS is allocating a new
-// GyroscopeSensorOptions object and copy all values from
-// input javascript object
-func GyroscopeSensorOptionsFromJS(value js.Wrapper) *GyroscopeSensorOptions {
-	input := value.JSValue()
+// GyroscopeSensorOptions object and copy all values in the value javascript object.
+func GyroscopeSensorOptionsFromJS(value js.Value) *GyroscopeSensorOptions {
 	var out GyroscopeSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1251,7 +1224,7 @@ type LinearAccelerationReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LinearAccelerationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1283,28 +1256,26 @@ func (_this *LinearAccelerationReadingValues) JSValue() js.Value {
 }
 
 // LinearAccelerationReadingValuesFromJS is allocating a new
-// LinearAccelerationReadingValues object and copy all values from
-// input javascript object
-func LinearAccelerationReadingValuesFromJS(value js.Wrapper) *LinearAccelerationReadingValues {
-	input := value.JSValue()
+// LinearAccelerationReadingValues object and copy all values in the value javascript object.
+func LinearAccelerationReadingValuesFromJS(value js.Value) *LinearAccelerationReadingValues {
 	var out LinearAccelerationReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1318,7 +1289,7 @@ type MagnetometerReadingValues struct {
 	Z *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MagnetometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1350,28 +1321,26 @@ func (_this *MagnetometerReadingValues) JSValue() js.Value {
 }
 
 // MagnetometerReadingValuesFromJS is allocating a new
-// MagnetometerReadingValues object and copy all values from
-// input javascript object
-func MagnetometerReadingValuesFromJS(value js.Wrapper) *MagnetometerReadingValues {
-	input := value.JSValue()
+// MagnetometerReadingValues object and copy all values in the value javascript object.
+func MagnetometerReadingValuesFromJS(value js.Value) *MagnetometerReadingValues {
 	var out MagnetometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
 		value1 *float64 // javascript: double {y Y y}
 		value2 *float64 // javascript: double {z Z z}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
@@ -1384,7 +1353,7 @@ type MagnetometerSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MagnetometerSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1396,18 +1365,16 @@ func (_this *MagnetometerSensorOptions) JSValue() js.Value {
 }
 
 // MagnetometerSensorOptionsFromJS is allocating a new
-// MagnetometerSensorOptions object and copy all values from
-// input javascript object
-func MagnetometerSensorOptionsFromJS(value js.Wrapper) *MagnetometerSensorOptions {
-	input := value.JSValue()
+// MagnetometerSensorOptions object and copy all values in the value javascript object.
+func MagnetometerSensorOptionsFromJS(value js.Value) *MagnetometerSensorOptions {
 	var out MagnetometerSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1419,7 +1386,7 @@ type MockSensor struct {
 	RequestedSamplingFrequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1433,21 +1400,19 @@ func (_this *MockSensor) JSValue() js.Value {
 }
 
 // MockSensorFromJS is allocating a new
-// MockSensor object and copy all values from
-// input javascript object
-func MockSensorFromJS(value js.Wrapper) *MockSensor {
-	input := value.JSValue()
+// MockSensor object and copy all values in the value javascript object.
+func MockSensorFromJS(value js.Value) *MockSensor {
 	var out MockSensor
 	var (
 		value0 float64 // javascript: double {maxSamplingFrequency MaxSamplingFrequency maxSamplingFrequency}
 		value1 float64 // javascript: double {minSamplingFrequency MinSamplingFrequency minSamplingFrequency}
 		value2 float64 // javascript: double {requestedSamplingFrequency RequestedSamplingFrequency requestedSamplingFrequency}
 	)
-	value0 = (input.Get("maxSamplingFrequency")).Float()
+	value0 = (value.Get("maxSamplingFrequency")).Float()
 	out.MaxSamplingFrequency = value0
-	value1 = (input.Get("minSamplingFrequency")).Float()
+	value1 = (value.Get("minSamplingFrequency")).Float()
 	out.MinSamplingFrequency = value1
-	value2 = (input.Get("requestedSamplingFrequency")).Float()
+	value2 = (value.Get("requestedSamplingFrequency")).Float()
 	out.RequestedSamplingFrequency = value2
 	return &out
 }
@@ -1460,7 +1425,7 @@ type MockSensorConfiguration struct {
 	MinSamplingFrequency *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensorConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1488,10 +1453,8 @@ func (_this *MockSensorConfiguration) JSValue() js.Value {
 }
 
 // MockSensorConfigurationFromJS is allocating a new
-// MockSensorConfiguration object and copy all values from
-// input javascript object
-func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
-	input := value.JSValue()
+// MockSensorConfiguration object and copy all values in the value javascript object.
+func MockSensorConfigurationFromJS(value js.Value) *MockSensorConfiguration {
 	var out MockSensorConfiguration
 	var (
 		value0 MockSensorType // javascript: MockSensorType {mockSensorType MockSensorType mockSensorType}
@@ -1499,17 +1462,17 @@ func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
 		value2 *float64       // javascript: double {maxSamplingFrequency MaxSamplingFrequency maxSamplingFrequency}
 		value3 *float64       // javascript: double {minSamplingFrequency MinSamplingFrequency minSamplingFrequency}
 	)
-	value0 = MockSensorTypeFromJS(input.Get("mockSensorType"))
+	value0 = MockSensorTypeFromJS(value.Get("mockSensorType"))
 	out.MockSensorType = value0
-	value1 = (input.Get("connected")).Bool()
+	value1 = (value.Get("connected")).Bool()
 	out.Connected = value1
-	if input.Get("maxSamplingFrequency").Type() != js.TypeNull && input.Get("maxSamplingFrequency").Type() != js.TypeUndefined {
-		__tmp := (input.Get("maxSamplingFrequency")).Float()
+	if value.Get("maxSamplingFrequency").Type() != js.TypeNull && value.Get("maxSamplingFrequency").Type() != js.TypeUndefined {
+		__tmp := (value.Get("maxSamplingFrequency")).Float()
 		value2 = &__tmp
 	}
 	out.MaxSamplingFrequency = value2
-	if input.Get("minSamplingFrequency").Type() != js.TypeNull && input.Get("minSamplingFrequency").Type() != js.TypeUndefined {
-		__tmp := (input.Get("minSamplingFrequency")).Float()
+	if value.Get("minSamplingFrequency").Type() != js.TypeNull && value.Get("minSamplingFrequency").Type() != js.TypeUndefined {
+		__tmp := (value.Get("minSamplingFrequency")).Float()
 		value3 = &__tmp
 	}
 	out.MinSamplingFrequency = value3
@@ -1520,7 +1483,7 @@ func MockSensorConfigurationFromJS(value js.Wrapper) *MockSensorConfiguration {
 type MockSensorReadingValues struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MockSensorReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1528,9 +1491,8 @@ func (_this *MockSensorReadingValues) JSValue() js.Value {
 }
 
 // MockSensorReadingValuesFromJS is allocating a new
-// MockSensorReadingValues object and copy all values from
-// input javascript object
-func MockSensorReadingValuesFromJS(value js.Wrapper) *MockSensorReadingValues {
+// MockSensorReadingValues object and copy all values in the value javascript object.
+func MockSensorReadingValuesFromJS(value js.Value) *MockSensorReadingValues {
 	var out MockSensorReadingValues
 	var ()
 	return &out
@@ -1542,7 +1504,7 @@ type OrientationSensorOptions struct {
 	ReferenceFrame LocalCoordinateSystem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OrientationSensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1554,18 +1516,16 @@ func (_this *OrientationSensorOptions) JSValue() js.Value {
 }
 
 // OrientationSensorOptionsFromJS is allocating a new
-// OrientationSensorOptions object and copy all values from
-// input javascript object
-func OrientationSensorOptionsFromJS(value js.Wrapper) *OrientationSensorOptions {
-	input := value.JSValue()
+// OrientationSensorOptions object and copy all values in the value javascript object.
+func OrientationSensorOptionsFromJS(value js.Value) *OrientationSensorOptions {
 	var out OrientationSensorOptions
 	var (
 		value0 float64               // javascript: double {frequency Frequency frequency}
 		value1 LocalCoordinateSystem // javascript: GenericSensorLocalCoordinateSystem {referenceFrame ReferenceFrame referenceFrame}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	value1 = LocalCoordinateSystemFromJS(input.Get("referenceFrame"))
+	value1 = LocalCoordinateSystemFromJS(value.Get("referenceFrame"))
 	out.ReferenceFrame = value1
 	return &out
 }
@@ -1577,7 +1537,7 @@ type PositionOptions struct {
 	MaximumAge         uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PositionOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1591,21 +1551,19 @@ func (_this *PositionOptions) JSValue() js.Value {
 }
 
 // PositionOptionsFromJS is allocating a new
-// PositionOptions object and copy all values from
-// input javascript object
-func PositionOptionsFromJS(value js.Wrapper) *PositionOptions {
-	input := value.JSValue()
+// PositionOptions object and copy all values in the value javascript object.
+func PositionOptionsFromJS(value js.Value) *PositionOptions {
 	var out PositionOptions
 	var (
 		value0 bool // javascript: boolean {enableHighAccuracy EnableHighAccuracy enableHighAccuracy}
 		value1 uint // javascript: unsigned long {timeout Timeout timeout}
 		value2 uint // javascript: unsigned long {maximumAge MaximumAge maximumAge}
 	)
-	value0 = (input.Get("enableHighAccuracy")).Bool()
+	value0 = (value.Get("enableHighAccuracy")).Bool()
 	out.EnableHighAccuracy = value0
-	value1 = (uint)((input.Get("timeout")).Int())
+	value1 = (uint)((value.Get("timeout")).Int())
 	out.Timeout = value1
-	value2 = (uint)((input.Get("maximumAge")).Int())
+	value2 = (uint)((value.Get("maximumAge")).Int())
 	out.MaximumAge = value2
 	return &out
 }
@@ -1617,7 +1575,7 @@ type ProximityReadingValues struct {
 	Near     *bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ProximityReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1649,28 +1607,26 @@ func (_this *ProximityReadingValues) JSValue() js.Value {
 }
 
 // ProximityReadingValuesFromJS is allocating a new
-// ProximityReadingValues object and copy all values from
-// input javascript object
-func ProximityReadingValuesFromJS(value js.Wrapper) *ProximityReadingValues {
-	input := value.JSValue()
+// ProximityReadingValues object and copy all values in the value javascript object.
+func ProximityReadingValuesFromJS(value js.Value) *ProximityReadingValues {
 	var out ProximityReadingValues
 	var (
 		value0 *float64 // javascript: double {distance Distance distance}
 		value1 *float64 // javascript: double {max Max max}
 		value2 *bool    // javascript: boolean {near Near near}
 	)
-	if input.Get("distance").Type() != js.TypeNull && input.Get("distance").Type() != js.TypeUndefined {
-		__tmp := (input.Get("distance")).Float()
+	if value.Get("distance").Type() != js.TypeNull && value.Get("distance").Type() != js.TypeUndefined {
+		__tmp := (value.Get("distance")).Float()
 		value0 = &__tmp
 	}
 	out.Distance = value0
-	if input.Get("max").Type() != js.TypeNull && input.Get("max").Type() != js.TypeUndefined {
-		__tmp := (input.Get("max")).Float()
+	if value.Get("max").Type() != js.TypeNull && value.Get("max").Type() != js.TypeUndefined {
+		__tmp := (value.Get("max")).Float()
 		value1 = &__tmp
 	}
 	out.Max = value1
-	if input.Get("near").Type() != js.TypeNull && input.Get("near").Type() != js.TypeUndefined {
-		__tmp := (input.Get("near")).Bool()
+	if value.Get("near").Type() != js.TypeNull && value.Get("near").Type() != js.TypeUndefined {
+		__tmp := (value.Get("near")).Bool()
 		value2 = &__tmp
 	}
 	out.Near = value2
@@ -1683,7 +1639,7 @@ type ReadOptions struct {
 	Signal    *domcore.AbortSignal
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReadOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1695,19 +1651,17 @@ func (_this *ReadOptions) JSValue() js.Value {
 }
 
 // ReadOptionsFromJS is allocating a new
-// ReadOptions object and copy all values from
-// input javascript object
-func ReadOptionsFromJS(value js.Wrapper) *ReadOptions {
-	input := value.JSValue()
+// ReadOptions object and copy all values in the value javascript object.
+func ReadOptionsFromJS(value js.Value) *ReadOptions {
 	var out ReadOptions
 	var (
 		value0 float64              // javascript: double {frequency Frequency frequency}
 		value1 *domcore.AbortSignal // javascript: AbortSignal {signal Signal signal}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value1 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value1 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value1
 	return &out
@@ -1718,7 +1672,7 @@ type RelativeOrientationReadingValues struct {
 	Quaternion *javascript.FrozenArray
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RelativeOrientationReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1728,16 +1682,14 @@ func (_this *RelativeOrientationReadingValues) JSValue() js.Value {
 }
 
 // RelativeOrientationReadingValuesFromJS is allocating a new
-// RelativeOrientationReadingValues object and copy all values from
-// input javascript object
-func RelativeOrientationReadingValuesFromJS(value js.Wrapper) *RelativeOrientationReadingValues {
-	input := value.JSValue()
+// RelativeOrientationReadingValues object and copy all values in the value javascript object.
+func RelativeOrientationReadingValuesFromJS(value js.Value) *RelativeOrientationReadingValues {
 	var out RelativeOrientationReadingValues
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {quaternion Quaternion quaternion}
 	)
-	if input.Get("quaternion").Type() != js.TypeNull && input.Get("quaternion").Type() != js.TypeUndefined {
-		value0 = javascript.FrozenArrayFromJS(input.Get("quaternion"))
+	if value.Get("quaternion").Type() != js.TypeNull && value.Get("quaternion").Type() != js.TypeUndefined {
+		value0 = javascript.FrozenArrayFromJS(value.Get("quaternion"))
 	}
 	out.Quaternion = value0
 	return &out
@@ -1751,7 +1703,7 @@ type SensorErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SensorErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1767,10 +1719,8 @@ func (_this *SensorErrorEventInit) JSValue() js.Value {
 }
 
 // SensorErrorEventInitFromJS is allocating a new
-// SensorErrorEventInit object and copy all values from
-// input javascript object
-func SensorErrorEventInitFromJS(value js.Wrapper) *SensorErrorEventInit {
-	input := value.JSValue()
+// SensorErrorEventInit object and copy all values in the value javascript object.
+func SensorErrorEventInitFromJS(value js.Value) *SensorErrorEventInit {
 	var out SensorErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -1778,13 +1728,13 @@ func SensorErrorEventInitFromJS(value js.Wrapper) *SensorErrorEventInit {
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -1794,7 +1744,7 @@ type SensorOptions struct {
 	Frequency float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SensorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1804,15 +1754,13 @@ func (_this *SensorOptions) JSValue() js.Value {
 }
 
 // SensorOptionsFromJS is allocating a new
-// SensorOptions object and copy all values from
-// input javascript object
-func SensorOptionsFromJS(value js.Wrapper) *SensorOptions {
-	input := value.JSValue()
+// SensorOptions object and copy all values in the value javascript object.
+func SensorOptionsFromJS(value js.Value) *SensorOptions {
 	var out SensorOptions
 	var (
 		value0 float64 // javascript: double {frequency Frequency frequency}
 	)
-	value0 = (input.Get("frequency")).Float()
+	value0 = (value.Get("frequency")).Float()
 	out.Frequency = value0
 	return &out
 }
@@ -1827,7 +1775,7 @@ type UncalibratedMagnetometerReadingValues struct {
 	ZBias *float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *UncalibratedMagnetometerReadingValues) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1883,10 +1831,8 @@ func (_this *UncalibratedMagnetometerReadingValues) JSValue() js.Value {
 }
 
 // UncalibratedMagnetometerReadingValuesFromJS is allocating a new
-// UncalibratedMagnetometerReadingValues object and copy all values from
-// input javascript object
-func UncalibratedMagnetometerReadingValuesFromJS(value js.Wrapper) *UncalibratedMagnetometerReadingValues {
-	input := value.JSValue()
+// UncalibratedMagnetometerReadingValues object and copy all values in the value javascript object.
+func UncalibratedMagnetometerReadingValuesFromJS(value js.Value) *UncalibratedMagnetometerReadingValues {
 	var out UncalibratedMagnetometerReadingValues
 	var (
 		value0 *float64 // javascript: double {x X x}
@@ -1896,33 +1842,33 @@ func UncalibratedMagnetometerReadingValuesFromJS(value js.Wrapper) *Uncalibrated
 		value4 *float64 // javascript: double {yBias YBias yBias}
 		value5 *float64 // javascript: double {zBias ZBias zBias}
 	)
-	if input.Get("x").Type() != js.TypeNull && input.Get("x").Type() != js.TypeUndefined {
-		__tmp := (input.Get("x")).Float()
+	if value.Get("x").Type() != js.TypeNull && value.Get("x").Type() != js.TypeUndefined {
+		__tmp := (value.Get("x")).Float()
 		value0 = &__tmp
 	}
 	out.X = value0
-	if input.Get("y").Type() != js.TypeNull && input.Get("y").Type() != js.TypeUndefined {
-		__tmp := (input.Get("y")).Float()
+	if value.Get("y").Type() != js.TypeNull && value.Get("y").Type() != js.TypeUndefined {
+		__tmp := (value.Get("y")).Float()
 		value1 = &__tmp
 	}
 	out.Y = value1
-	if input.Get("z").Type() != js.TypeNull && input.Get("z").Type() != js.TypeUndefined {
-		__tmp := (input.Get("z")).Float()
+	if value.Get("z").Type() != js.TypeNull && value.Get("z").Type() != js.TypeUndefined {
+		__tmp := (value.Get("z")).Float()
 		value2 = &__tmp
 	}
 	out.Z = value2
-	if input.Get("xBias").Type() != js.TypeNull && input.Get("xBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("xBias")).Float()
+	if value.Get("xBias").Type() != js.TypeNull && value.Get("xBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("xBias")).Float()
 		value3 = &__tmp
 	}
 	out.XBias = value3
-	if input.Get("yBias").Type() != js.TypeNull && input.Get("yBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("yBias")).Float()
+	if value.Get("yBias").Type() != js.TypeNull && value.Get("yBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("yBias")).Float()
 		value4 = &__tmp
 	}
 	out.YBias = value4
-	if input.Get("zBias").Type() != js.TypeNull && input.Get("zBias").Type() != js.TypeUndefined {
-		__tmp := (input.Get("zBias")).Float()
+	if value.Get("zBias").Type() != js.TypeNull && value.Get("zBias").Type() != js.TypeUndefined {
+		__tmp := (value.Get("zBias")).Float()
 		value5 = &__tmp
 	}
 	out.ZBias = value5
@@ -1934,15 +1880,19 @@ type AbsoluteOrientationSensor struct {
 	OrientationSensor
 }
 
-// AbsoluteOrientationSensorFromJS is casting a js.Wrapper into AbsoluteOrientationSensor.
-func AbsoluteOrientationSensorFromJS(value js.Wrapper) *AbsoluteOrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbsoluteOrientationSensorFromJS is casting a js.Value into AbsoluteOrientationSensor.
+func AbsoluteOrientationSensorFromJS(value js.Value) *AbsoluteOrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbsoluteOrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbsoluteOrientationSensorFromJS is casting from something that holds a js.Value into AbsoluteOrientationSensor.
+func AbsoluteOrientationSensorFromWrapper(input core.Wrapper) *AbsoluteOrientationSensor {
+	return AbsoluteOrientationSensorFromJS(input.JSValue())
 }
 
 func NewAbsoluteOrientationSensor(sensorOptions *OrientationSensorOptions) (_result *AbsoluteOrientationSensor) {
@@ -1970,15 +1920,19 @@ type Accelerometer struct {
 	Sensor
 }
 
-// AccelerometerFromJS is casting a js.Wrapper into Accelerometer.
-func AccelerometerFromJS(value js.Wrapper) *Accelerometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AccelerometerFromJS is casting a js.Value into Accelerometer.
+func AccelerometerFromJS(value js.Value) *Accelerometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Accelerometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AccelerometerFromJS is casting from something that holds a js.Value into Accelerometer.
+func AccelerometerFromWrapper(input core.Wrapper) *Accelerometer {
+	return AccelerometerFromJS(input.JSValue())
 }
 
 func NewAccelerometer(options *AccelerometerSensorOptions) (_result *Accelerometer) {
@@ -2042,15 +1996,19 @@ type AmbientLightSensor struct {
 	Sensor
 }
 
-// AmbientLightSensorFromJS is casting a js.Wrapper into AmbientLightSensor.
-func AmbientLightSensorFromJS(value js.Wrapper) *AmbientLightSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AmbientLightSensorFromJS is casting a js.Value into AmbientLightSensor.
+func AmbientLightSensorFromJS(value js.Value) *AmbientLightSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AmbientLightSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AmbientLightSensorFromJS is casting from something that holds a js.Value into AmbientLightSensor.
+func AmbientLightSensorFromWrapper(input core.Wrapper) *AmbientLightSensor {
+	return AmbientLightSensorFromJS(input.JSValue())
 }
 
 func NewAmbientLightSensor(sensorOptions *SensorOptions) (_result *AmbientLightSensor) {
@@ -2095,15 +2053,19 @@ func (_this *Coordinates) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CoordinatesFromJS is casting a js.Wrapper into Coordinates.
-func CoordinatesFromJS(value js.Wrapper) *Coordinates {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CoordinatesFromJS is casting a js.Value into Coordinates.
+func CoordinatesFromJS(value js.Value) *Coordinates {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Coordinates{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CoordinatesFromJS is casting from something that holds a js.Value into Coordinates.
+func CoordinatesFromWrapper(input core.Wrapper) *Coordinates {
+	return CoordinatesFromJS(input.JSValue())
 }
 
 // Latitude returning attribute 'latitude' with
@@ -2191,15 +2153,19 @@ func (_this *DeviceAcceleration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeviceAccelerationFromJS is casting a js.Wrapper into DeviceAcceleration.
-func DeviceAccelerationFromJS(value js.Wrapper) *DeviceAcceleration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceAccelerationFromJS is casting a js.Value into DeviceAcceleration.
+func DeviceAccelerationFromJS(value js.Value) *DeviceAcceleration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceAcceleration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceAccelerationFromJS is casting from something that holds a js.Value into DeviceAcceleration.
+func DeviceAccelerationFromWrapper(input core.Wrapper) *DeviceAcceleration {
+	return DeviceAccelerationFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -2243,15 +2209,19 @@ type DeviceMotionEvent struct {
 	domcore.Event
 }
 
-// DeviceMotionEventFromJS is casting a js.Wrapper into DeviceMotionEvent.
-func DeviceMotionEventFromJS(value js.Wrapper) *DeviceMotionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceMotionEventFromJS is casting a js.Value into DeviceMotionEvent.
+func DeviceMotionEventFromJS(value js.Value) *DeviceMotionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceMotionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceMotionEventFromJS is casting from something that holds a js.Value into DeviceMotionEvent.
+func DeviceMotionEventFromWrapper(input core.Wrapper) *DeviceMotionEvent {
+	return DeviceMotionEventFromJS(input.JSValue())
 }
 
 func NewDeviceMotionEvent(_type string, eventInitDict *DeviceMotionEventInit) (_result *DeviceMotionEvent) {
@@ -2324,15 +2294,19 @@ type DeviceOrientationEvent struct {
 	domcore.Event
 }
 
-// DeviceOrientationEventFromJS is casting a js.Wrapper into DeviceOrientationEvent.
-func DeviceOrientationEventFromJS(value js.Wrapper) *DeviceOrientationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceOrientationEventFromJS is casting a js.Value into DeviceOrientationEvent.
+func DeviceOrientationEventFromJS(value js.Value) *DeviceOrientationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceOrientationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceOrientationEventFromJS is casting from something that holds a js.Value into DeviceOrientationEvent.
+func DeviceOrientationEventFromWrapper(input core.Wrapper) *DeviceOrientationEvent {
+	return DeviceOrientationEventFromJS(input.JSValue())
 }
 
 func NewDeviceOrientationEvent(_type string, eventInitDict *DeviceOrientationEventInit) (_result *DeviceOrientationEvent) {
@@ -2413,15 +2387,19 @@ func (_this *DeviceRotationRate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeviceRotationRateFromJS is casting a js.Wrapper into DeviceRotationRate.
-func DeviceRotationRateFromJS(value js.Wrapper) *DeviceRotationRate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeviceRotationRateFromJS is casting a js.Value into DeviceRotationRate.
+func DeviceRotationRateFromJS(value js.Value) *DeviceRotationRate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeviceRotationRate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeviceRotationRateFromJS is casting from something that holds a js.Value into DeviceRotationRate.
+func DeviceRotationRateFromWrapper(input core.Wrapper) *DeviceRotationRate {
+	return DeviceRotationRateFromJS(input.JSValue())
 }
 
 // Alpha returning attribute 'alpha' with
@@ -2470,15 +2448,19 @@ func (_this *Geolocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// GeolocationFromJS is casting a js.Wrapper into Geolocation.
-func GeolocationFromJS(value js.Wrapper) *Geolocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GeolocationFromJS is casting a js.Value into Geolocation.
+func GeolocationFromJS(value js.Value) *Geolocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Geolocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GeolocationFromJS is casting from something that holds a js.Value into Geolocation.
+func GeolocationFromWrapper(input core.Wrapper) *Geolocation {
+	return GeolocationFromJS(input.JSValue())
 }
 
 func (_this *Geolocation) GetCurrentPosition(successCallback *PositionCallback, errorCallback *PositionErrorCallback, options *PositionOptions) {
@@ -2575,15 +2557,19 @@ type GeolocationSensor struct {
 	Sensor
 }
 
-// GeolocationSensorFromJS is casting a js.Wrapper into GeolocationSensor.
-func GeolocationSensorFromJS(value js.Wrapper) *GeolocationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GeolocationSensorFromJS is casting a js.Value into GeolocationSensor.
+func GeolocationSensorFromJS(value js.Value) *GeolocationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GeolocationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GeolocationSensorFromJS is casting from something that holds a js.Value into GeolocationSensor.
+func GeolocationSensorFromWrapper(input core.Wrapper) *GeolocationSensor {
+	return GeolocationSensorFromJS(input.JSValue())
 }
 
 func Read(readOptions *ReadOptions) (_result *PromiseGeolocationSensorReading) {
@@ -2716,15 +2702,19 @@ type GravitySensor struct {
 	Accelerometer
 }
 
-// GravitySensorFromJS is casting a js.Wrapper into GravitySensor.
-func GravitySensorFromJS(value js.Wrapper) *GravitySensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GravitySensorFromJS is casting a js.Value into GravitySensor.
+func GravitySensorFromJS(value js.Value) *GravitySensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GravitySensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GravitySensorFromJS is casting from something that holds a js.Value into GravitySensor.
+func GravitySensorFromWrapper(input core.Wrapper) *GravitySensor {
+	return GravitySensorFromJS(input.JSValue())
 }
 
 func NewGravitySensor(options *AccelerometerSensorOptions) (_result *GravitySensor) {
@@ -2752,15 +2742,19 @@ type Gyroscope struct {
 	Sensor
 }
 
-// GyroscopeFromJS is casting a js.Wrapper into Gyroscope.
-func GyroscopeFromJS(value js.Wrapper) *Gyroscope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GyroscopeFromJS is casting a js.Value into Gyroscope.
+func GyroscopeFromJS(value js.Value) *Gyroscope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Gyroscope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GyroscopeFromJS is casting from something that holds a js.Value into Gyroscope.
+func GyroscopeFromWrapper(input core.Wrapper) *Gyroscope {
+	return GyroscopeFromJS(input.JSValue())
 }
 
 func NewGyroscope(sensorOptions *GyroscopeSensorOptions) (_result *Gyroscope) {
@@ -2824,15 +2818,19 @@ type LinearAccelerationSensor struct {
 	Accelerometer
 }
 
-// LinearAccelerationSensorFromJS is casting a js.Wrapper into LinearAccelerationSensor.
-func LinearAccelerationSensorFromJS(value js.Wrapper) *LinearAccelerationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LinearAccelerationSensorFromJS is casting a js.Value into LinearAccelerationSensor.
+func LinearAccelerationSensorFromJS(value js.Value) *LinearAccelerationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LinearAccelerationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LinearAccelerationSensorFromJS is casting from something that holds a js.Value into LinearAccelerationSensor.
+func LinearAccelerationSensorFromWrapper(input core.Wrapper) *LinearAccelerationSensor {
+	return LinearAccelerationSensorFromJS(input.JSValue())
 }
 
 func NewLinearAccelerationSensor(options *AccelerometerSensorOptions) (_result *LinearAccelerationSensor) {
@@ -2860,15 +2858,19 @@ type Magnetometer struct {
 	Sensor
 }
 
-// MagnetometerFromJS is casting a js.Wrapper into Magnetometer.
-func MagnetometerFromJS(value js.Wrapper) *Magnetometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MagnetometerFromJS is casting a js.Value into Magnetometer.
+func MagnetometerFromJS(value js.Value) *Magnetometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Magnetometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MagnetometerFromJS is casting from something that holds a js.Value into Magnetometer.
+func MagnetometerFromWrapper(input core.Wrapper) *Magnetometer {
+	return MagnetometerFromJS(input.JSValue())
 }
 
 func NewMagnetometer(sensorOptions *MagnetometerSensorOptions) (_result *Magnetometer) {
@@ -2932,15 +2934,19 @@ type OrientationSensor struct {
 	Sensor
 }
 
-// OrientationSensorFromJS is casting a js.Wrapper into OrientationSensor.
-func OrientationSensorFromJS(value js.Wrapper) *OrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OrientationSensorFromJS is casting a js.Value into OrientationSensor.
+func OrientationSensorFromJS(value js.Value) *OrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OrientationSensorFromJS is casting from something that holds a js.Value into OrientationSensor.
+func OrientationSensorFromWrapper(input core.Wrapper) *OrientationSensor {
+	return OrientationSensorFromJS(input.JSValue())
 }
 
 // Quaternion returning attribute 'quaternion' with
@@ -2976,15 +2982,19 @@ func (_this *Position) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PositionFromJS is casting a js.Wrapper into Position.
-func PositionFromJS(value js.Wrapper) *Position {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PositionFromJS is casting a js.Value into Position.
+func PositionFromJS(value js.Value) *Position {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Position{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PositionFromJS is casting from something that holds a js.Value into Position.
+func PositionFromWrapper(input core.Wrapper) *Position {
+	return PositionFromJS(input.JSValue())
 }
 
 // Coords returning attribute 'coords' with
@@ -3015,15 +3025,19 @@ func (_this *PositionError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PositionErrorFromJS is casting a js.Wrapper into PositionError.
-func PositionErrorFromJS(value js.Wrapper) *PositionError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PositionErrorFromJS is casting a js.Value into PositionError.
+func PositionErrorFromJS(value js.Value) *PositionError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PositionError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PositionErrorFromJS is casting from something that holds a js.Value into PositionError.
+func PositionErrorFromWrapper(input core.Wrapper) *PositionError {
+	return PositionErrorFromJS(input.JSValue())
 }
 
 const (
@@ -3060,15 +3074,19 @@ func (_this *PromiseGeolocationSensorReading) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseGeolocationSensorReadingFromJS is casting a js.Wrapper into PromiseGeolocationSensorReading.
-func PromiseGeolocationSensorReadingFromJS(value js.Wrapper) *PromiseGeolocationSensorReading {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseGeolocationSensorReadingFromJS is casting a js.Value into PromiseGeolocationSensorReading.
+func PromiseGeolocationSensorReadingFromJS(value js.Value) *PromiseGeolocationSensorReading {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseGeolocationSensorReading{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseGeolocationSensorReadingFromJS is casting from something that holds a js.Value into PromiseGeolocationSensorReading.
+func PromiseGeolocationSensorReadingFromWrapper(input core.Wrapper) *PromiseGeolocationSensorReading {
+	return PromiseGeolocationSensorReadingFromJS(input.JSValue())
 }
 
 func (_this *PromiseGeolocationSensorReading) Then(onFulfilled *PromiseGeolocationSensorReadingOnFulfilled, onRejected *PromiseGeolocationSensorReadingOnRejected) (_result *PromiseGeolocationSensorReading) {
@@ -3160,15 +3178,19 @@ type ProximitySensor struct {
 	Sensor
 }
 
-// ProximitySensorFromJS is casting a js.Wrapper into ProximitySensor.
-func ProximitySensorFromJS(value js.Wrapper) *ProximitySensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProximitySensorFromJS is casting a js.Value into ProximitySensor.
+func ProximitySensorFromJS(value js.Value) *ProximitySensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProximitySensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProximitySensorFromJS is casting from something that holds a js.Value into ProximitySensor.
+func ProximitySensorFromWrapper(input core.Wrapper) *ProximitySensor {
+	return ProximitySensorFromJS(input.JSValue())
 }
 
 func NewProximitySensor(sensorOptions *SensorOptions) (_result *ProximitySensor) {
@@ -3232,15 +3254,19 @@ type RelativeOrientationSensor struct {
 	OrientationSensor
 }
 
-// RelativeOrientationSensorFromJS is casting a js.Wrapper into RelativeOrientationSensor.
-func RelativeOrientationSensorFromJS(value js.Wrapper) *RelativeOrientationSensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RelativeOrientationSensorFromJS is casting a js.Value into RelativeOrientationSensor.
+func RelativeOrientationSensorFromJS(value js.Value) *RelativeOrientationSensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RelativeOrientationSensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RelativeOrientationSensorFromJS is casting from something that holds a js.Value into RelativeOrientationSensor.
+func RelativeOrientationSensorFromWrapper(input core.Wrapper) *RelativeOrientationSensor {
+	return RelativeOrientationSensorFromJS(input.JSValue())
 }
 
 func NewRelativeOrientationSensor(sensorOptions *OrientationSensorOptions) (_result *RelativeOrientationSensor) {
@@ -3268,15 +3294,19 @@ type Sensor struct {
 	domcore.EventTarget
 }
 
-// SensorFromJS is casting a js.Wrapper into Sensor.
-func SensorFromJS(value js.Wrapper) *Sensor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SensorFromJS is casting a js.Value into Sensor.
+func SensorFromJS(value js.Value) *Sensor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sensor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SensorFromJS is casting from something that holds a js.Value into Sensor.
+func SensorFromWrapper(input core.Wrapper) *Sensor {
+	return SensorFromJS(input.JSValue())
 }
 
 // Activated returning attribute 'activated' with
@@ -3441,15 +3471,19 @@ type SensorErrorEvent struct {
 	domcore.Event
 }
 
-// SensorErrorEventFromJS is casting a js.Wrapper into SensorErrorEvent.
-func SensorErrorEventFromJS(value js.Wrapper) *SensorErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SensorErrorEventFromJS is casting a js.Value into SensorErrorEvent.
+func SensorErrorEventFromJS(value js.Value) *SensorErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SensorErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SensorErrorEventFromJS is casting from something that holds a js.Value into SensorErrorEvent.
+func SensorErrorEventFromWrapper(input core.Wrapper) *SensorErrorEvent {
+	return SensorErrorEventFromJS(input.JSValue())
 }
 
 func NewSensorErrorEvent(_type string, errorEventInitDict *SensorErrorEventInit) (_result *SensorErrorEvent) {
@@ -3487,15 +3521,19 @@ type UncalibratedMagnetometer struct {
 	Sensor
 }
 
-// UncalibratedMagnetometerFromJS is casting a js.Wrapper into UncalibratedMagnetometer.
-func UncalibratedMagnetometerFromJS(value js.Wrapper) *UncalibratedMagnetometer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UncalibratedMagnetometerFromJS is casting a js.Value into UncalibratedMagnetometer.
+func UncalibratedMagnetometerFromJS(value js.Value) *UncalibratedMagnetometer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UncalibratedMagnetometer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UncalibratedMagnetometerFromJS is casting from something that holds a js.Value into UncalibratedMagnetometer.
+func UncalibratedMagnetometerFromWrapper(input core.Wrapper) *UncalibratedMagnetometer {
+	return UncalibratedMagnetometerFromJS(input.JSValue())
 }
 
 func NewUncalibratedMagnetometer(sensorOptions *MagnetometerSensorOptions) (_result *UncalibratedMagnetometer) {

--- a/device/touchevents/touchevents.go
+++ b/device/touchevents/touchevents.go
@@ -7,6 +7,7 @@ package touchevents
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/inputcapabilities"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlevent"
@@ -109,7 +110,7 @@ type TouchEventInit struct {
 	ChangedTouches     []*Touch
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TouchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -175,10 +176,8 @@ func (_this *TouchEventInit) JSValue() js.Value {
 }
 
 // TouchEventInitFromJS is allocating a new
-// TouchEventInit object and copy all values from
-// input javascript object
-func TouchEventInitFromJS(value js.Wrapper) *TouchEventInit {
-	input := value.JSValue()
+// TouchEventInit object and copy all values in the value javascript object.
+func TouchEventInitFromJS(value js.Value) *TouchEventInit {
 	var out TouchEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -205,73 +204,73 @@ func TouchEventInitFromJS(value js.Wrapper) *TouchEventInit {
 		value21 []*Touch                                   // javascript: sequence<Touch> {targetTouches TargetTouches targetTouches}
 		value22 []*Touch                                   // javascript: sequence<Touch> {changedTouches ChangedTouches changedTouches}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	__length20 := input.Get("touches").Length()
+	__length20 := value.Get("touches").Length()
 	__array20 := make([]*Touch, __length20, __length20)
 	for __idx20 := 0; __idx20 < __length20; __idx20++ {
 		var __seq_out20 *Touch
-		__seq_in20 := input.Get("touches").Index(__idx20)
+		__seq_in20 := value.Get("touches").Index(__idx20)
 		__seq_out20 = TouchFromJS(__seq_in20)
 		__array20[__idx20] = __seq_out20
 	}
 	value20 = __array20
 	out.Touches = value20
-	__length21 := input.Get("targetTouches").Length()
+	__length21 := value.Get("targetTouches").Length()
 	__array21 := make([]*Touch, __length21, __length21)
 	for __idx21 := 0; __idx21 < __length21; __idx21++ {
 		var __seq_out21 *Touch
-		__seq_in21 := input.Get("targetTouches").Index(__idx21)
+		__seq_in21 := value.Get("targetTouches").Index(__idx21)
 		__seq_out21 = TouchFromJS(__seq_in21)
 		__array21[__idx21] = __seq_out21
 	}
 	value21 = __array21
 	out.TargetTouches = value21
-	__length22 := input.Get("changedTouches").Length()
+	__length22 := value.Get("changedTouches").Length()
 	__array22 := make([]*Touch, __length22, __length22)
 	for __idx22 := 0; __idx22 < __length22; __idx22++ {
 		var __seq_out22 *Touch
-		__seq_in22 := input.Get("changedTouches").Index(__idx22)
+		__seq_in22 := value.Get("changedTouches").Index(__idx22)
 		__seq_out22 = TouchFromJS(__seq_in22)
 		__array22[__idx22] = __seq_out22
 	}
@@ -299,7 +298,7 @@ type TouchInit struct {
 	TouchType     TouchType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TouchInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -337,10 +336,8 @@ func (_this *TouchInit) JSValue() js.Value {
 }
 
 // TouchInitFromJS is allocating a new
-// TouchInit object and copy all values from
-// input javascript object
-func TouchInitFromJS(value js.Wrapper) *TouchInit {
-	input := value.JSValue()
+// TouchInit object and copy all values in the value javascript object.
+func TouchInitFromJS(value js.Value) *TouchInit {
 	var out TouchInit
 	var (
 		value0  int                  // javascript: long {identifier Identifier identifier}
@@ -359,35 +356,35 @@ func TouchInitFromJS(value js.Wrapper) *TouchInit {
 		value13 float64              // javascript: double {azimuthAngle AzimuthAngle azimuthAngle}
 		value14 TouchType            // javascript: TouchType {touchType TouchType touchType}
 	)
-	value0 = (input.Get("identifier")).Int()
+	value0 = (value.Get("identifier")).Int()
 	out.Identifier = value0
-	value1 = domcore.EventTargetFromJS(input.Get("target"))
+	value1 = domcore.EventTargetFromJS(value.Get("target"))
 	out.Target = value1
-	value2 = (input.Get("clientX")).Float()
+	value2 = (value.Get("clientX")).Float()
 	out.ClientX = value2
-	value3 = (input.Get("clientY")).Float()
+	value3 = (value.Get("clientY")).Float()
 	out.ClientY = value3
-	value4 = (input.Get("screenX")).Float()
+	value4 = (value.Get("screenX")).Float()
 	out.ScreenX = value4
-	value5 = (input.Get("screenY")).Float()
+	value5 = (value.Get("screenY")).Float()
 	out.ScreenY = value5
-	value6 = (input.Get("pageX")).Float()
+	value6 = (value.Get("pageX")).Float()
 	out.PageX = value6
-	value7 = (input.Get("pageY")).Float()
+	value7 = (value.Get("pageY")).Float()
 	out.PageY = value7
-	value8 = (float32)((input.Get("radiusX")).Float())
+	value8 = (float32)((value.Get("radiusX")).Float())
 	out.RadiusX = value8
-	value9 = (float32)((input.Get("radiusY")).Float())
+	value9 = (float32)((value.Get("radiusY")).Float())
 	out.RadiusY = value9
-	value10 = (float32)((input.Get("rotationAngle")).Float())
+	value10 = (float32)((value.Get("rotationAngle")).Float())
 	out.RotationAngle = value10
-	value11 = (float32)((input.Get("force")).Float())
+	value11 = (float32)((value.Get("force")).Float())
 	out.Force = value11
-	value12 = (input.Get("altitudeAngle")).Float()
+	value12 = (value.Get("altitudeAngle")).Float()
 	out.AltitudeAngle = value12
-	value13 = (input.Get("azimuthAngle")).Float()
+	value13 = (value.Get("azimuthAngle")).Float()
 	out.AzimuthAngle = value13
-	value14 = TouchTypeFromJS(input.Get("touchType"))
+	value14 = TouchTypeFromJS(value.Get("touchType"))
 	out.TouchType = value14
 	return &out
 }
@@ -402,15 +399,19 @@ func (_this *Touch) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TouchFromJS is casting a js.Wrapper into Touch.
-func TouchFromJS(value js.Wrapper) *Touch {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchFromJS is casting a js.Value into Touch.
+func TouchFromJS(value js.Value) *Touch {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Touch{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchFromJS is casting from something that holds a js.Value into Touch.
+func TouchFromWrapper(input core.Wrapper) *Touch {
+	return TouchFromJS(input.JSValue())
 }
 
 func NewTouch(touchInitDict *TouchInit) (_result *Touch) {
@@ -571,15 +572,19 @@ type TouchEvent struct {
 	htmlevent.UIEvent
 }
 
-// TouchEventFromJS is casting a js.Wrapper into TouchEvent.
-func TouchEventFromJS(value js.Wrapper) *TouchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchEventFromJS is casting a js.Value into TouchEvent.
+func TouchEventFromJS(value js.Value) *TouchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TouchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchEventFromJS is casting from something that holds a js.Value into TouchEvent.
+func TouchEventFromWrapper(input core.Wrapper) *TouchEvent {
+	return TouchEventFromJS(input.JSValue())
 }
 
 func NewTouchEvent(_type string, eventInitDict *TouchEventInit) (_result *TouchEvent) {
@@ -678,15 +683,19 @@ func (_this *TouchList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TouchListFromJS is casting a js.Wrapper into TouchList.
-func TouchListFromJS(value js.Wrapper) *TouchList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchListFromJS is casting a js.Value into TouchList.
+func TouchListFromJS(value js.Value) *TouchList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TouchList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchListFromJS is casting from something that holds a js.Value into TouchList.
+func TouchListFromWrapper(input core.Wrapper) *TouchList {
+	return TouchListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/device/touchevents/touchevents_js.go
+++ b/device/touchevents/touchevents_js.go
@@ -5,6 +5,7 @@ package touchevents
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/inputcapabilities"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlevent"
@@ -107,7 +108,7 @@ type TouchEventInit struct {
 	ChangedTouches     []*Touch
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TouchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -173,10 +174,8 @@ func (_this *TouchEventInit) JSValue() js.Value {
 }
 
 // TouchEventInitFromJS is allocating a new
-// TouchEventInit object and copy all values from
-// input javascript object
-func TouchEventInitFromJS(value js.Wrapper) *TouchEventInit {
-	input := value.JSValue()
+// TouchEventInit object and copy all values in the value javascript object.
+func TouchEventInitFromJS(value js.Value) *TouchEventInit {
 	var out TouchEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -203,73 +202,73 @@ func TouchEventInitFromJS(value js.Wrapper) *TouchEventInit {
 		value21 []*Touch                                   // javascript: sequence<Touch> {targetTouches TargetTouches targetTouches}
 		value22 []*Touch                                   // javascript: sequence<Touch> {changedTouches ChangedTouches changedTouches}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	__length20 := input.Get("touches").Length()
+	__length20 := value.Get("touches").Length()
 	__array20 := make([]*Touch, __length20, __length20)
 	for __idx20 := 0; __idx20 < __length20; __idx20++ {
 		var __seq_out20 *Touch
-		__seq_in20 := input.Get("touches").Index(__idx20)
+		__seq_in20 := value.Get("touches").Index(__idx20)
 		__seq_out20 = TouchFromJS(__seq_in20)
 		__array20[__idx20] = __seq_out20
 	}
 	value20 = __array20
 	out.Touches = value20
-	__length21 := input.Get("targetTouches").Length()
+	__length21 := value.Get("targetTouches").Length()
 	__array21 := make([]*Touch, __length21, __length21)
 	for __idx21 := 0; __idx21 < __length21; __idx21++ {
 		var __seq_out21 *Touch
-		__seq_in21 := input.Get("targetTouches").Index(__idx21)
+		__seq_in21 := value.Get("targetTouches").Index(__idx21)
 		__seq_out21 = TouchFromJS(__seq_in21)
 		__array21[__idx21] = __seq_out21
 	}
 	value21 = __array21
 	out.TargetTouches = value21
-	__length22 := input.Get("changedTouches").Length()
+	__length22 := value.Get("changedTouches").Length()
 	__array22 := make([]*Touch, __length22, __length22)
 	for __idx22 := 0; __idx22 < __length22; __idx22++ {
 		var __seq_out22 *Touch
-		__seq_in22 := input.Get("changedTouches").Index(__idx22)
+		__seq_in22 := value.Get("changedTouches").Index(__idx22)
 		__seq_out22 = TouchFromJS(__seq_in22)
 		__array22[__idx22] = __seq_out22
 	}
@@ -297,7 +296,7 @@ type TouchInit struct {
 	TouchType     TouchType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TouchInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -335,10 +334,8 @@ func (_this *TouchInit) JSValue() js.Value {
 }
 
 // TouchInitFromJS is allocating a new
-// TouchInit object and copy all values from
-// input javascript object
-func TouchInitFromJS(value js.Wrapper) *TouchInit {
-	input := value.JSValue()
+// TouchInit object and copy all values in the value javascript object.
+func TouchInitFromJS(value js.Value) *TouchInit {
 	var out TouchInit
 	var (
 		value0  int                  // javascript: long {identifier Identifier identifier}
@@ -357,35 +354,35 @@ func TouchInitFromJS(value js.Wrapper) *TouchInit {
 		value13 float64              // javascript: double {azimuthAngle AzimuthAngle azimuthAngle}
 		value14 TouchType            // javascript: TouchType {touchType TouchType touchType}
 	)
-	value0 = (input.Get("identifier")).Int()
+	value0 = (value.Get("identifier")).Int()
 	out.Identifier = value0
-	value1 = domcore.EventTargetFromJS(input.Get("target"))
+	value1 = domcore.EventTargetFromJS(value.Get("target"))
 	out.Target = value1
-	value2 = (input.Get("clientX")).Float()
+	value2 = (value.Get("clientX")).Float()
 	out.ClientX = value2
-	value3 = (input.Get("clientY")).Float()
+	value3 = (value.Get("clientY")).Float()
 	out.ClientY = value3
-	value4 = (input.Get("screenX")).Float()
+	value4 = (value.Get("screenX")).Float()
 	out.ScreenX = value4
-	value5 = (input.Get("screenY")).Float()
+	value5 = (value.Get("screenY")).Float()
 	out.ScreenY = value5
-	value6 = (input.Get("pageX")).Float()
+	value6 = (value.Get("pageX")).Float()
 	out.PageX = value6
-	value7 = (input.Get("pageY")).Float()
+	value7 = (value.Get("pageY")).Float()
 	out.PageY = value7
-	value8 = (float32)((input.Get("radiusX")).Float())
+	value8 = (float32)((value.Get("radiusX")).Float())
 	out.RadiusX = value8
-	value9 = (float32)((input.Get("radiusY")).Float())
+	value9 = (float32)((value.Get("radiusY")).Float())
 	out.RadiusY = value9
-	value10 = (float32)((input.Get("rotationAngle")).Float())
+	value10 = (float32)((value.Get("rotationAngle")).Float())
 	out.RotationAngle = value10
-	value11 = (float32)((input.Get("force")).Float())
+	value11 = (float32)((value.Get("force")).Float())
 	out.Force = value11
-	value12 = (input.Get("altitudeAngle")).Float()
+	value12 = (value.Get("altitudeAngle")).Float()
 	out.AltitudeAngle = value12
-	value13 = (input.Get("azimuthAngle")).Float()
+	value13 = (value.Get("azimuthAngle")).Float()
 	out.AzimuthAngle = value13
-	value14 = TouchTypeFromJS(input.Get("touchType"))
+	value14 = TouchTypeFromJS(value.Get("touchType"))
 	out.TouchType = value14
 	return &out
 }
@@ -400,15 +397,19 @@ func (_this *Touch) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TouchFromJS is casting a js.Wrapper into Touch.
-func TouchFromJS(value js.Wrapper) *Touch {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchFromJS is casting a js.Value into Touch.
+func TouchFromJS(value js.Value) *Touch {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Touch{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchFromJS is casting from something that holds a js.Value into Touch.
+func TouchFromWrapper(input core.Wrapper) *Touch {
+	return TouchFromJS(input.JSValue())
 }
 
 func NewTouch(touchInitDict *TouchInit) (_result *Touch) {
@@ -569,15 +570,19 @@ type TouchEvent struct {
 	htmlevent.UIEvent
 }
 
-// TouchEventFromJS is casting a js.Wrapper into TouchEvent.
-func TouchEventFromJS(value js.Wrapper) *TouchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchEventFromJS is casting a js.Value into TouchEvent.
+func TouchEventFromJS(value js.Value) *TouchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TouchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchEventFromJS is casting from something that holds a js.Value into TouchEvent.
+func TouchEventFromWrapper(input core.Wrapper) *TouchEvent {
+	return TouchEventFromJS(input.JSValue())
 }
 
 func NewTouchEvent(_type string, eventInitDict *TouchEventInit) (_result *TouchEvent) {
@@ -676,15 +681,19 @@ func (_this *TouchList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TouchListFromJS is casting a js.Wrapper into TouchList.
-func TouchListFromJS(value js.Wrapper) *TouchList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TouchListFromJS is casting a js.Value into TouchList.
+func TouchListFromJS(value js.Value) *TouchList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TouchList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TouchListFromJS is casting from something that holds a js.Value into TouchList.
+func TouchListFromWrapper(input core.Wrapper) *TouchList {
+	return TouchListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/device/usb/usb.go
+++ b/device/usb/usb.go
@@ -7,6 +7,7 @@ package usb
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/permissions"
 	"github.com/gowebapi/webapi/javascript"
@@ -761,7 +762,7 @@ type AllowedUSBDevice struct {
 	SerialNumber string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AllowedUSBDevice) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -775,21 +776,19 @@ func (_this *AllowedUSBDevice) JSValue() js.Value {
 }
 
 // AllowedUSBDeviceFromJS is allocating a new
-// AllowedUSBDevice object and copy all values from
-// input javascript object
-func AllowedUSBDeviceFromJS(value js.Wrapper) *AllowedUSBDevice {
-	input := value.JSValue()
+// AllowedUSBDevice object and copy all values in the value javascript object.
+func AllowedUSBDeviceFromJS(value js.Value) *AllowedUSBDevice {
 	var out AllowedUSBDevice
 	var (
 		value0 int    // javascript: octet {vendorId VendorId vendorId}
 		value1 int    // javascript: octet {productId ProductId productId}
 		value2 string // javascript: DOMString {serialNumber SerialNumber serialNumber}
 	)
-	value0 = (input.Get("vendorId")).Int()
+	value0 = (value.Get("vendorId")).Int()
 	out.VendorId = value0
-	value1 = (input.Get("productId")).Int()
+	value1 = (value.Get("productId")).Int()
 	out.ProductId = value1
-	value2 = (input.Get("serialNumber")).String()
+	value2 = (value.Get("serialNumber")).String()
 	out.SerialNumber = value2
 	return &out
 }
@@ -802,7 +801,7 @@ type USBConnectionEventInit struct {
 	Device     *USBDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBConnectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -818,10 +817,8 @@ func (_this *USBConnectionEventInit) JSValue() js.Value {
 }
 
 // USBConnectionEventInitFromJS is allocating a new
-// USBConnectionEventInit object and copy all values from
-// input javascript object
-func USBConnectionEventInitFromJS(value js.Wrapper) *USBConnectionEventInit {
-	input := value.JSValue()
+// USBConnectionEventInit object and copy all values in the value javascript object.
+func USBConnectionEventInitFromJS(value js.Value) *USBConnectionEventInit {
 	var out USBConnectionEventInit
 	var (
 		value0 bool       // javascript: boolean {bubbles Bubbles bubbles}
@@ -829,13 +826,13 @@ func USBConnectionEventInitFromJS(value js.Wrapper) *USBConnectionEventInit {
 		value2 bool       // javascript: boolean {composed Composed composed}
 		value3 *USBDevice // javascript: USBDevice {device Device device}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = USBDeviceFromJS(input.Get("device"))
+	value3 = USBDeviceFromJS(value.Get("device"))
 	out.Device = value3
 	return &out
 }
@@ -849,7 +846,7 @@ type USBControlTransferParameters struct {
 	Index       int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBControlTransferParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -867,10 +864,8 @@ func (_this *USBControlTransferParameters) JSValue() js.Value {
 }
 
 // USBControlTransferParametersFromJS is allocating a new
-// USBControlTransferParameters object and copy all values from
-// input javascript object
-func USBControlTransferParametersFromJS(value js.Wrapper) *USBControlTransferParameters {
-	input := value.JSValue()
+// USBControlTransferParameters object and copy all values in the value javascript object.
+func USBControlTransferParametersFromJS(value js.Value) *USBControlTransferParameters {
 	var out USBControlTransferParameters
 	var (
 		value0 USBRequestType // javascript: USBRequestType {requestType RequestType requestType}
@@ -879,15 +874,15 @@ func USBControlTransferParametersFromJS(value js.Wrapper) *USBControlTransferPar
 		value3 int            // javascript: unsigned short {value Value value}
 		value4 int            // javascript: unsigned short {index Index index}
 	)
-	value0 = USBRequestTypeFromJS(input.Get("requestType"))
+	value0 = USBRequestTypeFromJS(value.Get("requestType"))
 	out.RequestType = value0
-	value1 = USBRecipientFromJS(input.Get("recipient"))
+	value1 = USBRecipientFromJS(value.Get("recipient"))
 	out.Recipient = value1
-	value2 = (input.Get("request")).Int()
+	value2 = (value.Get("request")).Int()
 	out.Request = value2
-	value3 = (input.Get("value")).Int()
+	value3 = (value.Get("value")).Int()
 	out.Value = value3
-	value4 = (input.Get("index")).Int()
+	value4 = (value.Get("index")).Int()
 	out.Index = value4
 	return &out
 }
@@ -902,7 +897,7 @@ type USBDeviceFilter struct {
 	SerialNumber string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBDeviceFilter) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -922,10 +917,8 @@ func (_this *USBDeviceFilter) JSValue() js.Value {
 }
 
 // USBDeviceFilterFromJS is allocating a new
-// USBDeviceFilter object and copy all values from
-// input javascript object
-func USBDeviceFilterFromJS(value js.Wrapper) *USBDeviceFilter {
-	input := value.JSValue()
+// USBDeviceFilter object and copy all values in the value javascript object.
+func USBDeviceFilterFromJS(value js.Value) *USBDeviceFilter {
 	var out USBDeviceFilter
 	var (
 		value0 int    // javascript: unsigned short {vendorId VendorId vendorId}
@@ -935,17 +928,17 @@ func USBDeviceFilterFromJS(value js.Wrapper) *USBDeviceFilter {
 		value4 int    // javascript: octet {protocolCode ProtocolCode protocolCode}
 		value5 string // javascript: DOMString {serialNumber SerialNumber serialNumber}
 	)
-	value0 = (input.Get("vendorId")).Int()
+	value0 = (value.Get("vendorId")).Int()
 	out.VendorId = value0
-	value1 = (input.Get("productId")).Int()
+	value1 = (value.Get("productId")).Int()
 	out.ProductId = value1
-	value2 = (input.Get("classCode")).Int()
+	value2 = (value.Get("classCode")).Int()
 	out.ClassCode = value2
-	value3 = (input.Get("subclassCode")).Int()
+	value3 = (value.Get("subclassCode")).Int()
 	out.SubclassCode = value3
-	value4 = (input.Get("protocolCode")).Int()
+	value4 = (value.Get("protocolCode")).Int()
 	out.ProtocolCode = value4
-	value5 = (input.Get("serialNumber")).String()
+	value5 = (value.Get("serialNumber")).String()
 	out.SerialNumber = value5
 	return &out
 }
@@ -955,7 +948,7 @@ type USBDeviceRequestOptions struct {
 	Filters []*USBDeviceFilter
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBDeviceRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -969,19 +962,17 @@ func (_this *USBDeviceRequestOptions) JSValue() js.Value {
 }
 
 // USBDeviceRequestOptionsFromJS is allocating a new
-// USBDeviceRequestOptions object and copy all values from
-// input javascript object
-func USBDeviceRequestOptionsFromJS(value js.Wrapper) *USBDeviceRequestOptions {
-	input := value.JSValue()
+// USBDeviceRequestOptions object and copy all values in the value javascript object.
+func USBDeviceRequestOptionsFromJS(value js.Value) *USBDeviceRequestOptions {
 	var out USBDeviceRequestOptions
 	var (
 		value0 []*USBDeviceFilter // javascript: sequence<USBDeviceFilter> {filters Filters filters}
 	)
-	__length0 := input.Get("filters").Length()
+	__length0 := value.Get("filters").Length()
 	__array0 := make([]*USBDeviceFilter, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *USBDeviceFilter
-		__seq_in0 := input.Get("filters").Index(__idx0)
+		__seq_in0 := value.Get("filters").Index(__idx0)
 		__seq_out0 = USBDeviceFilterFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -996,7 +987,7 @@ type USBPermissionDescriptor struct {
 	Filters []*USBDeviceFilter
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1012,22 +1003,20 @@ func (_this *USBPermissionDescriptor) JSValue() js.Value {
 }
 
 // USBPermissionDescriptorFromJS is allocating a new
-// USBPermissionDescriptor object and copy all values from
-// input javascript object
-func USBPermissionDescriptorFromJS(value js.Wrapper) *USBPermissionDescriptor {
-	input := value.JSValue()
+// USBPermissionDescriptor object and copy all values in the value javascript object.
+func USBPermissionDescriptorFromJS(value js.Value) *USBPermissionDescriptor {
 	var out USBPermissionDescriptor
 	var (
 		value0 string             // javascript: DOMString {name Name name}
 		value1 []*USBDeviceFilter // javascript: sequence<USBDeviceFilter> {filters Filters filters}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	__length1 := input.Get("filters").Length()
+	__length1 := value.Get("filters").Length()
 	__array1 := make([]*USBDeviceFilter, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *USBDeviceFilter
-		__seq_in1 := input.Get("filters").Index(__idx1)
+		__seq_in1 := value.Get("filters").Index(__idx1)
 		__seq_out1 = USBDeviceFilterFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -1041,7 +1030,7 @@ type USBPermissionStorage struct {
 	AllowedDevices []*AllowedUSBDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBPermissionStorage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1055,19 +1044,17 @@ func (_this *USBPermissionStorage) JSValue() js.Value {
 }
 
 // USBPermissionStorageFromJS is allocating a new
-// USBPermissionStorage object and copy all values from
-// input javascript object
-func USBPermissionStorageFromJS(value js.Wrapper) *USBPermissionStorage {
-	input := value.JSValue()
+// USBPermissionStorage object and copy all values in the value javascript object.
+func USBPermissionStorageFromJS(value js.Value) *USBPermissionStorage {
 	var out USBPermissionStorage
 	var (
 		value0 []*AllowedUSBDevice // javascript: sequence<AllowedUSBDevice> {allowedDevices AllowedDevices allowedDevices}
 	)
-	__length0 := input.Get("allowedDevices").Length()
+	__length0 := value.Get("allowedDevices").Length()
 	__array0 := make([]*AllowedUSBDevice, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *AllowedUSBDevice
-		__seq_in0 := input.Get("allowedDevices").Index(__idx0)
+		__seq_in0 := value.Get("allowedDevices").Index(__idx0)
 		__seq_out0 = AllowedUSBDeviceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -1086,15 +1073,19 @@ func (_this *PromiseSequenceUSBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceUSBDeviceFromJS is casting a js.Wrapper into PromiseSequenceUSBDevice.
-func PromiseSequenceUSBDeviceFromJS(value js.Wrapper) *PromiseSequenceUSBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceUSBDeviceFromJS is casting a js.Value into PromiseSequenceUSBDevice.
+func PromiseSequenceUSBDeviceFromJS(value js.Value) *PromiseSequenceUSBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceUSBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceUSBDeviceFromJS is casting from something that holds a js.Value into PromiseSequenceUSBDevice.
+func PromiseSequenceUSBDeviceFromWrapper(input core.Wrapper) *PromiseSequenceUSBDevice {
+	return PromiseSequenceUSBDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceUSBDevice) Then(onFulfilled *PromiseSequenceUSBDeviceOnFulfilled, onRejected *PromiseSequenceUSBDeviceOnRejected) (_result *PromiseSequenceUSBDevice) {
@@ -1191,15 +1182,19 @@ func (_this *PromiseUSBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBDeviceFromJS is casting a js.Wrapper into PromiseUSBDevice.
-func PromiseUSBDeviceFromJS(value js.Wrapper) *PromiseUSBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBDeviceFromJS is casting a js.Value into PromiseUSBDevice.
+func PromiseUSBDeviceFromJS(value js.Value) *PromiseUSBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBDeviceFromJS is casting from something that holds a js.Value into PromiseUSBDevice.
+func PromiseUSBDeviceFromWrapper(input core.Wrapper) *PromiseUSBDevice {
+	return PromiseUSBDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBDevice) Then(onFulfilled *PromiseUSBDeviceOnFulfilled, onRejected *PromiseUSBDeviceOnRejected) (_result *PromiseUSBDevice) {
@@ -1296,15 +1291,19 @@ func (_this *PromiseUSBInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBInTransferResultFromJS is casting a js.Wrapper into PromiseUSBInTransferResult.
-func PromiseUSBInTransferResultFromJS(value js.Wrapper) *PromiseUSBInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBInTransferResultFromJS is casting a js.Value into PromiseUSBInTransferResult.
+func PromiseUSBInTransferResultFromJS(value js.Value) *PromiseUSBInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBInTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBInTransferResult.
+func PromiseUSBInTransferResultFromWrapper(input core.Wrapper) *PromiseUSBInTransferResult {
+	return PromiseUSBInTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBInTransferResult) Then(onFulfilled *PromiseUSBInTransferResultOnFulfilled, onRejected *PromiseUSBInTransferResultOnRejected) (_result *PromiseUSBInTransferResult) {
@@ -1401,15 +1400,19 @@ func (_this *PromiseUSBIsochronousInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBIsochronousInTransferResultFromJS is casting a js.Wrapper into PromiseUSBIsochronousInTransferResult.
-func PromiseUSBIsochronousInTransferResultFromJS(value js.Wrapper) *PromiseUSBIsochronousInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBIsochronousInTransferResultFromJS is casting a js.Value into PromiseUSBIsochronousInTransferResult.
+func PromiseUSBIsochronousInTransferResultFromJS(value js.Value) *PromiseUSBIsochronousInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBIsochronousInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBIsochronousInTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBIsochronousInTransferResult.
+func PromiseUSBIsochronousInTransferResultFromWrapper(input core.Wrapper) *PromiseUSBIsochronousInTransferResult {
+	return PromiseUSBIsochronousInTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBIsochronousInTransferResult) Then(onFulfilled *PromiseUSBIsochronousInTransferResultOnFulfilled, onRejected *PromiseUSBIsochronousInTransferResultOnRejected) (_result *PromiseUSBIsochronousInTransferResult) {
@@ -1506,15 +1509,19 @@ func (_this *PromiseUSBIsochronousOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBIsochronousOutTransferResultFromJS is casting a js.Wrapper into PromiseUSBIsochronousOutTransferResult.
-func PromiseUSBIsochronousOutTransferResultFromJS(value js.Wrapper) *PromiseUSBIsochronousOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBIsochronousOutTransferResultFromJS is casting a js.Value into PromiseUSBIsochronousOutTransferResult.
+func PromiseUSBIsochronousOutTransferResultFromJS(value js.Value) *PromiseUSBIsochronousOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBIsochronousOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBIsochronousOutTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBIsochronousOutTransferResult.
+func PromiseUSBIsochronousOutTransferResultFromWrapper(input core.Wrapper) *PromiseUSBIsochronousOutTransferResult {
+	return PromiseUSBIsochronousOutTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBIsochronousOutTransferResult) Then(onFulfilled *PromiseUSBIsochronousOutTransferResultOnFulfilled, onRejected *PromiseUSBIsochronousOutTransferResultOnRejected) (_result *PromiseUSBIsochronousOutTransferResult) {
@@ -1611,15 +1618,19 @@ func (_this *PromiseUSBOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBOutTransferResultFromJS is casting a js.Wrapper into PromiseUSBOutTransferResult.
-func PromiseUSBOutTransferResultFromJS(value js.Wrapper) *PromiseUSBOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBOutTransferResultFromJS is casting a js.Value into PromiseUSBOutTransferResult.
+func PromiseUSBOutTransferResultFromJS(value js.Value) *PromiseUSBOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBOutTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBOutTransferResult.
+func PromiseUSBOutTransferResultFromWrapper(input core.Wrapper) *PromiseUSBOutTransferResult {
+	return PromiseUSBOutTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBOutTransferResult) Then(onFulfilled *PromiseUSBOutTransferResultOnFulfilled, onRejected *PromiseUSBOutTransferResultOnRejected) (_result *PromiseUSBOutTransferResult) {
@@ -1711,15 +1722,19 @@ type USB struct {
 	domcore.EventTarget
 }
 
-// USBFromJS is casting a js.Wrapper into USB.
-func USBFromJS(value js.Wrapper) *USB {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBFromJS is casting a js.Value into USB.
+func USBFromJS(value js.Value) *USB {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USB{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBFromJS is casting from something that holds a js.Value into USB.
+func USBFromWrapper(input core.Wrapper) *USB {
+	return USBFromJS(input.JSValue())
 }
 
 // OnConnect returning attribute 'onconnect' with
@@ -1831,15 +1846,19 @@ func (_this *USBAlternateInterface) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBAlternateInterfaceFromJS is casting a js.Wrapper into USBAlternateInterface.
-func USBAlternateInterfaceFromJS(value js.Wrapper) *USBAlternateInterface {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBAlternateInterfaceFromJS is casting a js.Value into USBAlternateInterface.
+func USBAlternateInterfaceFromJS(value js.Value) *USBAlternateInterface {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBAlternateInterface{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBAlternateInterfaceFromJS is casting from something that holds a js.Value into USBAlternateInterface.
+func USBAlternateInterfaceFromWrapper(input core.Wrapper) *USBAlternateInterface {
+	return USBAlternateInterfaceFromJS(input.JSValue())
 }
 
 func NewUSBAlternateInterface(deviceInterface *USBInterface, alternateSetting int) (_result *USBAlternateInterface) {
@@ -1930,15 +1949,19 @@ func (_this *USBConfiguration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBConfigurationFromJS is casting a js.Wrapper into USBConfiguration.
-func USBConfigurationFromJS(value js.Wrapper) *USBConfiguration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBConfigurationFromJS is casting a js.Value into USBConfiguration.
+func USBConfigurationFromJS(value js.Value) *USBConfiguration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBConfiguration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBConfigurationFromJS is casting from something that holds a js.Value into USBConfiguration.
+func USBConfigurationFromWrapper(input core.Wrapper) *USBConfiguration {
+	return USBConfigurationFromJS(input.JSValue())
 }
 
 func NewUSBConfiguration(device *USBDevice, configurationValue int) (_result *USBConfiguration) {
@@ -1997,15 +2020,19 @@ type USBConnectionEvent struct {
 	domcore.Event
 }
 
-// USBConnectionEventFromJS is casting a js.Wrapper into USBConnectionEvent.
-func USBConnectionEventFromJS(value js.Wrapper) *USBConnectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBConnectionEventFromJS is casting a js.Value into USBConnectionEvent.
+func USBConnectionEventFromJS(value js.Value) *USBConnectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBConnectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBConnectionEventFromJS is casting from something that holds a js.Value into USBConnectionEvent.
+func USBConnectionEventFromWrapper(input core.Wrapper) *USBConnectionEvent {
+	return USBConnectionEventFromJS(input.JSValue())
 }
 
 func NewUSBConnectionEvent(_type string, eventInitDict *USBConnectionEventInit) (_result *USBConnectionEvent) {
@@ -2048,15 +2075,19 @@ func (_this *USBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBDeviceFromJS is casting a js.Wrapper into USBDevice.
-func USBDeviceFromJS(value js.Wrapper) *USBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBDeviceFromJS is casting a js.Value into USBDevice.
+func USBDeviceFromJS(value js.Value) *USBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBDeviceFromJS is casting from something that holds a js.Value into USBDevice.
+func USBDeviceFromWrapper(input core.Wrapper) *USBDevice {
+	return USBDeviceFromJS(input.JSValue())
 }
 
 // UsbVersionMajor returning attribute 'usbVersionMajor' with
@@ -2499,15 +2530,19 @@ func (_this *USBEndpoint) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBEndpointFromJS is casting a js.Wrapper into USBEndpoint.
-func USBEndpointFromJS(value js.Wrapper) *USBEndpoint {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBEndpointFromJS is casting a js.Value into USBEndpoint.
+func USBEndpointFromJS(value js.Value) *USBEndpoint {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBEndpoint{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBEndpointFromJS is casting from something that holds a js.Value into USBEndpoint.
+func USBEndpointFromWrapper(input core.Wrapper) *USBEndpoint {
+	return USBEndpointFromJS(input.JSValue())
 }
 
 func NewUSBEndpoint(alternate *USBAlternateInterface, endpointNumber int, direction USBDirection) (_result *USBEndpoint) {
@@ -2580,15 +2615,19 @@ func (_this *USBInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBInTransferResultFromJS is casting a js.Wrapper into USBInTransferResult.
-func USBInTransferResultFromJS(value js.Wrapper) *USBInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBInTransferResultFromJS is casting a js.Value into USBInTransferResult.
+func USBInTransferResultFromJS(value js.Value) *USBInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBInTransferResultFromJS is casting from something that holds a js.Value into USBInTransferResult.
+func USBInTransferResultFromWrapper(input core.Wrapper) *USBInTransferResult {
+	return USBInTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBInTransferResult(status USBTransferStatus, data *javascript.DataView) (_result *USBInTransferResult) {
@@ -2644,15 +2683,19 @@ func (_this *USBInterface) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBInterfaceFromJS is casting a js.Wrapper into USBInterface.
-func USBInterfaceFromJS(value js.Wrapper) *USBInterface {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBInterfaceFromJS is casting a js.Value into USBInterface.
+func USBInterfaceFromJS(value js.Value) *USBInterface {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBInterface{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBInterfaceFromJS is casting from something that holds a js.Value into USBInterface.
+func USBInterfaceFromWrapper(input core.Wrapper) *USBInterface {
+	return USBInterfaceFromJS(input.JSValue())
 }
 
 func NewUSBInterface(configuration *USBConfiguration, interfaceNumber int) (_result *USBInterface) {
@@ -2722,15 +2765,19 @@ func (_this *USBIsochronousInTransferPacket) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousInTransferPacketFromJS is casting a js.Wrapper into USBIsochronousInTransferPacket.
-func USBIsochronousInTransferPacketFromJS(value js.Wrapper) *USBIsochronousInTransferPacket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousInTransferPacketFromJS is casting a js.Value into USBIsochronousInTransferPacket.
+func USBIsochronousInTransferPacketFromJS(value js.Value) *USBIsochronousInTransferPacket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousInTransferPacket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousInTransferPacketFromJS is casting from something that holds a js.Value into USBIsochronousInTransferPacket.
+func USBIsochronousInTransferPacketFromWrapper(input core.Wrapper) *USBIsochronousInTransferPacket {
+	return USBIsochronousInTransferPacketFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousInTransferPacket(status USBTransferStatus, data *javascript.DataView) (_result *USBIsochronousInTransferPacket) {
@@ -2786,15 +2833,19 @@ func (_this *USBIsochronousInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousInTransferResultFromJS is casting a js.Wrapper into USBIsochronousInTransferResult.
-func USBIsochronousInTransferResultFromJS(value js.Wrapper) *USBIsochronousInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousInTransferResultFromJS is casting a js.Value into USBIsochronousInTransferResult.
+func USBIsochronousInTransferResultFromJS(value js.Value) *USBIsochronousInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousInTransferResultFromJS is casting from something that holds a js.Value into USBIsochronousInTransferResult.
+func USBIsochronousInTransferResultFromWrapper(input core.Wrapper) *USBIsochronousInTransferResult {
+	return USBIsochronousInTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousInTransferResult(packets []*USBIsochronousInTransferPacket, data *javascript.DataView) (_result *USBIsochronousInTransferResult) {
@@ -2854,15 +2905,19 @@ func (_this *USBIsochronousOutTransferPacket) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousOutTransferPacketFromJS is casting a js.Wrapper into USBIsochronousOutTransferPacket.
-func USBIsochronousOutTransferPacketFromJS(value js.Wrapper) *USBIsochronousOutTransferPacket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousOutTransferPacketFromJS is casting a js.Value into USBIsochronousOutTransferPacket.
+func USBIsochronousOutTransferPacketFromJS(value js.Value) *USBIsochronousOutTransferPacket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousOutTransferPacket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousOutTransferPacketFromJS is casting from something that holds a js.Value into USBIsochronousOutTransferPacket.
+func USBIsochronousOutTransferPacketFromWrapper(input core.Wrapper) *USBIsochronousOutTransferPacket {
+	return USBIsochronousOutTransferPacketFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousOutTransferPacket(status USBTransferStatus, bytesWritten *uint) (_result *USBIsochronousOutTransferPacket) {
@@ -2922,15 +2977,19 @@ func (_this *USBIsochronousOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousOutTransferResultFromJS is casting a js.Wrapper into USBIsochronousOutTransferResult.
-func USBIsochronousOutTransferResultFromJS(value js.Wrapper) *USBIsochronousOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousOutTransferResultFromJS is casting a js.Value into USBIsochronousOutTransferResult.
+func USBIsochronousOutTransferResultFromJS(value js.Value) *USBIsochronousOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousOutTransferResultFromJS is casting from something that holds a js.Value into USBIsochronousOutTransferResult.
+func USBIsochronousOutTransferResultFromWrapper(input core.Wrapper) *USBIsochronousOutTransferResult {
+	return USBIsochronousOutTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousOutTransferResult(packets []*USBIsochronousOutTransferPacket) (_result *USBIsochronousOutTransferResult) {
@@ -2974,15 +3033,19 @@ func (_this *USBOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBOutTransferResultFromJS is casting a js.Wrapper into USBOutTransferResult.
-func USBOutTransferResultFromJS(value js.Wrapper) *USBOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBOutTransferResultFromJS is casting a js.Value into USBOutTransferResult.
+func USBOutTransferResultFromJS(value js.Value) *USBOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBOutTransferResultFromJS is casting from something that holds a js.Value into USBOutTransferResult.
+func USBOutTransferResultFromWrapper(input core.Wrapper) *USBOutTransferResult {
+	return USBOutTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBOutTransferResult(status USBTransferStatus, bytesWritten *uint) (_result *USBOutTransferResult) {
@@ -3037,15 +3100,19 @@ type USBPermissionResult struct {
 	permissions.PermissionStatus
 }
 
-// USBPermissionResultFromJS is casting a js.Wrapper into USBPermissionResult.
-func USBPermissionResultFromJS(value js.Wrapper) *USBPermissionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBPermissionResultFromJS is casting a js.Value into USBPermissionResult.
+func USBPermissionResultFromJS(value js.Value) *USBPermissionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBPermissionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBPermissionResultFromJS is casting from something that holds a js.Value into USBPermissionResult.
+func USBPermissionResultFromWrapper(input core.Wrapper) *USBPermissionResult {
+	return USBPermissionResultFromJS(input.JSValue())
 }
 
 // Devices returning attribute 'devices' with

--- a/device/usb/usb_js.go
+++ b/device/usb/usb_js.go
@@ -5,6 +5,7 @@ package usb
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/permissions"
 	"github.com/gowebapi/webapi/javascript"
@@ -759,7 +760,7 @@ type AllowedUSBDevice struct {
 	SerialNumber string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AllowedUSBDevice) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -773,21 +774,19 @@ func (_this *AllowedUSBDevice) JSValue() js.Value {
 }
 
 // AllowedUSBDeviceFromJS is allocating a new
-// AllowedUSBDevice object and copy all values from
-// input javascript object
-func AllowedUSBDeviceFromJS(value js.Wrapper) *AllowedUSBDevice {
-	input := value.JSValue()
+// AllowedUSBDevice object and copy all values in the value javascript object.
+func AllowedUSBDeviceFromJS(value js.Value) *AllowedUSBDevice {
 	var out AllowedUSBDevice
 	var (
 		value0 int    // javascript: octet {vendorId VendorId vendorId}
 		value1 int    // javascript: octet {productId ProductId productId}
 		value2 string // javascript: DOMString {serialNumber SerialNumber serialNumber}
 	)
-	value0 = (input.Get("vendorId")).Int()
+	value0 = (value.Get("vendorId")).Int()
 	out.VendorId = value0
-	value1 = (input.Get("productId")).Int()
+	value1 = (value.Get("productId")).Int()
 	out.ProductId = value1
-	value2 = (input.Get("serialNumber")).String()
+	value2 = (value.Get("serialNumber")).String()
 	out.SerialNumber = value2
 	return &out
 }
@@ -800,7 +799,7 @@ type USBConnectionEventInit struct {
 	Device     *USBDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBConnectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -816,10 +815,8 @@ func (_this *USBConnectionEventInit) JSValue() js.Value {
 }
 
 // USBConnectionEventInitFromJS is allocating a new
-// USBConnectionEventInit object and copy all values from
-// input javascript object
-func USBConnectionEventInitFromJS(value js.Wrapper) *USBConnectionEventInit {
-	input := value.JSValue()
+// USBConnectionEventInit object and copy all values in the value javascript object.
+func USBConnectionEventInitFromJS(value js.Value) *USBConnectionEventInit {
 	var out USBConnectionEventInit
 	var (
 		value0 bool       // javascript: boolean {bubbles Bubbles bubbles}
@@ -827,13 +824,13 @@ func USBConnectionEventInitFromJS(value js.Wrapper) *USBConnectionEventInit {
 		value2 bool       // javascript: boolean {composed Composed composed}
 		value3 *USBDevice // javascript: USBDevice {device Device device}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = USBDeviceFromJS(input.Get("device"))
+	value3 = USBDeviceFromJS(value.Get("device"))
 	out.Device = value3
 	return &out
 }
@@ -847,7 +844,7 @@ type USBControlTransferParameters struct {
 	Index       int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBControlTransferParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -865,10 +862,8 @@ func (_this *USBControlTransferParameters) JSValue() js.Value {
 }
 
 // USBControlTransferParametersFromJS is allocating a new
-// USBControlTransferParameters object and copy all values from
-// input javascript object
-func USBControlTransferParametersFromJS(value js.Wrapper) *USBControlTransferParameters {
-	input := value.JSValue()
+// USBControlTransferParameters object and copy all values in the value javascript object.
+func USBControlTransferParametersFromJS(value js.Value) *USBControlTransferParameters {
 	var out USBControlTransferParameters
 	var (
 		value0 USBRequestType // javascript: USBRequestType {requestType RequestType requestType}
@@ -877,15 +872,15 @@ func USBControlTransferParametersFromJS(value js.Wrapper) *USBControlTransferPar
 		value3 int            // javascript: unsigned short {value Value value}
 		value4 int            // javascript: unsigned short {index Index index}
 	)
-	value0 = USBRequestTypeFromJS(input.Get("requestType"))
+	value0 = USBRequestTypeFromJS(value.Get("requestType"))
 	out.RequestType = value0
-	value1 = USBRecipientFromJS(input.Get("recipient"))
+	value1 = USBRecipientFromJS(value.Get("recipient"))
 	out.Recipient = value1
-	value2 = (input.Get("request")).Int()
+	value2 = (value.Get("request")).Int()
 	out.Request = value2
-	value3 = (input.Get("value")).Int()
+	value3 = (value.Get("value")).Int()
 	out.Value = value3
-	value4 = (input.Get("index")).Int()
+	value4 = (value.Get("index")).Int()
 	out.Index = value4
 	return &out
 }
@@ -900,7 +895,7 @@ type USBDeviceFilter struct {
 	SerialNumber string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBDeviceFilter) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -920,10 +915,8 @@ func (_this *USBDeviceFilter) JSValue() js.Value {
 }
 
 // USBDeviceFilterFromJS is allocating a new
-// USBDeviceFilter object and copy all values from
-// input javascript object
-func USBDeviceFilterFromJS(value js.Wrapper) *USBDeviceFilter {
-	input := value.JSValue()
+// USBDeviceFilter object and copy all values in the value javascript object.
+func USBDeviceFilterFromJS(value js.Value) *USBDeviceFilter {
 	var out USBDeviceFilter
 	var (
 		value0 int    // javascript: unsigned short {vendorId VendorId vendorId}
@@ -933,17 +926,17 @@ func USBDeviceFilterFromJS(value js.Wrapper) *USBDeviceFilter {
 		value4 int    // javascript: octet {protocolCode ProtocolCode protocolCode}
 		value5 string // javascript: DOMString {serialNumber SerialNumber serialNumber}
 	)
-	value0 = (input.Get("vendorId")).Int()
+	value0 = (value.Get("vendorId")).Int()
 	out.VendorId = value0
-	value1 = (input.Get("productId")).Int()
+	value1 = (value.Get("productId")).Int()
 	out.ProductId = value1
-	value2 = (input.Get("classCode")).Int()
+	value2 = (value.Get("classCode")).Int()
 	out.ClassCode = value2
-	value3 = (input.Get("subclassCode")).Int()
+	value3 = (value.Get("subclassCode")).Int()
 	out.SubclassCode = value3
-	value4 = (input.Get("protocolCode")).Int()
+	value4 = (value.Get("protocolCode")).Int()
 	out.ProtocolCode = value4
-	value5 = (input.Get("serialNumber")).String()
+	value5 = (value.Get("serialNumber")).String()
 	out.SerialNumber = value5
 	return &out
 }
@@ -953,7 +946,7 @@ type USBDeviceRequestOptions struct {
 	Filters []*USBDeviceFilter
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBDeviceRequestOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -967,19 +960,17 @@ func (_this *USBDeviceRequestOptions) JSValue() js.Value {
 }
 
 // USBDeviceRequestOptionsFromJS is allocating a new
-// USBDeviceRequestOptions object and copy all values from
-// input javascript object
-func USBDeviceRequestOptionsFromJS(value js.Wrapper) *USBDeviceRequestOptions {
-	input := value.JSValue()
+// USBDeviceRequestOptions object and copy all values in the value javascript object.
+func USBDeviceRequestOptionsFromJS(value js.Value) *USBDeviceRequestOptions {
 	var out USBDeviceRequestOptions
 	var (
 		value0 []*USBDeviceFilter // javascript: sequence<USBDeviceFilter> {filters Filters filters}
 	)
-	__length0 := input.Get("filters").Length()
+	__length0 := value.Get("filters").Length()
 	__array0 := make([]*USBDeviceFilter, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *USBDeviceFilter
-		__seq_in0 := input.Get("filters").Index(__idx0)
+		__seq_in0 := value.Get("filters").Index(__idx0)
 		__seq_out0 = USBDeviceFilterFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -994,7 +985,7 @@ type USBPermissionDescriptor struct {
 	Filters []*USBDeviceFilter
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1010,22 +1001,20 @@ func (_this *USBPermissionDescriptor) JSValue() js.Value {
 }
 
 // USBPermissionDescriptorFromJS is allocating a new
-// USBPermissionDescriptor object and copy all values from
-// input javascript object
-func USBPermissionDescriptorFromJS(value js.Wrapper) *USBPermissionDescriptor {
-	input := value.JSValue()
+// USBPermissionDescriptor object and copy all values in the value javascript object.
+func USBPermissionDescriptorFromJS(value js.Value) *USBPermissionDescriptor {
 	var out USBPermissionDescriptor
 	var (
 		value0 string             // javascript: DOMString {name Name name}
 		value1 []*USBDeviceFilter // javascript: sequence<USBDeviceFilter> {filters Filters filters}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	__length1 := input.Get("filters").Length()
+	__length1 := value.Get("filters").Length()
 	__array1 := make([]*USBDeviceFilter, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *USBDeviceFilter
-		__seq_in1 := input.Get("filters").Index(__idx1)
+		__seq_in1 := value.Get("filters").Index(__idx1)
 		__seq_out1 = USBDeviceFilterFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -1039,7 +1028,7 @@ type USBPermissionStorage struct {
 	AllowedDevices []*AllowedUSBDevice
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *USBPermissionStorage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1053,19 +1042,17 @@ func (_this *USBPermissionStorage) JSValue() js.Value {
 }
 
 // USBPermissionStorageFromJS is allocating a new
-// USBPermissionStorage object and copy all values from
-// input javascript object
-func USBPermissionStorageFromJS(value js.Wrapper) *USBPermissionStorage {
-	input := value.JSValue()
+// USBPermissionStorage object and copy all values in the value javascript object.
+func USBPermissionStorageFromJS(value js.Value) *USBPermissionStorage {
 	var out USBPermissionStorage
 	var (
 		value0 []*AllowedUSBDevice // javascript: sequence<AllowedUSBDevice> {allowedDevices AllowedDevices allowedDevices}
 	)
-	__length0 := input.Get("allowedDevices").Length()
+	__length0 := value.Get("allowedDevices").Length()
 	__array0 := make([]*AllowedUSBDevice, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *AllowedUSBDevice
-		__seq_in0 := input.Get("allowedDevices").Index(__idx0)
+		__seq_in0 := value.Get("allowedDevices").Index(__idx0)
 		__seq_out0 = AllowedUSBDeviceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -1084,15 +1071,19 @@ func (_this *PromiseSequenceUSBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceUSBDeviceFromJS is casting a js.Wrapper into PromiseSequenceUSBDevice.
-func PromiseSequenceUSBDeviceFromJS(value js.Wrapper) *PromiseSequenceUSBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceUSBDeviceFromJS is casting a js.Value into PromiseSequenceUSBDevice.
+func PromiseSequenceUSBDeviceFromJS(value js.Value) *PromiseSequenceUSBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceUSBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceUSBDeviceFromJS is casting from something that holds a js.Value into PromiseSequenceUSBDevice.
+func PromiseSequenceUSBDeviceFromWrapper(input core.Wrapper) *PromiseSequenceUSBDevice {
+	return PromiseSequenceUSBDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceUSBDevice) Then(onFulfilled *PromiseSequenceUSBDeviceOnFulfilled, onRejected *PromiseSequenceUSBDeviceOnRejected) (_result *PromiseSequenceUSBDevice) {
@@ -1189,15 +1180,19 @@ func (_this *PromiseUSBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBDeviceFromJS is casting a js.Wrapper into PromiseUSBDevice.
-func PromiseUSBDeviceFromJS(value js.Wrapper) *PromiseUSBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBDeviceFromJS is casting a js.Value into PromiseUSBDevice.
+func PromiseUSBDeviceFromJS(value js.Value) *PromiseUSBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBDeviceFromJS is casting from something that holds a js.Value into PromiseUSBDevice.
+func PromiseUSBDeviceFromWrapper(input core.Wrapper) *PromiseUSBDevice {
+	return PromiseUSBDeviceFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBDevice) Then(onFulfilled *PromiseUSBDeviceOnFulfilled, onRejected *PromiseUSBDeviceOnRejected) (_result *PromiseUSBDevice) {
@@ -1294,15 +1289,19 @@ func (_this *PromiseUSBInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBInTransferResultFromJS is casting a js.Wrapper into PromiseUSBInTransferResult.
-func PromiseUSBInTransferResultFromJS(value js.Wrapper) *PromiseUSBInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBInTransferResultFromJS is casting a js.Value into PromiseUSBInTransferResult.
+func PromiseUSBInTransferResultFromJS(value js.Value) *PromiseUSBInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBInTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBInTransferResult.
+func PromiseUSBInTransferResultFromWrapper(input core.Wrapper) *PromiseUSBInTransferResult {
+	return PromiseUSBInTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBInTransferResult) Then(onFulfilled *PromiseUSBInTransferResultOnFulfilled, onRejected *PromiseUSBInTransferResultOnRejected) (_result *PromiseUSBInTransferResult) {
@@ -1399,15 +1398,19 @@ func (_this *PromiseUSBIsochronousInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBIsochronousInTransferResultFromJS is casting a js.Wrapper into PromiseUSBIsochronousInTransferResult.
-func PromiseUSBIsochronousInTransferResultFromJS(value js.Wrapper) *PromiseUSBIsochronousInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBIsochronousInTransferResultFromJS is casting a js.Value into PromiseUSBIsochronousInTransferResult.
+func PromiseUSBIsochronousInTransferResultFromJS(value js.Value) *PromiseUSBIsochronousInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBIsochronousInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBIsochronousInTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBIsochronousInTransferResult.
+func PromiseUSBIsochronousInTransferResultFromWrapper(input core.Wrapper) *PromiseUSBIsochronousInTransferResult {
+	return PromiseUSBIsochronousInTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBIsochronousInTransferResult) Then(onFulfilled *PromiseUSBIsochronousInTransferResultOnFulfilled, onRejected *PromiseUSBIsochronousInTransferResultOnRejected) (_result *PromiseUSBIsochronousInTransferResult) {
@@ -1504,15 +1507,19 @@ func (_this *PromiseUSBIsochronousOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBIsochronousOutTransferResultFromJS is casting a js.Wrapper into PromiseUSBIsochronousOutTransferResult.
-func PromiseUSBIsochronousOutTransferResultFromJS(value js.Wrapper) *PromiseUSBIsochronousOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBIsochronousOutTransferResultFromJS is casting a js.Value into PromiseUSBIsochronousOutTransferResult.
+func PromiseUSBIsochronousOutTransferResultFromJS(value js.Value) *PromiseUSBIsochronousOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBIsochronousOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBIsochronousOutTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBIsochronousOutTransferResult.
+func PromiseUSBIsochronousOutTransferResultFromWrapper(input core.Wrapper) *PromiseUSBIsochronousOutTransferResult {
+	return PromiseUSBIsochronousOutTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBIsochronousOutTransferResult) Then(onFulfilled *PromiseUSBIsochronousOutTransferResultOnFulfilled, onRejected *PromiseUSBIsochronousOutTransferResultOnRejected) (_result *PromiseUSBIsochronousOutTransferResult) {
@@ -1609,15 +1616,19 @@ func (_this *PromiseUSBOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseUSBOutTransferResultFromJS is casting a js.Wrapper into PromiseUSBOutTransferResult.
-func PromiseUSBOutTransferResultFromJS(value js.Wrapper) *PromiseUSBOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseUSBOutTransferResultFromJS is casting a js.Value into PromiseUSBOutTransferResult.
+func PromiseUSBOutTransferResultFromJS(value js.Value) *PromiseUSBOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseUSBOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseUSBOutTransferResultFromJS is casting from something that holds a js.Value into PromiseUSBOutTransferResult.
+func PromiseUSBOutTransferResultFromWrapper(input core.Wrapper) *PromiseUSBOutTransferResult {
+	return PromiseUSBOutTransferResultFromJS(input.JSValue())
 }
 
 func (_this *PromiseUSBOutTransferResult) Then(onFulfilled *PromiseUSBOutTransferResultOnFulfilled, onRejected *PromiseUSBOutTransferResultOnRejected) (_result *PromiseUSBOutTransferResult) {
@@ -1709,15 +1720,19 @@ type USB struct {
 	domcore.EventTarget
 }
 
-// USBFromJS is casting a js.Wrapper into USB.
-func USBFromJS(value js.Wrapper) *USB {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBFromJS is casting a js.Value into USB.
+func USBFromJS(value js.Value) *USB {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USB{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBFromJS is casting from something that holds a js.Value into USB.
+func USBFromWrapper(input core.Wrapper) *USB {
+	return USBFromJS(input.JSValue())
 }
 
 // OnConnect returning attribute 'onconnect' with
@@ -1829,15 +1844,19 @@ func (_this *USBAlternateInterface) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBAlternateInterfaceFromJS is casting a js.Wrapper into USBAlternateInterface.
-func USBAlternateInterfaceFromJS(value js.Wrapper) *USBAlternateInterface {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBAlternateInterfaceFromJS is casting a js.Value into USBAlternateInterface.
+func USBAlternateInterfaceFromJS(value js.Value) *USBAlternateInterface {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBAlternateInterface{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBAlternateInterfaceFromJS is casting from something that holds a js.Value into USBAlternateInterface.
+func USBAlternateInterfaceFromWrapper(input core.Wrapper) *USBAlternateInterface {
+	return USBAlternateInterfaceFromJS(input.JSValue())
 }
 
 func NewUSBAlternateInterface(deviceInterface *USBInterface, alternateSetting int) (_result *USBAlternateInterface) {
@@ -1928,15 +1947,19 @@ func (_this *USBConfiguration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBConfigurationFromJS is casting a js.Wrapper into USBConfiguration.
-func USBConfigurationFromJS(value js.Wrapper) *USBConfiguration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBConfigurationFromJS is casting a js.Value into USBConfiguration.
+func USBConfigurationFromJS(value js.Value) *USBConfiguration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBConfiguration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBConfigurationFromJS is casting from something that holds a js.Value into USBConfiguration.
+func USBConfigurationFromWrapper(input core.Wrapper) *USBConfiguration {
+	return USBConfigurationFromJS(input.JSValue())
 }
 
 func NewUSBConfiguration(device *USBDevice, configurationValue int) (_result *USBConfiguration) {
@@ -1995,15 +2018,19 @@ type USBConnectionEvent struct {
 	domcore.Event
 }
 
-// USBConnectionEventFromJS is casting a js.Wrapper into USBConnectionEvent.
-func USBConnectionEventFromJS(value js.Wrapper) *USBConnectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBConnectionEventFromJS is casting a js.Value into USBConnectionEvent.
+func USBConnectionEventFromJS(value js.Value) *USBConnectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBConnectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBConnectionEventFromJS is casting from something that holds a js.Value into USBConnectionEvent.
+func USBConnectionEventFromWrapper(input core.Wrapper) *USBConnectionEvent {
+	return USBConnectionEventFromJS(input.JSValue())
 }
 
 func NewUSBConnectionEvent(_type string, eventInitDict *USBConnectionEventInit) (_result *USBConnectionEvent) {
@@ -2046,15 +2073,19 @@ func (_this *USBDevice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBDeviceFromJS is casting a js.Wrapper into USBDevice.
-func USBDeviceFromJS(value js.Wrapper) *USBDevice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBDeviceFromJS is casting a js.Value into USBDevice.
+func USBDeviceFromJS(value js.Value) *USBDevice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBDevice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBDeviceFromJS is casting from something that holds a js.Value into USBDevice.
+func USBDeviceFromWrapper(input core.Wrapper) *USBDevice {
+	return USBDeviceFromJS(input.JSValue())
 }
 
 // UsbVersionMajor returning attribute 'usbVersionMajor' with
@@ -2497,15 +2528,19 @@ func (_this *USBEndpoint) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBEndpointFromJS is casting a js.Wrapper into USBEndpoint.
-func USBEndpointFromJS(value js.Wrapper) *USBEndpoint {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBEndpointFromJS is casting a js.Value into USBEndpoint.
+func USBEndpointFromJS(value js.Value) *USBEndpoint {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBEndpoint{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBEndpointFromJS is casting from something that holds a js.Value into USBEndpoint.
+func USBEndpointFromWrapper(input core.Wrapper) *USBEndpoint {
+	return USBEndpointFromJS(input.JSValue())
 }
 
 func NewUSBEndpoint(alternate *USBAlternateInterface, endpointNumber int, direction USBDirection) (_result *USBEndpoint) {
@@ -2578,15 +2613,19 @@ func (_this *USBInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBInTransferResultFromJS is casting a js.Wrapper into USBInTransferResult.
-func USBInTransferResultFromJS(value js.Wrapper) *USBInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBInTransferResultFromJS is casting a js.Value into USBInTransferResult.
+func USBInTransferResultFromJS(value js.Value) *USBInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBInTransferResultFromJS is casting from something that holds a js.Value into USBInTransferResult.
+func USBInTransferResultFromWrapper(input core.Wrapper) *USBInTransferResult {
+	return USBInTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBInTransferResult(status USBTransferStatus, data *javascript.DataView) (_result *USBInTransferResult) {
@@ -2642,15 +2681,19 @@ func (_this *USBInterface) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBInterfaceFromJS is casting a js.Wrapper into USBInterface.
-func USBInterfaceFromJS(value js.Wrapper) *USBInterface {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBInterfaceFromJS is casting a js.Value into USBInterface.
+func USBInterfaceFromJS(value js.Value) *USBInterface {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBInterface{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBInterfaceFromJS is casting from something that holds a js.Value into USBInterface.
+func USBInterfaceFromWrapper(input core.Wrapper) *USBInterface {
+	return USBInterfaceFromJS(input.JSValue())
 }
 
 func NewUSBInterface(configuration *USBConfiguration, interfaceNumber int) (_result *USBInterface) {
@@ -2720,15 +2763,19 @@ func (_this *USBIsochronousInTransferPacket) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousInTransferPacketFromJS is casting a js.Wrapper into USBIsochronousInTransferPacket.
-func USBIsochronousInTransferPacketFromJS(value js.Wrapper) *USBIsochronousInTransferPacket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousInTransferPacketFromJS is casting a js.Value into USBIsochronousInTransferPacket.
+func USBIsochronousInTransferPacketFromJS(value js.Value) *USBIsochronousInTransferPacket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousInTransferPacket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousInTransferPacketFromJS is casting from something that holds a js.Value into USBIsochronousInTransferPacket.
+func USBIsochronousInTransferPacketFromWrapper(input core.Wrapper) *USBIsochronousInTransferPacket {
+	return USBIsochronousInTransferPacketFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousInTransferPacket(status USBTransferStatus, data *javascript.DataView) (_result *USBIsochronousInTransferPacket) {
@@ -2784,15 +2831,19 @@ func (_this *USBIsochronousInTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousInTransferResultFromJS is casting a js.Wrapper into USBIsochronousInTransferResult.
-func USBIsochronousInTransferResultFromJS(value js.Wrapper) *USBIsochronousInTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousInTransferResultFromJS is casting a js.Value into USBIsochronousInTransferResult.
+func USBIsochronousInTransferResultFromJS(value js.Value) *USBIsochronousInTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousInTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousInTransferResultFromJS is casting from something that holds a js.Value into USBIsochronousInTransferResult.
+func USBIsochronousInTransferResultFromWrapper(input core.Wrapper) *USBIsochronousInTransferResult {
+	return USBIsochronousInTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousInTransferResult(packets []*USBIsochronousInTransferPacket, data *javascript.DataView) (_result *USBIsochronousInTransferResult) {
@@ -2852,15 +2903,19 @@ func (_this *USBIsochronousOutTransferPacket) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousOutTransferPacketFromJS is casting a js.Wrapper into USBIsochronousOutTransferPacket.
-func USBIsochronousOutTransferPacketFromJS(value js.Wrapper) *USBIsochronousOutTransferPacket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousOutTransferPacketFromJS is casting a js.Value into USBIsochronousOutTransferPacket.
+func USBIsochronousOutTransferPacketFromJS(value js.Value) *USBIsochronousOutTransferPacket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousOutTransferPacket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousOutTransferPacketFromJS is casting from something that holds a js.Value into USBIsochronousOutTransferPacket.
+func USBIsochronousOutTransferPacketFromWrapper(input core.Wrapper) *USBIsochronousOutTransferPacket {
+	return USBIsochronousOutTransferPacketFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousOutTransferPacket(status USBTransferStatus, bytesWritten *uint) (_result *USBIsochronousOutTransferPacket) {
@@ -2920,15 +2975,19 @@ func (_this *USBIsochronousOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBIsochronousOutTransferResultFromJS is casting a js.Wrapper into USBIsochronousOutTransferResult.
-func USBIsochronousOutTransferResultFromJS(value js.Wrapper) *USBIsochronousOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBIsochronousOutTransferResultFromJS is casting a js.Value into USBIsochronousOutTransferResult.
+func USBIsochronousOutTransferResultFromJS(value js.Value) *USBIsochronousOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBIsochronousOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBIsochronousOutTransferResultFromJS is casting from something that holds a js.Value into USBIsochronousOutTransferResult.
+func USBIsochronousOutTransferResultFromWrapper(input core.Wrapper) *USBIsochronousOutTransferResult {
+	return USBIsochronousOutTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBIsochronousOutTransferResult(packets []*USBIsochronousOutTransferPacket) (_result *USBIsochronousOutTransferResult) {
@@ -2972,15 +3031,19 @@ func (_this *USBOutTransferResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// USBOutTransferResultFromJS is casting a js.Wrapper into USBOutTransferResult.
-func USBOutTransferResultFromJS(value js.Wrapper) *USBOutTransferResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBOutTransferResultFromJS is casting a js.Value into USBOutTransferResult.
+func USBOutTransferResultFromJS(value js.Value) *USBOutTransferResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBOutTransferResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBOutTransferResultFromJS is casting from something that holds a js.Value into USBOutTransferResult.
+func USBOutTransferResultFromWrapper(input core.Wrapper) *USBOutTransferResult {
+	return USBOutTransferResultFromJS(input.JSValue())
 }
 
 func NewUSBOutTransferResult(status USBTransferStatus, bytesWritten *uint) (_result *USBOutTransferResult) {
@@ -3035,15 +3098,19 @@ type USBPermissionResult struct {
 	permissions.PermissionStatus
 }
 
-// USBPermissionResultFromJS is casting a js.Wrapper into USBPermissionResult.
-func USBPermissionResultFromJS(value js.Wrapper) *USBPermissionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// USBPermissionResultFromJS is casting a js.Value into USBPermissionResult.
+func USBPermissionResultFromJS(value js.Value) *USBPermissionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &USBPermissionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// USBPermissionResultFromJS is casting from something that holds a js.Value into USBPermissionResult.
+func USBPermissionResultFromWrapper(input core.Wrapper) *USBPermissionResult {
+	return USBPermissionResultFromJS(input.JSValue())
 }
 
 // Devices returning attribute 'devices' with

--- a/device/wakelock/wakelock.go
+++ b/device/wakelock/wakelock.go
@@ -7,6 +7,7 @@ package wakelock
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -174,15 +175,19 @@ func (_this *PromiseWakeLock) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseWakeLockFromJS is casting a js.Wrapper into PromiseWakeLock.
-func PromiseWakeLockFromJS(value js.Wrapper) *PromiseWakeLock {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseWakeLockFromJS is casting a js.Value into PromiseWakeLock.
+func PromiseWakeLockFromJS(value js.Value) *PromiseWakeLock {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseWakeLock{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseWakeLockFromJS is casting from something that holds a js.Value into PromiseWakeLock.
+func PromiseWakeLockFromWrapper(input core.Wrapper) *PromiseWakeLock {
+	return PromiseWakeLockFromJS(input.JSValue())
 }
 
 func (_this *PromiseWakeLock) Then(onFulfilled *PromiseWakeLockOnFulfilled, onRejected *PromiseWakeLockOnRejected) (_result *PromiseWakeLock) {
@@ -274,15 +279,19 @@ type WakeLock struct {
 	domcore.EventTarget
 }
 
-// WakeLockFromJS is casting a js.Wrapper into WakeLock.
-func WakeLockFromJS(value js.Wrapper) *WakeLock {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WakeLockFromJS is casting a js.Value into WakeLock.
+func WakeLockFromJS(value js.Value) *WakeLock {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WakeLock{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WakeLockFromJS is casting from something that holds a js.Value into WakeLock.
+func WakeLockFromWrapper(input core.Wrapper) *WakeLock {
+	return WakeLockFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -368,15 +377,19 @@ func (_this *WakeLockRequest) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WakeLockRequestFromJS is casting a js.Wrapper into WakeLockRequest.
-func WakeLockRequestFromJS(value js.Wrapper) *WakeLockRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WakeLockRequestFromJS is casting a js.Value into WakeLockRequest.
+func WakeLockRequestFromJS(value js.Value) *WakeLockRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WakeLockRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WakeLockRequestFromJS is casting from something that holds a js.Value into WakeLockRequest.
+func WakeLockRequestFromWrapper(input core.Wrapper) *WakeLockRequest {
+	return WakeLockRequestFromJS(input.JSValue())
 }
 
 func (_this *WakeLockRequest) Cancel() {

--- a/device/wakelock/wakelock_js.go
+++ b/device/wakelock/wakelock_js.go
@@ -5,6 +5,7 @@ package wakelock
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -172,15 +173,19 @@ func (_this *PromiseWakeLock) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseWakeLockFromJS is casting a js.Wrapper into PromiseWakeLock.
-func PromiseWakeLockFromJS(value js.Wrapper) *PromiseWakeLock {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseWakeLockFromJS is casting a js.Value into PromiseWakeLock.
+func PromiseWakeLockFromJS(value js.Value) *PromiseWakeLock {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseWakeLock{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseWakeLockFromJS is casting from something that holds a js.Value into PromiseWakeLock.
+func PromiseWakeLockFromWrapper(input core.Wrapper) *PromiseWakeLock {
+	return PromiseWakeLockFromJS(input.JSValue())
 }
 
 func (_this *PromiseWakeLock) Then(onFulfilled *PromiseWakeLockOnFulfilled, onRejected *PromiseWakeLockOnRejected) (_result *PromiseWakeLock) {
@@ -272,15 +277,19 @@ type WakeLock struct {
 	domcore.EventTarget
 }
 
-// WakeLockFromJS is casting a js.Wrapper into WakeLock.
-func WakeLockFromJS(value js.Wrapper) *WakeLock {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WakeLockFromJS is casting a js.Value into WakeLock.
+func WakeLockFromJS(value js.Value) *WakeLock {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WakeLock{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WakeLockFromJS is casting from something that holds a js.Value into WakeLock.
+func WakeLockFromWrapper(input core.Wrapper) *WakeLock {
+	return WakeLockFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -366,15 +375,19 @@ func (_this *WakeLockRequest) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WakeLockRequestFromJS is casting a js.Wrapper into WakeLockRequest.
-func WakeLockRequestFromJS(value js.Wrapper) *WakeLockRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WakeLockRequestFromJS is casting a js.Value into WakeLockRequest.
+func WakeLockRequestFromJS(value js.Value) *WakeLockRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WakeLockRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WakeLockRequestFromJS is casting from something that holds a js.Value into WakeLockRequest.
+func WakeLockRequestFromWrapper(input core.Wrapper) *WakeLockRequest {
+	return WakeLockRequestFromJS(input.JSValue())
 }
 
 func (_this *WakeLockRequest) Cancel() {

--- a/device/webvr/webvr.go
+++ b/device/webvr/webvr.go
@@ -7,6 +7,7 @@ package webvr
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlcommon"
@@ -233,7 +234,7 @@ type DisplayEventInit struct {
 	Reason     DisplayEventReason
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DisplayEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -251,10 +252,8 @@ func (_this *DisplayEventInit) JSValue() js.Value {
 }
 
 // DisplayEventInitFromJS is allocating a new
-// DisplayEventInit object and copy all values from
-// input javascript object
-func DisplayEventInitFromJS(value js.Wrapper) *DisplayEventInit {
-	input := value.JSValue()
+// DisplayEventInit object and copy all values in the value javascript object.
+func DisplayEventInitFromJS(value js.Value) *DisplayEventInit {
 	var out DisplayEventInit
 	var (
 		value0 bool               // javascript: boolean {bubbles Bubbles bubbles}
@@ -263,15 +262,15 @@ func DisplayEventInitFromJS(value js.Wrapper) *DisplayEventInit {
 		value3 *Display           // javascript: VRDisplay {display Display display}
 		value4 DisplayEventReason // javascript: VRDisplayEventReason {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DisplayFromJS(input.Get("display"))
+	value3 = DisplayFromJS(value.Get("display"))
 	out.Display = value3
-	value4 = DisplayEventReasonFromJS(input.Get("reason"))
+	value4 = DisplayEventReasonFromJS(value.Get("reason"))
 	out.Reason = value4
 	return &out
 }
@@ -283,7 +282,7 @@ type LayerInit struct {
 	RightBounds []float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayerInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -297,23 +296,21 @@ func (_this *LayerInit) JSValue() js.Value {
 }
 
 // LayerInitFromJS is allocating a new
-// LayerInit object and copy all values from
-// input javascript object
-func LayerInitFromJS(value js.Wrapper) *LayerInit {
-	input := value.JSValue()
+// LayerInit object and copy all values in the value javascript object.
+func LayerInitFromJS(value js.Value) *LayerInit {
 	var out LayerInit
 	var (
 		value0 *Union    // javascript: Union {source Source source}
 		value1 []float32 // javascript: typed-array {leftBounds LeftBounds leftBounds}
 		value2 []float32 // javascript: typed-array {rightBounds RightBounds rightBounds}
 	)
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value0 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value0 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value0
-	value1 = jsarray.Float32ToGo(input.Get("leftBounds"))
+	value1 = jsarray.Float32ToGo(value.Get("leftBounds"))
 	out.LeftBounds = value1
-	value2 = jsarray.Float32ToGo(input.Get("rightBounds"))
+	value2 = jsarray.Float32ToGo(value.Get("rightBounds"))
 	out.RightBounds = value2
 	return &out
 }
@@ -323,15 +320,19 @@ type Display struct {
 	domcore.EventTarget
 }
 
-// DisplayFromJS is casting a js.Wrapper into Display.
-func DisplayFromJS(value js.Wrapper) *Display {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayFromJS is casting a js.Value into Display.
+func DisplayFromJS(value js.Value) *Display {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Display{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayFromJS is casting from something that holds a js.Value into Display.
+func DisplayFromWrapper(input core.Wrapper) *Display {
+	return DisplayFromJS(input.JSValue())
 }
 
 // IsConnected returning attribute 'isConnected' with
@@ -591,15 +592,19 @@ func (_this *DisplayCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DisplayCapabilitiesFromJS is casting a js.Wrapper into DisplayCapabilities.
-func DisplayCapabilitiesFromJS(value js.Wrapper) *DisplayCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayCapabilitiesFromJS is casting a js.Value into DisplayCapabilities.
+func DisplayCapabilitiesFromJS(value js.Value) *DisplayCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DisplayCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayCapabilitiesFromJS is casting from something that holds a js.Value into DisplayCapabilities.
+func DisplayCapabilitiesFromWrapper(input core.Wrapper) *DisplayCapabilities {
+	return DisplayCapabilitiesFromJS(input.JSValue())
 }
 
 // HasPosition returning attribute 'hasPosition' with
@@ -652,15 +657,19 @@ type DisplayEvent struct {
 	domcore.Event
 }
 
-// DisplayEventFromJS is casting a js.Wrapper into DisplayEvent.
-func DisplayEventFromJS(value js.Wrapper) *DisplayEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayEventFromJS is casting a js.Value into DisplayEvent.
+func DisplayEventFromJS(value js.Value) *DisplayEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DisplayEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayEventFromJS is casting from something that holds a js.Value into DisplayEvent.
+func DisplayEventFromWrapper(input core.Wrapper) *DisplayEvent {
+	return DisplayEventFromJS(input.JSValue())
 }
 
 func NewVRDisplayEvent(_type string, eventInitDict *DisplayEventInit) (_result *DisplayEvent) {
@@ -715,15 +724,19 @@ func (_this *EyeParameters) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EyeParametersFromJS is casting a js.Wrapper into EyeParameters.
-func EyeParametersFromJS(value js.Wrapper) *EyeParameters {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EyeParametersFromJS is casting a js.Value into EyeParameters.
+func EyeParametersFromJS(value js.Value) *EyeParameters {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EyeParameters{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EyeParametersFromJS is casting from something that holds a js.Value into EyeParameters.
+func EyeParametersFromWrapper(input core.Wrapper) *EyeParameters {
+	return EyeParametersFromJS(input.JSValue())
 }
 
 // Offset returning attribute 'offset' with
@@ -772,15 +785,19 @@ func (_this *FieldOfView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FieldOfViewFromJS is casting a js.Wrapper into FieldOfView.
-func FieldOfViewFromJS(value js.Wrapper) *FieldOfView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FieldOfViewFromJS is casting a js.Value into FieldOfView.
+func FieldOfViewFromJS(value js.Value) *FieldOfView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FieldOfView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FieldOfViewFromJS is casting from something that holds a js.Value into FieldOfView.
+func FieldOfViewFromWrapper(input core.Wrapper) *FieldOfView {
+	return FieldOfViewFromJS(input.JSValue())
 }
 
 // UpDegrees returning attribute 'upDegrees' with
@@ -829,15 +846,19 @@ func (_this *FrameData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FrameDataFromJS is casting a js.Wrapper into FrameData.
-func FrameDataFromJS(value js.Wrapper) *FrameData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FrameDataFromJS is casting a js.Value into FrameData.
+func FrameDataFromJS(value js.Value) *FrameData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FrameData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FrameDataFromJS is casting from something that holds a js.Value into FrameData.
+func FrameDataFromWrapper(input core.Wrapper) *FrameData {
+	return FrameDataFromJS(input.JSValue())
 }
 
 func NewVRFrameData() (_result *FrameData) {
@@ -919,15 +940,19 @@ func (_this *Pose) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PoseFromJS is casting a js.Wrapper into Pose.
-func PoseFromJS(value js.Wrapper) *Pose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PoseFromJS is casting a js.Value into Pose.
+func PoseFromJS(value js.Value) *Pose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Pose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PoseFromJS is casting from something that holds a js.Value into Pose.
+func PoseFromWrapper(input core.Wrapper) *Pose {
+	return PoseFromJS(input.JSValue())
 }
 
 // Position returning attribute 'position' with
@@ -1006,15 +1031,19 @@ func (_this *PromiseSequenceDisplay) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDisplayFromJS is casting a js.Wrapper into PromiseSequenceDisplay.
-func PromiseSequenceDisplayFromJS(value js.Wrapper) *PromiseSequenceDisplay {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDisplayFromJS is casting a js.Value into PromiseSequenceDisplay.
+func PromiseSequenceDisplayFromJS(value js.Value) *PromiseSequenceDisplay {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDisplay{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDisplayFromJS is casting from something that holds a js.Value into PromiseSequenceDisplay.
+func PromiseSequenceDisplayFromWrapper(input core.Wrapper) *PromiseSequenceDisplay {
+	return PromiseSequenceDisplayFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDisplay) Then(onFulfilled *PromiseSequenceDisplayOnFulfilled, onRejected *PromiseSequenceDisplayOnRejected) (_result *PromiseSequenceDisplay) {
@@ -1111,15 +1140,19 @@ func (_this *StageParameters) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StageParametersFromJS is casting a js.Wrapper into StageParameters.
-func StageParametersFromJS(value js.Wrapper) *StageParameters {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StageParametersFromJS is casting a js.Value into StageParameters.
+func StageParametersFromJS(value js.Value) *StageParameters {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StageParameters{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StageParametersFromJS is casting from something that holds a js.Value into StageParameters.
+func StageParametersFromWrapper(input core.Wrapper) *StageParameters {
+	return StageParametersFromJS(input.JSValue())
 }
 
 // SittingToStandingTransform returning attribute 'sittingToStandingTransform' with

--- a/device/webvr/webvr_js.go
+++ b/device/webvr/webvr_js.go
@@ -5,6 +5,7 @@ package webvr
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/htmlcommon"
@@ -231,7 +232,7 @@ type DisplayEventInit struct {
 	Reason     DisplayEventReason
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DisplayEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -249,10 +250,8 @@ func (_this *DisplayEventInit) JSValue() js.Value {
 }
 
 // DisplayEventInitFromJS is allocating a new
-// DisplayEventInit object and copy all values from
-// input javascript object
-func DisplayEventInitFromJS(value js.Wrapper) *DisplayEventInit {
-	input := value.JSValue()
+// DisplayEventInit object and copy all values in the value javascript object.
+func DisplayEventInitFromJS(value js.Value) *DisplayEventInit {
 	var out DisplayEventInit
 	var (
 		value0 bool               // javascript: boolean {bubbles Bubbles bubbles}
@@ -261,15 +260,15 @@ func DisplayEventInitFromJS(value js.Wrapper) *DisplayEventInit {
 		value3 *Display           // javascript: VRDisplay {display Display display}
 		value4 DisplayEventReason // javascript: VRDisplayEventReason {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DisplayFromJS(input.Get("display"))
+	value3 = DisplayFromJS(value.Get("display"))
 	out.Display = value3
-	value4 = DisplayEventReasonFromJS(input.Get("reason"))
+	value4 = DisplayEventReasonFromJS(value.Get("reason"))
 	out.Reason = value4
 	return &out
 }
@@ -281,7 +280,7 @@ type LayerInit struct {
 	RightBounds []float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *LayerInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -295,23 +294,21 @@ func (_this *LayerInit) JSValue() js.Value {
 }
 
 // LayerInitFromJS is allocating a new
-// LayerInit object and copy all values from
-// input javascript object
-func LayerInitFromJS(value js.Wrapper) *LayerInit {
-	input := value.JSValue()
+// LayerInit object and copy all values in the value javascript object.
+func LayerInitFromJS(value js.Value) *LayerInit {
 	var out LayerInit
 	var (
 		value0 *Union    // javascript: Union {source Source source}
 		value1 []float32 // javascript: typed-array {leftBounds LeftBounds leftBounds}
 		value2 []float32 // javascript: typed-array {rightBounds RightBounds rightBounds}
 	)
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value0 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value0 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value0
-	value1 = jsarray.Float32ToGo(input.Get("leftBounds"))
+	value1 = jsarray.Float32ToGo(value.Get("leftBounds"))
 	out.LeftBounds = value1
-	value2 = jsarray.Float32ToGo(input.Get("rightBounds"))
+	value2 = jsarray.Float32ToGo(value.Get("rightBounds"))
 	out.RightBounds = value2
 	return &out
 }
@@ -321,15 +318,19 @@ type Display struct {
 	domcore.EventTarget
 }
 
-// DisplayFromJS is casting a js.Wrapper into Display.
-func DisplayFromJS(value js.Wrapper) *Display {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayFromJS is casting a js.Value into Display.
+func DisplayFromJS(value js.Value) *Display {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Display{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayFromJS is casting from something that holds a js.Value into Display.
+func DisplayFromWrapper(input core.Wrapper) *Display {
+	return DisplayFromJS(input.JSValue())
 }
 
 // IsConnected returning attribute 'isConnected' with
@@ -589,15 +590,19 @@ func (_this *DisplayCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DisplayCapabilitiesFromJS is casting a js.Wrapper into DisplayCapabilities.
-func DisplayCapabilitiesFromJS(value js.Wrapper) *DisplayCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayCapabilitiesFromJS is casting a js.Value into DisplayCapabilities.
+func DisplayCapabilitiesFromJS(value js.Value) *DisplayCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DisplayCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayCapabilitiesFromJS is casting from something that holds a js.Value into DisplayCapabilities.
+func DisplayCapabilitiesFromWrapper(input core.Wrapper) *DisplayCapabilities {
+	return DisplayCapabilitiesFromJS(input.JSValue())
 }
 
 // HasPosition returning attribute 'hasPosition' with
@@ -650,15 +655,19 @@ type DisplayEvent struct {
 	domcore.Event
 }
 
-// DisplayEventFromJS is casting a js.Wrapper into DisplayEvent.
-func DisplayEventFromJS(value js.Wrapper) *DisplayEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DisplayEventFromJS is casting a js.Value into DisplayEvent.
+func DisplayEventFromJS(value js.Value) *DisplayEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DisplayEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DisplayEventFromJS is casting from something that holds a js.Value into DisplayEvent.
+func DisplayEventFromWrapper(input core.Wrapper) *DisplayEvent {
+	return DisplayEventFromJS(input.JSValue())
 }
 
 func NewVRDisplayEvent(_type string, eventInitDict *DisplayEventInit) (_result *DisplayEvent) {
@@ -713,15 +722,19 @@ func (_this *EyeParameters) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EyeParametersFromJS is casting a js.Wrapper into EyeParameters.
-func EyeParametersFromJS(value js.Wrapper) *EyeParameters {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EyeParametersFromJS is casting a js.Value into EyeParameters.
+func EyeParametersFromJS(value js.Value) *EyeParameters {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EyeParameters{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EyeParametersFromJS is casting from something that holds a js.Value into EyeParameters.
+func EyeParametersFromWrapper(input core.Wrapper) *EyeParameters {
+	return EyeParametersFromJS(input.JSValue())
 }
 
 // Offset returning attribute 'offset' with
@@ -770,15 +783,19 @@ func (_this *FieldOfView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FieldOfViewFromJS is casting a js.Wrapper into FieldOfView.
-func FieldOfViewFromJS(value js.Wrapper) *FieldOfView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FieldOfViewFromJS is casting a js.Value into FieldOfView.
+func FieldOfViewFromJS(value js.Value) *FieldOfView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FieldOfView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FieldOfViewFromJS is casting from something that holds a js.Value into FieldOfView.
+func FieldOfViewFromWrapper(input core.Wrapper) *FieldOfView {
+	return FieldOfViewFromJS(input.JSValue())
 }
 
 // UpDegrees returning attribute 'upDegrees' with
@@ -827,15 +844,19 @@ func (_this *FrameData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FrameDataFromJS is casting a js.Wrapper into FrameData.
-func FrameDataFromJS(value js.Wrapper) *FrameData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FrameDataFromJS is casting a js.Value into FrameData.
+func FrameDataFromJS(value js.Value) *FrameData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FrameData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FrameDataFromJS is casting from something that holds a js.Value into FrameData.
+func FrameDataFromWrapper(input core.Wrapper) *FrameData {
+	return FrameDataFromJS(input.JSValue())
 }
 
 func NewVRFrameData() (_result *FrameData) {
@@ -917,15 +938,19 @@ func (_this *Pose) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PoseFromJS is casting a js.Wrapper into Pose.
-func PoseFromJS(value js.Wrapper) *Pose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PoseFromJS is casting a js.Value into Pose.
+func PoseFromJS(value js.Value) *Pose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Pose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PoseFromJS is casting from something that holds a js.Value into Pose.
+func PoseFromWrapper(input core.Wrapper) *Pose {
+	return PoseFromJS(input.JSValue())
 }
 
 // Position returning attribute 'position' with
@@ -1004,15 +1029,19 @@ func (_this *PromiseSequenceDisplay) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDisplayFromJS is casting a js.Wrapper into PromiseSequenceDisplay.
-func PromiseSequenceDisplayFromJS(value js.Wrapper) *PromiseSequenceDisplay {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDisplayFromJS is casting a js.Value into PromiseSequenceDisplay.
+func PromiseSequenceDisplayFromJS(value js.Value) *PromiseSequenceDisplay {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDisplay{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDisplayFromJS is casting from something that holds a js.Value into PromiseSequenceDisplay.
+func PromiseSequenceDisplayFromWrapper(input core.Wrapper) *PromiseSequenceDisplay {
+	return PromiseSequenceDisplayFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDisplay) Then(onFulfilled *PromiseSequenceDisplayOnFulfilled, onRejected *PromiseSequenceDisplayOnRejected) (_result *PromiseSequenceDisplay) {
@@ -1109,15 +1138,19 @@ func (_this *StageParameters) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StageParametersFromJS is casting a js.Wrapper into StageParameters.
-func StageParametersFromJS(value js.Wrapper) *StageParameters {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StageParametersFromJS is casting a js.Value into StageParameters.
+func StageParametersFromJS(value js.Value) *StageParameters {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StageParameters{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StageParametersFromJS is casting from something that holds a js.Value into StageParameters.
+func StageParametersFromWrapper(input core.Wrapper) *StageParameters {
+	return StageParametersFromJS(input.JSValue())
 }
 
 // SittingToStandingTransform returning attribute 'sittingToStandingTransform' with

--- a/device/webxr/webxr.go
+++ b/device/webxr/webxr.go
@@ -7,6 +7,7 @@ package webxr
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/graphics/webgl"
@@ -566,7 +567,7 @@ type XRInputSourceEventInit struct {
 	InputSource *XRInputSource
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRInputSourceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -584,10 +585,8 @@ func (_this *XRInputSourceEventInit) JSValue() js.Value {
 }
 
 // XRInputSourceEventInitFromJS is allocating a new
-// XRInputSourceEventInit object and copy all values from
-// input javascript object
-func XRInputSourceEventInitFromJS(value js.Wrapper) *XRInputSourceEventInit {
-	input := value.JSValue()
+// XRInputSourceEventInit object and copy all values in the value javascript object.
+func XRInputSourceEventInitFromJS(value js.Value) *XRInputSourceEventInit {
 	var out XRInputSourceEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -596,15 +595,15 @@ func XRInputSourceEventInitFromJS(value js.Wrapper) *XRInputSourceEventInit {
 		value3 *XRFrame       // javascript: XRFrame {frame Frame frame}
 		value4 *XRInputSource // javascript: XRInputSource {inputSource InputSource inputSource}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRFrameFromJS(input.Get("frame"))
+	value3 = XRFrameFromJS(value.Get("frame"))
 	out.Frame = value3
-	value4 = XRInputSourceFromJS(input.Get("inputSource"))
+	value4 = XRInputSourceFromJS(value.Get("inputSource"))
 	out.InputSource = value4
 	return &out
 }
@@ -618,7 +617,7 @@ type XRReferenceSpaceEventInit struct {
 	Transform      *XRRigidTransform
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRReferenceSpaceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -636,10 +635,8 @@ func (_this *XRReferenceSpaceEventInit) JSValue() js.Value {
 }
 
 // XRReferenceSpaceEventInitFromJS is allocating a new
-// XRReferenceSpaceEventInit object and copy all values from
-// input javascript object
-func XRReferenceSpaceEventInitFromJS(value js.Wrapper) *XRReferenceSpaceEventInit {
-	input := value.JSValue()
+// XRReferenceSpaceEventInit object and copy all values in the value javascript object.
+func XRReferenceSpaceEventInitFromJS(value js.Value) *XRReferenceSpaceEventInit {
 	var out XRReferenceSpaceEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -648,15 +645,15 @@ func XRReferenceSpaceEventInitFromJS(value js.Wrapper) *XRReferenceSpaceEventIni
 		value3 *XRReferenceSpace // javascript: XRReferenceSpace {referenceSpace ReferenceSpace referenceSpace}
 		value4 *XRRigidTransform // javascript: XRRigidTransform {transform Transform transform}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRReferenceSpaceFromJS(input.Get("referenceSpace"))
+	value3 = XRReferenceSpaceFromJS(value.Get("referenceSpace"))
 	out.ReferenceSpace = value3
-	value4 = XRRigidTransformFromJS(input.Get("transform"))
+	value4 = XRRigidTransformFromJS(value.Get("transform"))
 	out.Transform = value4
 	return &out
 }
@@ -667,7 +664,7 @@ type XRReferenceSpaceOptions struct {
 	Subtype XRStationaryReferenceSpaceSubtype
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRReferenceSpaceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -679,18 +676,16 @@ func (_this *XRReferenceSpaceOptions) JSValue() js.Value {
 }
 
 // XRReferenceSpaceOptionsFromJS is allocating a new
-// XRReferenceSpaceOptions object and copy all values from
-// input javascript object
-func XRReferenceSpaceOptionsFromJS(value js.Wrapper) *XRReferenceSpaceOptions {
-	input := value.JSValue()
+// XRReferenceSpaceOptions object and copy all values in the value javascript object.
+func XRReferenceSpaceOptionsFromJS(value js.Value) *XRReferenceSpaceOptions {
 	var out XRReferenceSpaceOptions
 	var (
 		value0 XRReferenceSpaceType              // javascript: XRReferenceSpaceType {type Type _type}
 		value1 XRStationaryReferenceSpaceSubtype // javascript: XRStationaryReferenceSpaceSubtype {subtype Subtype subtype}
 	)
-	value0 = XRReferenceSpaceTypeFromJS(input.Get("type"))
+	value0 = XRReferenceSpaceTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = XRStationaryReferenceSpaceSubtypeFromJS(input.Get("subtype"))
+	value1 = XRStationaryReferenceSpaceSubtypeFromJS(value.Get("subtype"))
 	out.Subtype = value1
 	return &out
 }
@@ -702,7 +697,7 @@ type XRRenderStateInit struct {
 	BaseLayer *XRLayer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRRenderStateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -716,22 +711,20 @@ func (_this *XRRenderStateInit) JSValue() js.Value {
 }
 
 // XRRenderStateInitFromJS is allocating a new
-// XRRenderStateInit object and copy all values from
-// input javascript object
-func XRRenderStateInitFromJS(value js.Wrapper) *XRRenderStateInit {
-	input := value.JSValue()
+// XRRenderStateInit object and copy all values in the value javascript object.
+func XRRenderStateInitFromJS(value js.Value) *XRRenderStateInit {
 	var out XRRenderStateInit
 	var (
 		value0 float64  // javascript: double {depthNear DepthNear depthNear}
 		value1 float64  // javascript: double {depthFar DepthFar depthFar}
 		value2 *XRLayer // javascript: XRLayer {baseLayer BaseLayer baseLayer}
 	)
-	value0 = (input.Get("depthNear")).Float()
+	value0 = (value.Get("depthNear")).Float()
 	out.DepthNear = value0
-	value1 = (input.Get("depthFar")).Float()
+	value1 = (value.Get("depthFar")).Float()
 	out.DepthFar = value1
-	if input.Get("baseLayer").Type() != js.TypeNull && input.Get("baseLayer").Type() != js.TypeUndefined {
-		value2 = XRLayerFromJS(input.Get("baseLayer"))
+	if value.Get("baseLayer").Type() != js.TypeNull && value.Get("baseLayer").Type() != js.TypeUndefined {
+		value2 = XRLayerFromJS(value.Get("baseLayer"))
 	}
 	out.BaseLayer = value2
 	return &out
@@ -743,7 +736,7 @@ type XRSessionCreationOptions struct {
 	OutputContext *XRPresentationContext
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRSessionCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -755,19 +748,17 @@ func (_this *XRSessionCreationOptions) JSValue() js.Value {
 }
 
 // XRSessionCreationOptionsFromJS is allocating a new
-// XRSessionCreationOptions object and copy all values from
-// input javascript object
-func XRSessionCreationOptionsFromJS(value js.Wrapper) *XRSessionCreationOptions {
-	input := value.JSValue()
+// XRSessionCreationOptions object and copy all values in the value javascript object.
+func XRSessionCreationOptionsFromJS(value js.Value) *XRSessionCreationOptions {
 	var out XRSessionCreationOptions
 	var (
 		value0 XRSessionMode          // javascript: XRSessionMode {mode Mode mode}
 		value1 *XRPresentationContext // javascript: XRPresentationContext {outputContext OutputContext outputContext}
 	)
-	value0 = XRSessionModeFromJS(input.Get("mode"))
+	value0 = XRSessionModeFromJS(value.Get("mode"))
 	out.Mode = value0
-	if input.Get("outputContext").Type() != js.TypeNull && input.Get("outputContext").Type() != js.TypeUndefined {
-		value1 = XRPresentationContextFromJS(input.Get("outputContext"))
+	if value.Get("outputContext").Type() != js.TypeNull && value.Get("outputContext").Type() != js.TypeUndefined {
+		value1 = XRPresentationContextFromJS(value.Get("outputContext"))
 	}
 	out.OutputContext = value1
 	return &out
@@ -781,7 +772,7 @@ type XRSessionEventInit struct {
 	Session    *XRSession
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRSessionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -797,10 +788,8 @@ func (_this *XRSessionEventInit) JSValue() js.Value {
 }
 
 // XRSessionEventInitFromJS is allocating a new
-// XRSessionEventInit object and copy all values from
-// input javascript object
-func XRSessionEventInitFromJS(value js.Wrapper) *XRSessionEventInit {
-	input := value.JSValue()
+// XRSessionEventInit object and copy all values in the value javascript object.
+func XRSessionEventInitFromJS(value js.Value) *XRSessionEventInit {
 	var out XRSessionEventInit
 	var (
 		value0 bool       // javascript: boolean {bubbles Bubbles bubbles}
@@ -808,13 +797,13 @@ func XRSessionEventInitFromJS(value js.Wrapper) *XRSessionEventInit {
 		value2 bool       // javascript: boolean {composed Composed composed}
 		value3 *XRSession // javascript: XRSession {session Session session}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRSessionFromJS(input.Get("session"))
+	value3 = XRSessionFromJS(value.Get("session"))
 	out.Session = value3
 	return &out
 }
@@ -828,7 +817,7 @@ type XRWebGLLayerInit struct {
 	FramebufferScaleFactor float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRWebGLLayerInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -846,10 +835,8 @@ func (_this *XRWebGLLayerInit) JSValue() js.Value {
 }
 
 // XRWebGLLayerInitFromJS is allocating a new
-// XRWebGLLayerInit object and copy all values from
-// input javascript object
-func XRWebGLLayerInitFromJS(value js.Wrapper) *XRWebGLLayerInit {
-	input := value.JSValue()
+// XRWebGLLayerInit object and copy all values in the value javascript object.
+func XRWebGLLayerInitFromJS(value js.Value) *XRWebGLLayerInit {
 	var out XRWebGLLayerInit
 	var (
 		value0 bool    // javascript: boolean {antialias Antialias antialias}
@@ -858,15 +845,15 @@ func XRWebGLLayerInitFromJS(value js.Wrapper) *XRWebGLLayerInit {
 		value3 bool    // javascript: boolean {alpha Alpha alpha}
 		value4 float64 // javascript: double {framebufferScaleFactor FramebufferScaleFactor framebufferScaleFactor}
 	)
-	value0 = (input.Get("antialias")).Bool()
+	value0 = (value.Get("antialias")).Bool()
 	out.Antialias = value0
-	value1 = (input.Get("depth")).Bool()
+	value1 = (value.Get("depth")).Bool()
 	out.Depth = value1
-	value2 = (input.Get("stencil")).Bool()
+	value2 = (value.Get("stencil")).Bool()
 	out.Stencil = value2
-	value3 = (input.Get("alpha")).Bool()
+	value3 = (value.Get("alpha")).Bool()
 	out.Alpha = value3
-	value4 = (input.Get("framebufferScaleFactor")).Float()
+	value4 = (value.Get("framebufferScaleFactor")).Float()
 	out.FramebufferScaleFactor = value4
 	return &out
 }
@@ -881,15 +868,19 @@ func (_this *PromiseXRReferenceSpace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseXRReferenceSpaceFromJS is casting a js.Wrapper into PromiseXRReferenceSpace.
-func PromiseXRReferenceSpaceFromJS(value js.Wrapper) *PromiseXRReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseXRReferenceSpaceFromJS is casting a js.Value into PromiseXRReferenceSpace.
+func PromiseXRReferenceSpaceFromJS(value js.Value) *PromiseXRReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseXRReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseXRReferenceSpaceFromJS is casting from something that holds a js.Value into PromiseXRReferenceSpace.
+func PromiseXRReferenceSpaceFromWrapper(input core.Wrapper) *PromiseXRReferenceSpace {
+	return PromiseXRReferenceSpaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseXRReferenceSpace) Then(onFulfilled *PromiseXRReferenceSpaceOnFulfilled, onRejected *PromiseXRReferenceSpaceOnRejected) (_result *PromiseXRReferenceSpace) {
@@ -986,15 +977,19 @@ func (_this *PromiseXRSession) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseXRSessionFromJS is casting a js.Wrapper into PromiseXRSession.
-func PromiseXRSessionFromJS(value js.Wrapper) *PromiseXRSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseXRSessionFromJS is casting a js.Value into PromiseXRSession.
+func PromiseXRSessionFromJS(value js.Value) *PromiseXRSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseXRSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseXRSessionFromJS is casting from something that holds a js.Value into PromiseXRSession.
+func PromiseXRSessionFromWrapper(input core.Wrapper) *PromiseXRSession {
+	return PromiseXRSessionFromJS(input.JSValue())
 }
 
 func (_this *PromiseXRSession) Then(onFulfilled *PromiseXRSessionOnFulfilled, onRejected *PromiseXRSessionOnRejected) (_result *PromiseXRSession) {
@@ -1086,15 +1081,19 @@ type XR struct {
 	domcore.EventTarget
 }
 
-// XRFromJS is casting a js.Wrapper into XR.
-func XRFromJS(value js.Wrapper) *XR {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRFromJS is casting a js.Value into XR.
+func XRFromJS(value js.Value) *XR {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XR{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRFromJS is casting from something that holds a js.Value into XR.
+func XRFromWrapper(input core.Wrapper) *XR {
+	return XRFromJS(input.JSValue())
 }
 
 // OnDeviceChange returning attribute 'ondevicechange' with
@@ -1179,15 +1178,19 @@ type XRBoundedReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRBoundedReferenceSpaceFromJS is casting a js.Wrapper into XRBoundedReferenceSpace.
-func XRBoundedReferenceSpaceFromJS(value js.Wrapper) *XRBoundedReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRBoundedReferenceSpaceFromJS is casting a js.Value into XRBoundedReferenceSpace.
+func XRBoundedReferenceSpaceFromJS(value js.Value) *XRBoundedReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRBoundedReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRBoundedReferenceSpaceFromJS is casting from something that holds a js.Value into XRBoundedReferenceSpace.
+func XRBoundedReferenceSpaceFromWrapper(input core.Wrapper) *XRBoundedReferenceSpace {
+	return XRBoundedReferenceSpaceFromJS(input.JSValue())
 }
 
 // BoundsGeometry returning attribute 'boundsGeometry' with
@@ -1209,15 +1212,19 @@ func (_this *XRFrame) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRFrameFromJS is casting a js.Wrapper into XRFrame.
-func XRFrameFromJS(value js.Wrapper) *XRFrame {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRFrameFromJS is casting a js.Value into XRFrame.
+func XRFrameFromJS(value js.Value) *XRFrame {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRFrame{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRFrameFromJS is casting from something that holds a js.Value into XRFrame.
+func XRFrameFromWrapper(input core.Wrapper) *XRFrame {
+	return XRFrameFromJS(input.JSValue())
 }
 
 // Session returning attribute 'session' with
@@ -1280,15 +1287,19 @@ func (_this *XRInputSource) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRInputSourceFromJS is casting a js.Wrapper into XRInputSource.
-func XRInputSourceFromJS(value js.Wrapper) *XRInputSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRInputSourceFromJS is casting a js.Value into XRInputSource.
+func XRInputSourceFromJS(value js.Value) *XRInputSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRInputSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRInputSourceFromJS is casting from something that holds a js.Value into XRInputSource.
+func XRInputSourceFromWrapper(input core.Wrapper) *XRInputSource {
+	return XRInputSourceFromJS(input.JSValue())
 }
 
 // Handedness returning attribute 'handedness' with
@@ -1334,15 +1345,19 @@ type XRInputSourceEvent struct {
 	domcore.Event
 }
 
-// XRInputSourceEventFromJS is casting a js.Wrapper into XRInputSourceEvent.
-func XRInputSourceEventFromJS(value js.Wrapper) *XRInputSourceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRInputSourceEventFromJS is casting a js.Value into XRInputSourceEvent.
+func XRInputSourceEventFromJS(value js.Value) *XRInputSourceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRInputSourceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRInputSourceEventFromJS is casting from something that holds a js.Value into XRInputSourceEvent.
+func XRInputSourceEventFromWrapper(input core.Wrapper) *XRInputSourceEvent {
+	return XRInputSourceEventFromJS(input.JSValue())
 }
 
 func NewXRInputSourceEvent(_type string, eventInitDict *XRInputSourceEventInit) (_result *XRInputSourceEvent) {
@@ -1394,15 +1409,19 @@ func (_this *XRLayer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRLayerFromJS is casting a js.Wrapper into XRLayer.
-func XRLayerFromJS(value js.Wrapper) *XRLayer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRLayerFromJS is casting a js.Value into XRLayer.
+func XRLayerFromJS(value js.Value) *XRLayer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRLayer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRLayerFromJS is casting from something that holds a js.Value into XRLayer.
+func XRLayerFromWrapper(input core.Wrapper) *XRLayer {
+	return XRLayerFromJS(input.JSValue())
 }
 
 // class: XRPose
@@ -1415,15 +1434,19 @@ func (_this *XRPose) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRPoseFromJS is casting a js.Wrapper into XRPose.
-func XRPoseFromJS(value js.Wrapper) *XRPose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRPoseFromJS is casting a js.Value into XRPose.
+func XRPoseFromJS(value js.Value) *XRPose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRPose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRPoseFromJS is casting from something that holds a js.Value into XRPose.
+func XRPoseFromWrapper(input core.Wrapper) *XRPose {
+	return XRPoseFromJS(input.JSValue())
 }
 
 // Transform returning attribute 'transform' with
@@ -1454,15 +1477,19 @@ func (_this *XRPresentationContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRPresentationContextFromJS is casting a js.Wrapper into XRPresentationContext.
-func XRPresentationContextFromJS(value js.Wrapper) *XRPresentationContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRPresentationContextFromJS is casting a js.Value into XRPresentationContext.
+func XRPresentationContextFromJS(value js.Value) *XRPresentationContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRPresentationContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRPresentationContextFromJS is casting from something that holds a js.Value into XRPresentationContext.
+func XRPresentationContextFromWrapper(input core.Wrapper) *XRPresentationContext {
+	return XRPresentationContextFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -1484,15 +1511,19 @@ func (_this *XRRay) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRayFromJS is casting a js.Wrapper into XRRay.
-func XRRayFromJS(value js.Wrapper) *XRRay {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRayFromJS is casting a js.Value into XRRay.
+func XRRayFromJS(value js.Value) *XRRay {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRay{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRayFromJS is casting from something that holds a js.Value into XRRay.
+func XRRayFromWrapper(input core.Wrapper) *XRRay {
+	return XRRayFromJS(input.JSValue())
 }
 
 func NewXRRay(transform *XRRigidTransform) (_result *XRRay) {
@@ -1545,15 +1576,19 @@ type XRReferenceSpace struct {
 	XRSpace
 }
 
-// XRReferenceSpaceFromJS is casting a js.Wrapper into XRReferenceSpace.
-func XRReferenceSpaceFromJS(value js.Wrapper) *XRReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRReferenceSpaceFromJS is casting a js.Value into XRReferenceSpace.
+func XRReferenceSpaceFromJS(value js.Value) *XRReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRReferenceSpaceFromJS is casting from something that holds a js.Value into XRReferenceSpace.
+func XRReferenceSpaceFromWrapper(input core.Wrapper) *XRReferenceSpace {
+	return XRReferenceSpaceFromJS(input.JSValue())
 }
 
 // OriginOffset returning attribute 'originOffset' with
@@ -1618,15 +1653,19 @@ type XRReferenceSpaceEvent struct {
 	domcore.Event
 }
 
-// XRReferenceSpaceEventFromJS is casting a js.Wrapper into XRReferenceSpaceEvent.
-func XRReferenceSpaceEventFromJS(value js.Wrapper) *XRReferenceSpaceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRReferenceSpaceEventFromJS is casting a js.Value into XRReferenceSpaceEvent.
+func XRReferenceSpaceEventFromJS(value js.Value) *XRReferenceSpaceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRReferenceSpaceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRReferenceSpaceEventFromJS is casting from something that holds a js.Value into XRReferenceSpaceEvent.
+func XRReferenceSpaceEventFromWrapper(input core.Wrapper) *XRReferenceSpaceEvent {
+	return XRReferenceSpaceEventFromJS(input.JSValue())
 }
 
 func NewXRReferenceSpaceEvent(_type string, eventInitDict *XRReferenceSpaceEventInit) (_result *XRReferenceSpaceEvent) {
@@ -1680,15 +1719,19 @@ func (_this *XRRenderState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRenderStateFromJS is casting a js.Wrapper into XRRenderState.
-func XRRenderStateFromJS(value js.Wrapper) *XRRenderState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRenderStateFromJS is casting a js.Value into XRRenderState.
+func XRRenderStateFromJS(value js.Value) *XRRenderState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRenderState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRenderStateFromJS is casting from something that holds a js.Value into XRRenderState.
+func XRRenderStateFromWrapper(input core.Wrapper) *XRRenderState {
+	return XRRenderStateFromJS(input.JSValue())
 }
 
 // DepthNear returning attribute 'depthNear' with
@@ -1730,15 +1773,19 @@ func (_this *XRRigidTransform) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRigidTransformFromJS is casting a js.Wrapper into XRRigidTransform.
-func XRRigidTransformFromJS(value js.Wrapper) *XRRigidTransform {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRigidTransformFromJS is casting a js.Value into XRRigidTransform.
+func XRRigidTransformFromJS(value js.Value) *XRRigidTransform {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRigidTransform{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRigidTransformFromJS is casting from something that holds a js.Value into XRRigidTransform.
+func XRRigidTransformFromWrapper(input core.Wrapper) *XRRigidTransform {
+	return XRRigidTransformFromJS(input.JSValue())
 }
 
 func NewXRRigidTransform(position *geometry.DOMPointInit, orientation *geometry.DOMPointInit) (_result *XRRigidTransform) {
@@ -1798,15 +1845,19 @@ type XRSession struct {
 	domcore.EventTarget
 }
 
-// XRSessionFromJS is casting a js.Wrapper into XRSession.
-func XRSessionFromJS(value js.Wrapper) *XRSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSessionFromJS is casting a js.Value into XRSession.
+func XRSessionFromJS(value js.Value) *XRSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSessionFromJS is casting from something that holds a js.Value into XRSession.
+func XRSessionFromWrapper(input core.Wrapper) *XRSession {
+	return XRSessionFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -2184,15 +2235,19 @@ type XRSessionEvent struct {
 	domcore.Event
 }
 
-// XRSessionEventFromJS is casting a js.Wrapper into XRSessionEvent.
-func XRSessionEventFromJS(value js.Wrapper) *XRSessionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSessionEventFromJS is casting a js.Value into XRSessionEvent.
+func XRSessionEventFromJS(value js.Value) *XRSessionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSessionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSessionEventFromJS is casting from something that holds a js.Value into XRSessionEvent.
+func XRSessionEventFromWrapper(input core.Wrapper) *XRSessionEvent {
+	return XRSessionEventFromJS(input.JSValue())
 }
 
 func NewXRSessionEvent(_type string, eventInitDict *XRSessionEventInit) (_result *XRSessionEvent) {
@@ -2230,15 +2285,19 @@ type XRSpace struct {
 	domcore.EventTarget
 }
 
-// XRSpaceFromJS is casting a js.Wrapper into XRSpace.
-func XRSpaceFromJS(value js.Wrapper) *XRSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSpaceFromJS is casting a js.Value into XRSpace.
+func XRSpaceFromJS(value js.Value) *XRSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSpaceFromJS is casting from something that holds a js.Value into XRSpace.
+func XRSpaceFromWrapper(input core.Wrapper) *XRSpace {
+	return XRSpaceFromJS(input.JSValue())
 }
 
 // class: XRStationaryReferenceSpace
@@ -2246,15 +2305,19 @@ type XRStationaryReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRStationaryReferenceSpaceFromJS is casting a js.Wrapper into XRStationaryReferenceSpace.
-func XRStationaryReferenceSpaceFromJS(value js.Wrapper) *XRStationaryReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRStationaryReferenceSpaceFromJS is casting a js.Value into XRStationaryReferenceSpace.
+func XRStationaryReferenceSpaceFromJS(value js.Value) *XRStationaryReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRStationaryReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRStationaryReferenceSpaceFromJS is casting from something that holds a js.Value into XRStationaryReferenceSpace.
+func XRStationaryReferenceSpaceFromWrapper(input core.Wrapper) *XRStationaryReferenceSpace {
+	return XRStationaryReferenceSpaceFromJS(input.JSValue())
 }
 
 // Subtype returning attribute 'subtype' with
@@ -2271,15 +2334,19 @@ type XRUnboundedReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRUnboundedReferenceSpaceFromJS is casting a js.Wrapper into XRUnboundedReferenceSpace.
-func XRUnboundedReferenceSpaceFromJS(value js.Wrapper) *XRUnboundedReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRUnboundedReferenceSpaceFromJS is casting a js.Value into XRUnboundedReferenceSpace.
+func XRUnboundedReferenceSpaceFromJS(value js.Value) *XRUnboundedReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRUnboundedReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRUnboundedReferenceSpaceFromJS is casting from something that holds a js.Value into XRUnboundedReferenceSpace.
+func XRUnboundedReferenceSpaceFromWrapper(input core.Wrapper) *XRUnboundedReferenceSpace {
+	return XRUnboundedReferenceSpaceFromJS(input.JSValue())
 }
 
 // class: XRView
@@ -2292,15 +2359,19 @@ func (_this *XRView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRViewFromJS is casting a js.Wrapper into XRView.
-func XRViewFromJS(value js.Wrapper) *XRView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewFromJS is casting a js.Value into XRView.
+func XRViewFromJS(value js.Value) *XRView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewFromJS is casting from something that holds a js.Value into XRView.
+func XRViewFromWrapper(input core.Wrapper) *XRView {
+	return XRViewFromJS(input.JSValue())
 }
 
 // Eye returning attribute 'eye' with
@@ -2344,15 +2415,19 @@ type XRViewerPose struct {
 	XRPose
 }
 
-// XRViewerPoseFromJS is casting a js.Wrapper into XRViewerPose.
-func XRViewerPoseFromJS(value js.Wrapper) *XRViewerPose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewerPoseFromJS is casting a js.Value into XRViewerPose.
+func XRViewerPoseFromJS(value js.Value) *XRViewerPose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRViewerPose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewerPoseFromJS is casting from something that holds a js.Value into XRViewerPose.
+func XRViewerPoseFromWrapper(input core.Wrapper) *XRViewerPose {
+	return XRViewerPoseFromJS(input.JSValue())
 }
 
 // Views returning attribute 'views' with
@@ -2374,15 +2449,19 @@ func (_this *XRViewport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRViewportFromJS is casting a js.Wrapper into XRViewport.
-func XRViewportFromJS(value js.Wrapper) *XRViewport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewportFromJS is casting a js.Value into XRViewport.
+func XRViewportFromJS(value js.Value) *XRViewport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRViewport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewportFromJS is casting from something that holds a js.Value into XRViewport.
+func XRViewportFromWrapper(input core.Wrapper) *XRViewport {
+	return XRViewportFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -2426,15 +2505,19 @@ type XRWebGLLayer struct {
 	XRLayer
 }
 
-// XRWebGLLayerFromJS is casting a js.Wrapper into XRWebGLLayer.
-func XRWebGLLayerFromJS(value js.Wrapper) *XRWebGLLayer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRWebGLLayerFromJS is casting a js.Value into XRWebGLLayer.
+func XRWebGLLayerFromJS(value js.Value) *XRWebGLLayer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRWebGLLayer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRWebGLLayerFromJS is casting from something that holds a js.Value into XRWebGLLayer.
+func XRWebGLLayerFromWrapper(input core.Wrapper) *XRWebGLLayer {
+	return XRWebGLLayerFromJS(input.JSValue())
 }
 
 func GetNativeFramebufferScaleFactor(session *XRSession) (_result float64) {

--- a/device/webxr/webxr_js.go
+++ b/device/webxr/webxr_js.go
@@ -5,6 +5,7 @@ package webxr
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/graphics/webgl"
@@ -564,7 +565,7 @@ type XRInputSourceEventInit struct {
 	InputSource *XRInputSource
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRInputSourceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -582,10 +583,8 @@ func (_this *XRInputSourceEventInit) JSValue() js.Value {
 }
 
 // XRInputSourceEventInitFromJS is allocating a new
-// XRInputSourceEventInit object and copy all values from
-// input javascript object
-func XRInputSourceEventInitFromJS(value js.Wrapper) *XRInputSourceEventInit {
-	input := value.JSValue()
+// XRInputSourceEventInit object and copy all values in the value javascript object.
+func XRInputSourceEventInitFromJS(value js.Value) *XRInputSourceEventInit {
 	var out XRInputSourceEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -594,15 +593,15 @@ func XRInputSourceEventInitFromJS(value js.Wrapper) *XRInputSourceEventInit {
 		value3 *XRFrame       // javascript: XRFrame {frame Frame frame}
 		value4 *XRInputSource // javascript: XRInputSource {inputSource InputSource inputSource}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRFrameFromJS(input.Get("frame"))
+	value3 = XRFrameFromJS(value.Get("frame"))
 	out.Frame = value3
-	value4 = XRInputSourceFromJS(input.Get("inputSource"))
+	value4 = XRInputSourceFromJS(value.Get("inputSource"))
 	out.InputSource = value4
 	return &out
 }
@@ -616,7 +615,7 @@ type XRReferenceSpaceEventInit struct {
 	Transform      *XRRigidTransform
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRReferenceSpaceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -634,10 +633,8 @@ func (_this *XRReferenceSpaceEventInit) JSValue() js.Value {
 }
 
 // XRReferenceSpaceEventInitFromJS is allocating a new
-// XRReferenceSpaceEventInit object and copy all values from
-// input javascript object
-func XRReferenceSpaceEventInitFromJS(value js.Wrapper) *XRReferenceSpaceEventInit {
-	input := value.JSValue()
+// XRReferenceSpaceEventInit object and copy all values in the value javascript object.
+func XRReferenceSpaceEventInitFromJS(value js.Value) *XRReferenceSpaceEventInit {
 	var out XRReferenceSpaceEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -646,15 +643,15 @@ func XRReferenceSpaceEventInitFromJS(value js.Wrapper) *XRReferenceSpaceEventIni
 		value3 *XRReferenceSpace // javascript: XRReferenceSpace {referenceSpace ReferenceSpace referenceSpace}
 		value4 *XRRigidTransform // javascript: XRRigidTransform {transform Transform transform}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRReferenceSpaceFromJS(input.Get("referenceSpace"))
+	value3 = XRReferenceSpaceFromJS(value.Get("referenceSpace"))
 	out.ReferenceSpace = value3
-	value4 = XRRigidTransformFromJS(input.Get("transform"))
+	value4 = XRRigidTransformFromJS(value.Get("transform"))
 	out.Transform = value4
 	return &out
 }
@@ -665,7 +662,7 @@ type XRReferenceSpaceOptions struct {
 	Subtype XRStationaryReferenceSpaceSubtype
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRReferenceSpaceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -677,18 +674,16 @@ func (_this *XRReferenceSpaceOptions) JSValue() js.Value {
 }
 
 // XRReferenceSpaceOptionsFromJS is allocating a new
-// XRReferenceSpaceOptions object and copy all values from
-// input javascript object
-func XRReferenceSpaceOptionsFromJS(value js.Wrapper) *XRReferenceSpaceOptions {
-	input := value.JSValue()
+// XRReferenceSpaceOptions object and copy all values in the value javascript object.
+func XRReferenceSpaceOptionsFromJS(value js.Value) *XRReferenceSpaceOptions {
 	var out XRReferenceSpaceOptions
 	var (
 		value0 XRReferenceSpaceType              // javascript: XRReferenceSpaceType {type Type _type}
 		value1 XRStationaryReferenceSpaceSubtype // javascript: XRStationaryReferenceSpaceSubtype {subtype Subtype subtype}
 	)
-	value0 = XRReferenceSpaceTypeFromJS(input.Get("type"))
+	value0 = XRReferenceSpaceTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = XRStationaryReferenceSpaceSubtypeFromJS(input.Get("subtype"))
+	value1 = XRStationaryReferenceSpaceSubtypeFromJS(value.Get("subtype"))
 	out.Subtype = value1
 	return &out
 }
@@ -700,7 +695,7 @@ type XRRenderStateInit struct {
 	BaseLayer *XRLayer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRRenderStateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -714,22 +709,20 @@ func (_this *XRRenderStateInit) JSValue() js.Value {
 }
 
 // XRRenderStateInitFromJS is allocating a new
-// XRRenderStateInit object and copy all values from
-// input javascript object
-func XRRenderStateInitFromJS(value js.Wrapper) *XRRenderStateInit {
-	input := value.JSValue()
+// XRRenderStateInit object and copy all values in the value javascript object.
+func XRRenderStateInitFromJS(value js.Value) *XRRenderStateInit {
 	var out XRRenderStateInit
 	var (
 		value0 float64  // javascript: double {depthNear DepthNear depthNear}
 		value1 float64  // javascript: double {depthFar DepthFar depthFar}
 		value2 *XRLayer // javascript: XRLayer {baseLayer BaseLayer baseLayer}
 	)
-	value0 = (input.Get("depthNear")).Float()
+	value0 = (value.Get("depthNear")).Float()
 	out.DepthNear = value0
-	value1 = (input.Get("depthFar")).Float()
+	value1 = (value.Get("depthFar")).Float()
 	out.DepthFar = value1
-	if input.Get("baseLayer").Type() != js.TypeNull && input.Get("baseLayer").Type() != js.TypeUndefined {
-		value2 = XRLayerFromJS(input.Get("baseLayer"))
+	if value.Get("baseLayer").Type() != js.TypeNull && value.Get("baseLayer").Type() != js.TypeUndefined {
+		value2 = XRLayerFromJS(value.Get("baseLayer"))
 	}
 	out.BaseLayer = value2
 	return &out
@@ -741,7 +734,7 @@ type XRSessionCreationOptions struct {
 	OutputContext *XRPresentationContext
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRSessionCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -753,19 +746,17 @@ func (_this *XRSessionCreationOptions) JSValue() js.Value {
 }
 
 // XRSessionCreationOptionsFromJS is allocating a new
-// XRSessionCreationOptions object and copy all values from
-// input javascript object
-func XRSessionCreationOptionsFromJS(value js.Wrapper) *XRSessionCreationOptions {
-	input := value.JSValue()
+// XRSessionCreationOptions object and copy all values in the value javascript object.
+func XRSessionCreationOptionsFromJS(value js.Value) *XRSessionCreationOptions {
 	var out XRSessionCreationOptions
 	var (
 		value0 XRSessionMode          // javascript: XRSessionMode {mode Mode mode}
 		value1 *XRPresentationContext // javascript: XRPresentationContext {outputContext OutputContext outputContext}
 	)
-	value0 = XRSessionModeFromJS(input.Get("mode"))
+	value0 = XRSessionModeFromJS(value.Get("mode"))
 	out.Mode = value0
-	if input.Get("outputContext").Type() != js.TypeNull && input.Get("outputContext").Type() != js.TypeUndefined {
-		value1 = XRPresentationContextFromJS(input.Get("outputContext"))
+	if value.Get("outputContext").Type() != js.TypeNull && value.Get("outputContext").Type() != js.TypeUndefined {
+		value1 = XRPresentationContextFromJS(value.Get("outputContext"))
 	}
 	out.OutputContext = value1
 	return &out
@@ -779,7 +770,7 @@ type XRSessionEventInit struct {
 	Session    *XRSession
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRSessionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -795,10 +786,8 @@ func (_this *XRSessionEventInit) JSValue() js.Value {
 }
 
 // XRSessionEventInitFromJS is allocating a new
-// XRSessionEventInit object and copy all values from
-// input javascript object
-func XRSessionEventInitFromJS(value js.Wrapper) *XRSessionEventInit {
-	input := value.JSValue()
+// XRSessionEventInit object and copy all values in the value javascript object.
+func XRSessionEventInitFromJS(value js.Value) *XRSessionEventInit {
 	var out XRSessionEventInit
 	var (
 		value0 bool       // javascript: boolean {bubbles Bubbles bubbles}
@@ -806,13 +795,13 @@ func XRSessionEventInitFromJS(value js.Wrapper) *XRSessionEventInit {
 		value2 bool       // javascript: boolean {composed Composed composed}
 		value3 *XRSession // javascript: XRSession {session Session session}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = XRSessionFromJS(input.Get("session"))
+	value3 = XRSessionFromJS(value.Get("session"))
 	out.Session = value3
 	return &out
 }
@@ -826,7 +815,7 @@ type XRWebGLLayerInit struct {
 	FramebufferScaleFactor float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *XRWebGLLayerInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -844,10 +833,8 @@ func (_this *XRWebGLLayerInit) JSValue() js.Value {
 }
 
 // XRWebGLLayerInitFromJS is allocating a new
-// XRWebGLLayerInit object and copy all values from
-// input javascript object
-func XRWebGLLayerInitFromJS(value js.Wrapper) *XRWebGLLayerInit {
-	input := value.JSValue()
+// XRWebGLLayerInit object and copy all values in the value javascript object.
+func XRWebGLLayerInitFromJS(value js.Value) *XRWebGLLayerInit {
 	var out XRWebGLLayerInit
 	var (
 		value0 bool    // javascript: boolean {antialias Antialias antialias}
@@ -856,15 +843,15 @@ func XRWebGLLayerInitFromJS(value js.Wrapper) *XRWebGLLayerInit {
 		value3 bool    // javascript: boolean {alpha Alpha alpha}
 		value4 float64 // javascript: double {framebufferScaleFactor FramebufferScaleFactor framebufferScaleFactor}
 	)
-	value0 = (input.Get("antialias")).Bool()
+	value0 = (value.Get("antialias")).Bool()
 	out.Antialias = value0
-	value1 = (input.Get("depth")).Bool()
+	value1 = (value.Get("depth")).Bool()
 	out.Depth = value1
-	value2 = (input.Get("stencil")).Bool()
+	value2 = (value.Get("stencil")).Bool()
 	out.Stencil = value2
-	value3 = (input.Get("alpha")).Bool()
+	value3 = (value.Get("alpha")).Bool()
 	out.Alpha = value3
-	value4 = (input.Get("framebufferScaleFactor")).Float()
+	value4 = (value.Get("framebufferScaleFactor")).Float()
 	out.FramebufferScaleFactor = value4
 	return &out
 }
@@ -879,15 +866,19 @@ func (_this *PromiseXRReferenceSpace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseXRReferenceSpaceFromJS is casting a js.Wrapper into PromiseXRReferenceSpace.
-func PromiseXRReferenceSpaceFromJS(value js.Wrapper) *PromiseXRReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseXRReferenceSpaceFromJS is casting a js.Value into PromiseXRReferenceSpace.
+func PromiseXRReferenceSpaceFromJS(value js.Value) *PromiseXRReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseXRReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseXRReferenceSpaceFromJS is casting from something that holds a js.Value into PromiseXRReferenceSpace.
+func PromiseXRReferenceSpaceFromWrapper(input core.Wrapper) *PromiseXRReferenceSpace {
+	return PromiseXRReferenceSpaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseXRReferenceSpace) Then(onFulfilled *PromiseXRReferenceSpaceOnFulfilled, onRejected *PromiseXRReferenceSpaceOnRejected) (_result *PromiseXRReferenceSpace) {
@@ -984,15 +975,19 @@ func (_this *PromiseXRSession) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseXRSessionFromJS is casting a js.Wrapper into PromiseXRSession.
-func PromiseXRSessionFromJS(value js.Wrapper) *PromiseXRSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseXRSessionFromJS is casting a js.Value into PromiseXRSession.
+func PromiseXRSessionFromJS(value js.Value) *PromiseXRSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseXRSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseXRSessionFromJS is casting from something that holds a js.Value into PromiseXRSession.
+func PromiseXRSessionFromWrapper(input core.Wrapper) *PromiseXRSession {
+	return PromiseXRSessionFromJS(input.JSValue())
 }
 
 func (_this *PromiseXRSession) Then(onFulfilled *PromiseXRSessionOnFulfilled, onRejected *PromiseXRSessionOnRejected) (_result *PromiseXRSession) {
@@ -1084,15 +1079,19 @@ type XR struct {
 	domcore.EventTarget
 }
 
-// XRFromJS is casting a js.Wrapper into XR.
-func XRFromJS(value js.Wrapper) *XR {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRFromJS is casting a js.Value into XR.
+func XRFromJS(value js.Value) *XR {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XR{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRFromJS is casting from something that holds a js.Value into XR.
+func XRFromWrapper(input core.Wrapper) *XR {
+	return XRFromJS(input.JSValue())
 }
 
 // OnDeviceChange returning attribute 'ondevicechange' with
@@ -1177,15 +1176,19 @@ type XRBoundedReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRBoundedReferenceSpaceFromJS is casting a js.Wrapper into XRBoundedReferenceSpace.
-func XRBoundedReferenceSpaceFromJS(value js.Wrapper) *XRBoundedReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRBoundedReferenceSpaceFromJS is casting a js.Value into XRBoundedReferenceSpace.
+func XRBoundedReferenceSpaceFromJS(value js.Value) *XRBoundedReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRBoundedReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRBoundedReferenceSpaceFromJS is casting from something that holds a js.Value into XRBoundedReferenceSpace.
+func XRBoundedReferenceSpaceFromWrapper(input core.Wrapper) *XRBoundedReferenceSpace {
+	return XRBoundedReferenceSpaceFromJS(input.JSValue())
 }
 
 // BoundsGeometry returning attribute 'boundsGeometry' with
@@ -1207,15 +1210,19 @@ func (_this *XRFrame) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRFrameFromJS is casting a js.Wrapper into XRFrame.
-func XRFrameFromJS(value js.Wrapper) *XRFrame {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRFrameFromJS is casting a js.Value into XRFrame.
+func XRFrameFromJS(value js.Value) *XRFrame {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRFrame{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRFrameFromJS is casting from something that holds a js.Value into XRFrame.
+func XRFrameFromWrapper(input core.Wrapper) *XRFrame {
+	return XRFrameFromJS(input.JSValue())
 }
 
 // Session returning attribute 'session' with
@@ -1278,15 +1285,19 @@ func (_this *XRInputSource) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRInputSourceFromJS is casting a js.Wrapper into XRInputSource.
-func XRInputSourceFromJS(value js.Wrapper) *XRInputSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRInputSourceFromJS is casting a js.Value into XRInputSource.
+func XRInputSourceFromJS(value js.Value) *XRInputSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRInputSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRInputSourceFromJS is casting from something that holds a js.Value into XRInputSource.
+func XRInputSourceFromWrapper(input core.Wrapper) *XRInputSource {
+	return XRInputSourceFromJS(input.JSValue())
 }
 
 // Handedness returning attribute 'handedness' with
@@ -1332,15 +1343,19 @@ type XRInputSourceEvent struct {
 	domcore.Event
 }
 
-// XRInputSourceEventFromJS is casting a js.Wrapper into XRInputSourceEvent.
-func XRInputSourceEventFromJS(value js.Wrapper) *XRInputSourceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRInputSourceEventFromJS is casting a js.Value into XRInputSourceEvent.
+func XRInputSourceEventFromJS(value js.Value) *XRInputSourceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRInputSourceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRInputSourceEventFromJS is casting from something that holds a js.Value into XRInputSourceEvent.
+func XRInputSourceEventFromWrapper(input core.Wrapper) *XRInputSourceEvent {
+	return XRInputSourceEventFromJS(input.JSValue())
 }
 
 func NewXRInputSourceEvent(_type string, eventInitDict *XRInputSourceEventInit) (_result *XRInputSourceEvent) {
@@ -1392,15 +1407,19 @@ func (_this *XRLayer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRLayerFromJS is casting a js.Wrapper into XRLayer.
-func XRLayerFromJS(value js.Wrapper) *XRLayer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRLayerFromJS is casting a js.Value into XRLayer.
+func XRLayerFromJS(value js.Value) *XRLayer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRLayer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRLayerFromJS is casting from something that holds a js.Value into XRLayer.
+func XRLayerFromWrapper(input core.Wrapper) *XRLayer {
+	return XRLayerFromJS(input.JSValue())
 }
 
 // class: XRPose
@@ -1413,15 +1432,19 @@ func (_this *XRPose) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRPoseFromJS is casting a js.Wrapper into XRPose.
-func XRPoseFromJS(value js.Wrapper) *XRPose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRPoseFromJS is casting a js.Value into XRPose.
+func XRPoseFromJS(value js.Value) *XRPose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRPose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRPoseFromJS is casting from something that holds a js.Value into XRPose.
+func XRPoseFromWrapper(input core.Wrapper) *XRPose {
+	return XRPoseFromJS(input.JSValue())
 }
 
 // Transform returning attribute 'transform' with
@@ -1452,15 +1475,19 @@ func (_this *XRPresentationContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRPresentationContextFromJS is casting a js.Wrapper into XRPresentationContext.
-func XRPresentationContextFromJS(value js.Wrapper) *XRPresentationContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRPresentationContextFromJS is casting a js.Value into XRPresentationContext.
+func XRPresentationContextFromJS(value js.Value) *XRPresentationContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRPresentationContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRPresentationContextFromJS is casting from something that holds a js.Value into XRPresentationContext.
+func XRPresentationContextFromWrapper(input core.Wrapper) *XRPresentationContext {
+	return XRPresentationContextFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -1482,15 +1509,19 @@ func (_this *XRRay) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRayFromJS is casting a js.Wrapper into XRRay.
-func XRRayFromJS(value js.Wrapper) *XRRay {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRayFromJS is casting a js.Value into XRRay.
+func XRRayFromJS(value js.Value) *XRRay {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRay{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRayFromJS is casting from something that holds a js.Value into XRRay.
+func XRRayFromWrapper(input core.Wrapper) *XRRay {
+	return XRRayFromJS(input.JSValue())
 }
 
 func NewXRRay(transform *XRRigidTransform) (_result *XRRay) {
@@ -1543,15 +1574,19 @@ type XRReferenceSpace struct {
 	XRSpace
 }
 
-// XRReferenceSpaceFromJS is casting a js.Wrapper into XRReferenceSpace.
-func XRReferenceSpaceFromJS(value js.Wrapper) *XRReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRReferenceSpaceFromJS is casting a js.Value into XRReferenceSpace.
+func XRReferenceSpaceFromJS(value js.Value) *XRReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRReferenceSpaceFromJS is casting from something that holds a js.Value into XRReferenceSpace.
+func XRReferenceSpaceFromWrapper(input core.Wrapper) *XRReferenceSpace {
+	return XRReferenceSpaceFromJS(input.JSValue())
 }
 
 // OriginOffset returning attribute 'originOffset' with
@@ -1616,15 +1651,19 @@ type XRReferenceSpaceEvent struct {
 	domcore.Event
 }
 
-// XRReferenceSpaceEventFromJS is casting a js.Wrapper into XRReferenceSpaceEvent.
-func XRReferenceSpaceEventFromJS(value js.Wrapper) *XRReferenceSpaceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRReferenceSpaceEventFromJS is casting a js.Value into XRReferenceSpaceEvent.
+func XRReferenceSpaceEventFromJS(value js.Value) *XRReferenceSpaceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRReferenceSpaceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRReferenceSpaceEventFromJS is casting from something that holds a js.Value into XRReferenceSpaceEvent.
+func XRReferenceSpaceEventFromWrapper(input core.Wrapper) *XRReferenceSpaceEvent {
+	return XRReferenceSpaceEventFromJS(input.JSValue())
 }
 
 func NewXRReferenceSpaceEvent(_type string, eventInitDict *XRReferenceSpaceEventInit) (_result *XRReferenceSpaceEvent) {
@@ -1678,15 +1717,19 @@ func (_this *XRRenderState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRenderStateFromJS is casting a js.Wrapper into XRRenderState.
-func XRRenderStateFromJS(value js.Wrapper) *XRRenderState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRenderStateFromJS is casting a js.Value into XRRenderState.
+func XRRenderStateFromJS(value js.Value) *XRRenderState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRenderState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRenderStateFromJS is casting from something that holds a js.Value into XRRenderState.
+func XRRenderStateFromWrapper(input core.Wrapper) *XRRenderState {
+	return XRRenderStateFromJS(input.JSValue())
 }
 
 // DepthNear returning attribute 'depthNear' with
@@ -1728,15 +1771,19 @@ func (_this *XRRigidTransform) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRRigidTransformFromJS is casting a js.Wrapper into XRRigidTransform.
-func XRRigidTransformFromJS(value js.Wrapper) *XRRigidTransform {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRRigidTransformFromJS is casting a js.Value into XRRigidTransform.
+func XRRigidTransformFromJS(value js.Value) *XRRigidTransform {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRRigidTransform{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRRigidTransformFromJS is casting from something that holds a js.Value into XRRigidTransform.
+func XRRigidTransformFromWrapper(input core.Wrapper) *XRRigidTransform {
+	return XRRigidTransformFromJS(input.JSValue())
 }
 
 func NewXRRigidTransform(position *geometry.DOMPointInit, orientation *geometry.DOMPointInit) (_result *XRRigidTransform) {
@@ -1796,15 +1843,19 @@ type XRSession struct {
 	domcore.EventTarget
 }
 
-// XRSessionFromJS is casting a js.Wrapper into XRSession.
-func XRSessionFromJS(value js.Wrapper) *XRSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSessionFromJS is casting a js.Value into XRSession.
+func XRSessionFromJS(value js.Value) *XRSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSessionFromJS is casting from something that holds a js.Value into XRSession.
+func XRSessionFromWrapper(input core.Wrapper) *XRSession {
+	return XRSessionFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -2182,15 +2233,19 @@ type XRSessionEvent struct {
 	domcore.Event
 }
 
-// XRSessionEventFromJS is casting a js.Wrapper into XRSessionEvent.
-func XRSessionEventFromJS(value js.Wrapper) *XRSessionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSessionEventFromJS is casting a js.Value into XRSessionEvent.
+func XRSessionEventFromJS(value js.Value) *XRSessionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSessionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSessionEventFromJS is casting from something that holds a js.Value into XRSessionEvent.
+func XRSessionEventFromWrapper(input core.Wrapper) *XRSessionEvent {
+	return XRSessionEventFromJS(input.JSValue())
 }
 
 func NewXRSessionEvent(_type string, eventInitDict *XRSessionEventInit) (_result *XRSessionEvent) {
@@ -2228,15 +2283,19 @@ type XRSpace struct {
 	domcore.EventTarget
 }
 
-// XRSpaceFromJS is casting a js.Wrapper into XRSpace.
-func XRSpaceFromJS(value js.Wrapper) *XRSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRSpaceFromJS is casting a js.Value into XRSpace.
+func XRSpaceFromJS(value js.Value) *XRSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRSpaceFromJS is casting from something that holds a js.Value into XRSpace.
+func XRSpaceFromWrapper(input core.Wrapper) *XRSpace {
+	return XRSpaceFromJS(input.JSValue())
 }
 
 // class: XRStationaryReferenceSpace
@@ -2244,15 +2303,19 @@ type XRStationaryReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRStationaryReferenceSpaceFromJS is casting a js.Wrapper into XRStationaryReferenceSpace.
-func XRStationaryReferenceSpaceFromJS(value js.Wrapper) *XRStationaryReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRStationaryReferenceSpaceFromJS is casting a js.Value into XRStationaryReferenceSpace.
+func XRStationaryReferenceSpaceFromJS(value js.Value) *XRStationaryReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRStationaryReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRStationaryReferenceSpaceFromJS is casting from something that holds a js.Value into XRStationaryReferenceSpace.
+func XRStationaryReferenceSpaceFromWrapper(input core.Wrapper) *XRStationaryReferenceSpace {
+	return XRStationaryReferenceSpaceFromJS(input.JSValue())
 }
 
 // Subtype returning attribute 'subtype' with
@@ -2269,15 +2332,19 @@ type XRUnboundedReferenceSpace struct {
 	XRReferenceSpace
 }
 
-// XRUnboundedReferenceSpaceFromJS is casting a js.Wrapper into XRUnboundedReferenceSpace.
-func XRUnboundedReferenceSpaceFromJS(value js.Wrapper) *XRUnboundedReferenceSpace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRUnboundedReferenceSpaceFromJS is casting a js.Value into XRUnboundedReferenceSpace.
+func XRUnboundedReferenceSpaceFromJS(value js.Value) *XRUnboundedReferenceSpace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRUnboundedReferenceSpace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRUnboundedReferenceSpaceFromJS is casting from something that holds a js.Value into XRUnboundedReferenceSpace.
+func XRUnboundedReferenceSpaceFromWrapper(input core.Wrapper) *XRUnboundedReferenceSpace {
+	return XRUnboundedReferenceSpaceFromJS(input.JSValue())
 }
 
 // class: XRView
@@ -2290,15 +2357,19 @@ func (_this *XRView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRViewFromJS is casting a js.Wrapper into XRView.
-func XRViewFromJS(value js.Wrapper) *XRView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewFromJS is casting a js.Value into XRView.
+func XRViewFromJS(value js.Value) *XRView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewFromJS is casting from something that holds a js.Value into XRView.
+func XRViewFromWrapper(input core.Wrapper) *XRView {
+	return XRViewFromJS(input.JSValue())
 }
 
 // Eye returning attribute 'eye' with
@@ -2342,15 +2413,19 @@ type XRViewerPose struct {
 	XRPose
 }
 
-// XRViewerPoseFromJS is casting a js.Wrapper into XRViewerPose.
-func XRViewerPoseFromJS(value js.Wrapper) *XRViewerPose {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewerPoseFromJS is casting a js.Value into XRViewerPose.
+func XRViewerPoseFromJS(value js.Value) *XRViewerPose {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRViewerPose{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewerPoseFromJS is casting from something that holds a js.Value into XRViewerPose.
+func XRViewerPoseFromWrapper(input core.Wrapper) *XRViewerPose {
+	return XRViewerPoseFromJS(input.JSValue())
 }
 
 // Views returning attribute 'views' with
@@ -2372,15 +2447,19 @@ func (_this *XRViewport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XRViewportFromJS is casting a js.Wrapper into XRViewport.
-func XRViewportFromJS(value js.Wrapper) *XRViewport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRViewportFromJS is casting a js.Value into XRViewport.
+func XRViewportFromJS(value js.Value) *XRViewport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRViewport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRViewportFromJS is casting from something that holds a js.Value into XRViewport.
+func XRViewportFromWrapper(input core.Wrapper) *XRViewport {
+	return XRViewportFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -2424,15 +2503,19 @@ type XRWebGLLayer struct {
 	XRLayer
 }
 
-// XRWebGLLayerFromJS is casting a js.Wrapper into XRWebGLLayer.
-func XRWebGLLayerFromJS(value js.Wrapper) *XRWebGLLayer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XRWebGLLayerFromJS is casting a js.Value into XRWebGLLayer.
+func XRWebGLLayerFromJS(value js.Value) *XRWebGLLayer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XRWebGLLayer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XRWebGLLayerFromJS is casting from something that holds a js.Value into XRWebGLLayer.
+func XRWebGLLayerFromWrapper(input core.Wrapper) *XRWebGLLayer {
+	return XRWebGLLayerFromJS(input.JSValue())
 }
 
 func GetNativeFramebufferScaleFactor(session *XRSession) (_result float64) {

--- a/dom/dom.go
+++ b/dom/dom.go
@@ -7,6 +7,7 @@ package dom
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/css/cssom/view"
@@ -331,7 +332,7 @@ type FullscreenOptions struct {
 	NavigationUI FullscreenNavigationUI
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FullscreenOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -341,15 +342,13 @@ func (_this *FullscreenOptions) JSValue() js.Value {
 }
 
 // FullscreenOptionsFromJS is allocating a new
-// FullscreenOptions object and copy all values from
-// input javascript object
-func FullscreenOptionsFromJS(value js.Wrapper) *FullscreenOptions {
-	input := value.JSValue()
+// FullscreenOptions object and copy all values in the value javascript object.
+func FullscreenOptionsFromJS(value js.Value) *FullscreenOptions {
 	var out FullscreenOptions
 	var (
 		value0 FullscreenNavigationUI // javascript: FullscreenNavigationUI {navigationUI NavigationUI navigationUI}
 	)
-	value0 = FullscreenNavigationUIFromJS(input.Get("navigationUI"))
+	value0 = FullscreenNavigationUIFromJS(value.Get("navigationUI"))
 	out.NavigationUI = value0
 	return &out
 }
@@ -359,7 +358,7 @@ type GetRootNodeOptions struct {
 	Composed bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GetRootNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -369,15 +368,13 @@ func (_this *GetRootNodeOptions) JSValue() js.Value {
 }
 
 // GetRootNodeOptionsFromJS is allocating a new
-// GetRootNodeOptions object and copy all values from
-// input javascript object
-func GetRootNodeOptionsFromJS(value js.Wrapper) *GetRootNodeOptions {
-	input := value.JSValue()
+// GetRootNodeOptions object and copy all values in the value javascript object.
+func GetRootNodeOptionsFromJS(value js.Value) *GetRootNodeOptions {
 	var out GetRootNodeOptions
 	var (
 		value0 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("composed")).Bool()
+	value0 = (value.Get("composed")).Bool()
 	out.Composed = value0
 	return &out
 }
@@ -388,7 +385,7 @@ type NodeListEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -404,26 +401,24 @@ func (_this *NodeListEntryIteratorValue) JSValue() js.Value {
 }
 
 // NodeListEntryIteratorValueFromJS is allocating a new
-// NodeListEntryIteratorValue object and copy all values from
-// input javascript object
-func NodeListEntryIteratorValueFromJS(value js.Wrapper) *NodeListEntryIteratorValue {
-	input := value.JSValue()
+// NodeListEntryIteratorValue object and copy all values in the value javascript object.
+func NodeListEntryIteratorValueFromJS(value js.Value) *NodeListEntryIteratorValue {
 	var out NodeListEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -434,7 +429,7 @@ type NodeListKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -446,18 +441,16 @@ func (_this *NodeListKeyIteratorValue) JSValue() js.Value {
 }
 
 // NodeListKeyIteratorValueFromJS is allocating a new
-// NodeListKeyIteratorValue object and copy all values from
-// input javascript object
-func NodeListKeyIteratorValueFromJS(value js.Wrapper) *NodeListKeyIteratorValue {
-	input := value.JSValue()
+// NodeListKeyIteratorValue object and copy all values in the value javascript object.
+func NodeListKeyIteratorValueFromJS(value js.Value) *NodeListKeyIteratorValue {
 	var out NodeListKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -468,7 +461,7 @@ type NodeListValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -480,18 +473,16 @@ func (_this *NodeListValueIteratorValue) JSValue() js.Value {
 }
 
 // NodeListValueIteratorValueFromJS is allocating a new
-// NodeListValueIteratorValue object and copy all values from
-// input javascript object
-func NodeListValueIteratorValueFromJS(value js.Wrapper) *NodeListValueIteratorValue {
-	input := value.JSValue()
+// NodeListValueIteratorValue object and copy all values in the value javascript object.
+func NodeListValueIteratorValueFromJS(value js.Value) *NodeListValueIteratorValue {
 	var out NodeListValueIteratorValue
 	var (
 		value0 *Node // javascript: Node {value Value value}
 		value1 bool  // javascript: boolean {done Done done}
 	)
-	value0 = NodeFromJS(input.Get("value"))
+	value0 = NodeFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -501,7 +492,7 @@ type ShadowRootInit struct {
 	Mode ShadowRootMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ShadowRootInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -511,15 +502,13 @@ func (_this *ShadowRootInit) JSValue() js.Value {
 }
 
 // ShadowRootInitFromJS is allocating a new
-// ShadowRootInit object and copy all values from
-// input javascript object
-func ShadowRootInitFromJS(value js.Wrapper) *ShadowRootInit {
-	input := value.JSValue()
+// ShadowRootInit object and copy all values in the value javascript object.
+func ShadowRootInitFromJS(value js.Value) *ShadowRootInit {
 	var out ShadowRootInit
 	var (
 		value0 ShadowRootMode // javascript: ShadowRootMode {mode Mode mode}
 	)
-	value0 = ShadowRootModeFromJS(input.Get("mode"))
+	value0 = ShadowRootModeFromJS(value.Get("mode"))
 	out.Mode = value0
 	return &out
 }
@@ -534,15 +523,19 @@ func (_this *AbstractRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AbstractRangeFromJS is casting a js.Wrapper into AbstractRange.
-func AbstractRangeFromJS(value js.Wrapper) *AbstractRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbstractRangeFromJS is casting a js.Value into AbstractRange.
+func AbstractRangeFromJS(value js.Value) *AbstractRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbstractRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbstractRangeFromJS is casting from something that holds a js.Value into AbstractRange.
+func AbstractRangeFromWrapper(input core.Wrapper) *AbstractRange {
+	return AbstractRangeFromJS(input.JSValue())
 }
 
 // StartContainer returning attribute 'startContainer' with
@@ -595,15 +588,19 @@ type Attr struct {
 	Node
 }
 
-// AttrFromJS is casting a js.Wrapper into Attr.
-func AttrFromJS(value js.Wrapper) *Attr {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AttrFromJS is casting a js.Value into Attr.
+func AttrFromJS(value js.Value) *Attr {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Attr{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AttrFromJS is casting from something that holds a js.Value into Attr.
+func AttrFromWrapper(input core.Wrapper) *Attr {
+	return AttrFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -689,15 +686,19 @@ type CDATASection struct {
 	Text
 }
 
-// CDATASectionFromJS is casting a js.Wrapper into CDATASection.
-func CDATASectionFromJS(value js.Wrapper) *CDATASection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CDATASectionFromJS is casting a js.Value into CDATASection.
+func CDATASectionFromJS(value js.Value) *CDATASection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CDATASection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CDATASectionFromJS is casting from something that holds a js.Value into CDATASection.
+func CDATASectionFromWrapper(input core.Wrapper) *CDATASection {
+	return CDATASectionFromJS(input.JSValue())
 }
 
 // class: CharacterData
@@ -705,15 +706,19 @@ type CharacterData struct {
 	Node
 }
 
-// CharacterDataFromJS is casting a js.Wrapper into CharacterData.
-func CharacterDataFromJS(value js.Wrapper) *CharacterData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CharacterDataFromJS is casting a js.Value into CharacterData.
+func CharacterDataFromJS(value js.Value) *CharacterData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CharacterData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CharacterDataFromJS is casting from something that holds a js.Value into CharacterData.
+func CharacterDataFromWrapper(input core.Wrapper) *CharacterData {
+	return CharacterDataFromJS(input.JSValue())
 }
 
 // Data returning attribute 'data' with
@@ -899,15 +904,19 @@ type Comment struct {
 	CharacterData
 }
 
-// CommentFromJS is casting a js.Wrapper into Comment.
-func CommentFromJS(value js.Wrapper) *Comment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CommentFromJS is casting a js.Value into Comment.
+func CommentFromJS(value js.Value) *Comment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Comment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CommentFromJS is casting from something that holds a js.Value into Comment.
+func CommentFromWrapper(input core.Wrapper) *Comment {
+	return CommentFromJS(input.JSValue())
 }
 
 func NewComment(data *string) (_result *Comment) {
@@ -946,15 +955,19 @@ func (_this *DeadFragmentInformation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeadFragmentInformationFromJS is casting a js.Wrapper into DeadFragmentInformation.
-func DeadFragmentInformationFromJS(value js.Wrapper) *DeadFragmentInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeadFragmentInformationFromJS is casting a js.Value into DeadFragmentInformation.
+func DeadFragmentInformationFromJS(value js.Value) *DeadFragmentInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeadFragmentInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeadFragmentInformationFromJS is casting from something that holds a js.Value into DeadFragmentInformation.
+func DeadFragmentInformationFromWrapper(input core.Wrapper) *DeadFragmentInformation {
+	return DeadFragmentInformationFromJS(input.JSValue())
 }
 
 // Node returning attribute 'node' with
@@ -1071,15 +1084,19 @@ type DocumentFragment struct {
 	Node
 }
 
-// DocumentFragmentFromJS is casting a js.Wrapper into DocumentFragment.
-func DocumentFragmentFromJS(value js.Wrapper) *DocumentFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentFragmentFromJS is casting a js.Value into DocumentFragment.
+func DocumentFragmentFromJS(value js.Value) *DocumentFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentFragmentFromJS is casting from something that holds a js.Value into DocumentFragment.
+func DocumentFragmentFromWrapper(input core.Wrapper) *DocumentFragment {
+	return DocumentFragmentFromJS(input.JSValue())
 }
 
 func NewDocumentFragment() (_result *DocumentFragment) {
@@ -1225,15 +1242,19 @@ type DocumentType struct {
 	Node
 }
 
-// DocumentTypeFromJS is casting a js.Wrapper into DocumentType.
-func DocumentTypeFromJS(value js.Wrapper) *DocumentType {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentTypeFromJS is casting a js.Value into DocumentType.
+func DocumentTypeFromJS(value js.Value) *DocumentType {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentType{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentTypeFromJS is casting from something that holds a js.Value into DocumentType.
+func DocumentTypeFromWrapper(input core.Wrapper) *DocumentType {
+	return DocumentTypeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1319,15 +1340,19 @@ type Element struct {
 	Node
 }
 
-// ElementFromJS is casting a js.Wrapper into Element.
-func ElementFromJS(value js.Wrapper) *Element {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ElementFromJS is casting a js.Value into Element.
+func ElementFromJS(value js.Value) *Element {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Element{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ElementFromJS is casting from something that holds a js.Value into Element.
+func ElementFromWrapper(input core.Wrapper) *Element {
+	return ElementFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -3846,15 +3871,19 @@ func (_this *HTMLCollection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HTMLCollectionFromJS is casting a js.Wrapper into HTMLCollection.
-func HTMLCollectionFromJS(value js.Wrapper) *HTMLCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLCollectionFromJS is casting a js.Value into HTMLCollection.
+func HTMLCollectionFromJS(value js.Value) *HTMLCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLCollectionFromJS is casting from something that holds a js.Value into HTMLCollection.
+func HTMLCollectionFromWrapper(input core.Wrapper) *HTMLCollection {
+	return HTMLCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -3952,15 +3981,19 @@ func (_this *NamedNodeMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NamedNodeMapFromJS is casting a js.Wrapper into NamedNodeMap.
-func NamedNodeMapFromJS(value js.Wrapper) *NamedNodeMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedNodeMapFromJS is casting a js.Value into NamedNodeMap.
+func NamedNodeMapFromJS(value js.Value) *NamedNodeMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedNodeMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedNodeMapFromJS is casting from something that holds a js.Value into NamedNodeMap.
+func NamedNodeMapFromWrapper(input core.Wrapper) *NamedNodeMap {
+	return NamedNodeMapFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -4162,15 +4195,19 @@ type Node struct {
 	domcore.EventTarget
 }
 
-// NodeFromJS is casting a js.Wrapper into Node.
-func NodeFromJS(value js.Wrapper) *Node {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeFromJS is casting a js.Value into Node.
+func NodeFromJS(value js.Value) *Node {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Node{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeFromJS is casting from something that holds a js.Value into Node.
+func NodeFromWrapper(input core.Wrapper) *Node {
+	return NodeFromJS(input.JSValue())
 }
 
 const (
@@ -4671,7 +4708,7 @@ type NodeFilter interface {
 }
 
 // NodeFilterValue is javascript reference value for callback interface NodeFilter.
-// This is holding the underlaying javascript object.
+// This is holding the underlying javascript object.
 type NodeFilterValue struct {
 	// Value is the underlying javascript object or function.
 	Value js.Value
@@ -4723,15 +4760,18 @@ func NewNodeFilterFunc(f func(node *Node) (_result int)) *NodeFilterValue {
 // NodeFilterFromJS is taking an javascript object that reference to a
 // callback interface and return a corresponding interface that can be used
 // to invoke on that element.
-func NodeFilterFromJS(value js.Wrapper) *NodeFilterValue {
-	input := value.JSValue()
-	if input.Type() == js.TypeObject {
-		return &NodeFilterValue{Value: input}
+func NodeFilterFromJS(value js.Value) *NodeFilterValue {
+	if value.Type() == js.TypeObject {
+		return &NodeFilterValue{Value: value}
 	}
-	if input.Type() == js.TypeFunction {
-		return &NodeFilterValue{Value: input, useInvoke: true}
+	if value.Type() == js.TypeFunction {
+		return &NodeFilterValue{Value: value, useInvoke: true}
 	}
 	panic("unsupported type")
+}
+
+func NodeFilterFromWrapper(input core.Wrapper) *NodeFilterValue {
+	return NodeFilterFromJS(input.JSValue())
 }
 
 func (t *NodeFilterValue) allocateAcceptNode() js.Func {
@@ -4791,15 +4831,19 @@ func (_this *NodeIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeIteratorFromJS is casting a js.Wrapper into NodeIterator.
-func NodeIteratorFromJS(value js.Wrapper) *NodeIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeIteratorFromJS is casting a js.Value into NodeIterator.
+func NodeIteratorFromJS(value js.Value) *NodeIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeIteratorFromJS is casting from something that holds a js.Value into NodeIterator.
+func NodeIteratorFromWrapper(input core.Wrapper) *NodeIterator {
+	return NodeIteratorFromJS(input.JSValue())
 }
 
 // Root returning attribute 'root' with
@@ -4900,15 +4944,19 @@ func (_this *NodeList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListFromJS is casting a js.Wrapper into NodeList.
-func NodeListFromJS(value js.Wrapper) *NodeList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListFromJS is casting a js.Value into NodeList.
+func NodeListFromJS(value js.Value) *NodeList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListFromJS is casting from something that holds a js.Value into NodeList.
+func NodeListFromWrapper(input core.Wrapper) *NodeList {
+	return NodeListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5034,15 +5082,19 @@ func (_this *NodeListEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListEntryIteratorFromJS is casting a js.Wrapper into NodeListEntryIterator.
-func NodeListEntryIteratorFromJS(value js.Wrapper) *NodeListEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListEntryIteratorFromJS is casting a js.Value into NodeListEntryIterator.
+func NodeListEntryIteratorFromJS(value js.Value) *NodeListEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListEntryIteratorFromJS is casting from something that holds a js.Value into NodeListEntryIterator.
+func NodeListEntryIteratorFromWrapper(input core.Wrapper) *NodeListEntryIterator {
+	return NodeListEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListEntryIterator) Next() (_result *NodeListEntryIteratorValue) {
@@ -5069,15 +5121,19 @@ func (_this *NodeListKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListKeyIteratorFromJS is casting a js.Wrapper into NodeListKeyIterator.
-func NodeListKeyIteratorFromJS(value js.Wrapper) *NodeListKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListKeyIteratorFromJS is casting a js.Value into NodeListKeyIterator.
+func NodeListKeyIteratorFromJS(value js.Value) *NodeListKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListKeyIteratorFromJS is casting from something that holds a js.Value into NodeListKeyIterator.
+func NodeListKeyIteratorFromWrapper(input core.Wrapper) *NodeListKeyIterator {
+	return NodeListKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListKeyIterator) Next() (_result *NodeListKeyIteratorValue) {
@@ -5104,15 +5160,19 @@ func (_this *NodeListValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListValueIteratorFromJS is casting a js.Wrapper into NodeListValueIterator.
-func NodeListValueIteratorFromJS(value js.Wrapper) *NodeListValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListValueIteratorFromJS is casting a js.Value into NodeListValueIterator.
+func NodeListValueIteratorFromJS(value js.Value) *NodeListValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListValueIteratorFromJS is casting from something that holds a js.Value into NodeListValueIterator.
+func NodeListValueIteratorFromWrapper(input core.Wrapper) *NodeListValueIterator {
+	return NodeListValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListValueIterator) Next() (_result *NodeListValueIteratorValue) {
@@ -5134,15 +5194,19 @@ type ProcessingInstruction struct {
 	CharacterData
 }
 
-// ProcessingInstructionFromJS is casting a js.Wrapper into ProcessingInstruction.
-func ProcessingInstructionFromJS(value js.Wrapper) *ProcessingInstruction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProcessingInstructionFromJS is casting a js.Value into ProcessingInstruction.
+func ProcessingInstructionFromJS(value js.Value) *ProcessingInstruction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProcessingInstruction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProcessingInstructionFromJS is casting from something that holds a js.Value into ProcessingInstruction.
+func ProcessingInstructionFromWrapper(input core.Wrapper) *ProcessingInstruction {
+	return ProcessingInstructionFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -5175,15 +5239,19 @@ func (_this *PromiseDeadFragmentInformation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDeadFragmentInformationFromJS is casting a js.Wrapper into PromiseDeadFragmentInformation.
-func PromiseDeadFragmentInformationFromJS(value js.Wrapper) *PromiseDeadFragmentInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDeadFragmentInformationFromJS is casting a js.Value into PromiseDeadFragmentInformation.
+func PromiseDeadFragmentInformationFromJS(value js.Value) *PromiseDeadFragmentInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDeadFragmentInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDeadFragmentInformationFromJS is casting from something that holds a js.Value into PromiseDeadFragmentInformation.
+func PromiseDeadFragmentInformationFromWrapper(input core.Wrapper) *PromiseDeadFragmentInformation {
+	return PromiseDeadFragmentInformationFromJS(input.JSValue())
 }
 
 func (_this *PromiseDeadFragmentInformation) Then(onFulfilled *PromiseDeadFragmentInformationOnFulfilled, onRejected *PromiseDeadFragmentInformationOnRejected) (_result *PromiseDeadFragmentInformation) {
@@ -5275,15 +5343,19 @@ type Range struct {
 	AbstractRange
 }
 
-// RangeFromJS is casting a js.Wrapper into Range.
-func RangeFromJS(value js.Wrapper) *Range {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RangeFromJS is casting a js.Value into Range.
+func RangeFromJS(value js.Value) *Range {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Range{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RangeFromJS is casting from something that holds a js.Value into Range.
+func RangeFromWrapper(input core.Wrapper) *Range {
+	return RangeFromJS(input.JSValue())
 }
 
 const (
@@ -5664,15 +5736,19 @@ type ShadowRoot struct {
 	DocumentFragment
 }
 
-// ShadowRootFromJS is casting a js.Wrapper into ShadowRoot.
-func ShadowRootFromJS(value js.Wrapper) *ShadowRoot {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShadowRootFromJS is casting a js.Value into ShadowRoot.
+func ShadowRootFromJS(value js.Value) *ShadowRoot {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShadowRoot{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShadowRootFromJS is casting from something that holds a js.Value into ShadowRoot.
+func ShadowRootFromWrapper(input core.Wrapper) *ShadowRoot {
+	return ShadowRootFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -5740,15 +5816,19 @@ type StaticRange struct {
 	AbstractRange
 }
 
-// StaticRangeFromJS is casting a js.Wrapper into StaticRange.
-func StaticRangeFromJS(value js.Wrapper) *StaticRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StaticRangeFromJS is casting a js.Value into StaticRange.
+func StaticRangeFromJS(value js.Value) *StaticRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StaticRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StaticRangeFromJS is casting from something that holds a js.Value into StaticRange.
+func StaticRangeFromWrapper(input core.Wrapper) *StaticRange {
+	return StaticRangeFromJS(input.JSValue())
 }
 
 // class: Text
@@ -5756,15 +5836,19 @@ type Text struct {
 	CharacterData
 }
 
-// TextFromJS is casting a js.Wrapper into Text.
-func TextFromJS(value js.Wrapper) *Text {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextFromJS is casting a js.Value into Text.
+func TextFromJS(value js.Value) *Text {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Text{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextFromJS is casting from something that holds a js.Value into Text.
+func TextFromWrapper(input core.Wrapper) *Text {
+	return TextFromJS(input.JSValue())
 }
 
 func NewText(data *string) (_result *Text) {
@@ -5940,15 +6024,19 @@ func (_this *TreeWalker) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TreeWalkerFromJS is casting a js.Wrapper into TreeWalker.
-func TreeWalkerFromJS(value js.Wrapper) *TreeWalker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TreeWalkerFromJS is casting a js.Value into TreeWalker.
+func TreeWalkerFromJS(value js.Value) *TreeWalker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TreeWalker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TreeWalkerFromJS is casting from something that holds a js.Value into TreeWalker.
+func TreeWalkerFromWrapper(input core.Wrapper) *TreeWalker {
+	return TreeWalkerFromJS(input.JSValue())
 }
 
 // Root returning attribute 'root' with

--- a/dom/dom_js.go
+++ b/dom/dom_js.go
@@ -5,6 +5,7 @@ package dom
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/css/animations/webani"
 	"github.com/gowebapi/webapi/css/cssom"
 	"github.com/gowebapi/webapi/css/cssom/view"
@@ -329,7 +330,7 @@ type FullscreenOptions struct {
 	NavigationUI FullscreenNavigationUI
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FullscreenOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -339,15 +340,13 @@ func (_this *FullscreenOptions) JSValue() js.Value {
 }
 
 // FullscreenOptionsFromJS is allocating a new
-// FullscreenOptions object and copy all values from
-// input javascript object
-func FullscreenOptionsFromJS(value js.Wrapper) *FullscreenOptions {
-	input := value.JSValue()
+// FullscreenOptions object and copy all values in the value javascript object.
+func FullscreenOptionsFromJS(value js.Value) *FullscreenOptions {
 	var out FullscreenOptions
 	var (
 		value0 FullscreenNavigationUI // javascript: FullscreenNavigationUI {navigationUI NavigationUI navigationUI}
 	)
-	value0 = FullscreenNavigationUIFromJS(input.Get("navigationUI"))
+	value0 = FullscreenNavigationUIFromJS(value.Get("navigationUI"))
 	out.NavigationUI = value0
 	return &out
 }
@@ -357,7 +356,7 @@ type GetRootNodeOptions struct {
 	Composed bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GetRootNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -367,15 +366,13 @@ func (_this *GetRootNodeOptions) JSValue() js.Value {
 }
 
 // GetRootNodeOptionsFromJS is allocating a new
-// GetRootNodeOptions object and copy all values from
-// input javascript object
-func GetRootNodeOptionsFromJS(value js.Wrapper) *GetRootNodeOptions {
-	input := value.JSValue()
+// GetRootNodeOptions object and copy all values in the value javascript object.
+func GetRootNodeOptionsFromJS(value js.Value) *GetRootNodeOptions {
 	var out GetRootNodeOptions
 	var (
 		value0 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("composed")).Bool()
+	value0 = (value.Get("composed")).Bool()
 	out.Composed = value0
 	return &out
 }
@@ -386,7 +383,7 @@ type NodeListEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -402,26 +399,24 @@ func (_this *NodeListEntryIteratorValue) JSValue() js.Value {
 }
 
 // NodeListEntryIteratorValueFromJS is allocating a new
-// NodeListEntryIteratorValue object and copy all values from
-// input javascript object
-func NodeListEntryIteratorValueFromJS(value js.Wrapper) *NodeListEntryIteratorValue {
-	input := value.JSValue()
+// NodeListEntryIteratorValue object and copy all values in the value javascript object.
+func NodeListEntryIteratorValueFromJS(value js.Value) *NodeListEntryIteratorValue {
 	var out NodeListEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -432,7 +427,7 @@ type NodeListKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -444,18 +439,16 @@ func (_this *NodeListKeyIteratorValue) JSValue() js.Value {
 }
 
 // NodeListKeyIteratorValueFromJS is allocating a new
-// NodeListKeyIteratorValue object and copy all values from
-// input javascript object
-func NodeListKeyIteratorValueFromJS(value js.Wrapper) *NodeListKeyIteratorValue {
-	input := value.JSValue()
+// NodeListKeyIteratorValue object and copy all values in the value javascript object.
+func NodeListKeyIteratorValueFromJS(value js.Value) *NodeListKeyIteratorValue {
 	var out NodeListKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -466,7 +459,7 @@ type NodeListValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NodeListValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -478,18 +471,16 @@ func (_this *NodeListValueIteratorValue) JSValue() js.Value {
 }
 
 // NodeListValueIteratorValueFromJS is allocating a new
-// NodeListValueIteratorValue object and copy all values from
-// input javascript object
-func NodeListValueIteratorValueFromJS(value js.Wrapper) *NodeListValueIteratorValue {
-	input := value.JSValue()
+// NodeListValueIteratorValue object and copy all values in the value javascript object.
+func NodeListValueIteratorValueFromJS(value js.Value) *NodeListValueIteratorValue {
 	var out NodeListValueIteratorValue
 	var (
 		value0 *Node // javascript: Node {value Value value}
 		value1 bool  // javascript: boolean {done Done done}
 	)
-	value0 = NodeFromJS(input.Get("value"))
+	value0 = NodeFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -499,7 +490,7 @@ type ShadowRootInit struct {
 	Mode ShadowRootMode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ShadowRootInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -509,15 +500,13 @@ func (_this *ShadowRootInit) JSValue() js.Value {
 }
 
 // ShadowRootInitFromJS is allocating a new
-// ShadowRootInit object and copy all values from
-// input javascript object
-func ShadowRootInitFromJS(value js.Wrapper) *ShadowRootInit {
-	input := value.JSValue()
+// ShadowRootInit object and copy all values in the value javascript object.
+func ShadowRootInitFromJS(value js.Value) *ShadowRootInit {
 	var out ShadowRootInit
 	var (
 		value0 ShadowRootMode // javascript: ShadowRootMode {mode Mode mode}
 	)
-	value0 = ShadowRootModeFromJS(input.Get("mode"))
+	value0 = ShadowRootModeFromJS(value.Get("mode"))
 	out.Mode = value0
 	return &out
 }
@@ -532,15 +521,19 @@ func (_this *AbstractRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AbstractRangeFromJS is casting a js.Wrapper into AbstractRange.
-func AbstractRangeFromJS(value js.Wrapper) *AbstractRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbstractRangeFromJS is casting a js.Value into AbstractRange.
+func AbstractRangeFromJS(value js.Value) *AbstractRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbstractRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbstractRangeFromJS is casting from something that holds a js.Value into AbstractRange.
+func AbstractRangeFromWrapper(input core.Wrapper) *AbstractRange {
+	return AbstractRangeFromJS(input.JSValue())
 }
 
 // StartContainer returning attribute 'startContainer' with
@@ -593,15 +586,19 @@ type Attr struct {
 	Node
 }
 
-// AttrFromJS is casting a js.Wrapper into Attr.
-func AttrFromJS(value js.Wrapper) *Attr {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AttrFromJS is casting a js.Value into Attr.
+func AttrFromJS(value js.Value) *Attr {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Attr{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AttrFromJS is casting from something that holds a js.Value into Attr.
+func AttrFromWrapper(input core.Wrapper) *Attr {
+	return AttrFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -687,15 +684,19 @@ type CDATASection struct {
 	Text
 }
 
-// CDATASectionFromJS is casting a js.Wrapper into CDATASection.
-func CDATASectionFromJS(value js.Wrapper) *CDATASection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CDATASectionFromJS is casting a js.Value into CDATASection.
+func CDATASectionFromJS(value js.Value) *CDATASection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CDATASection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CDATASectionFromJS is casting from something that holds a js.Value into CDATASection.
+func CDATASectionFromWrapper(input core.Wrapper) *CDATASection {
+	return CDATASectionFromJS(input.JSValue())
 }
 
 // class: CharacterData
@@ -703,15 +704,19 @@ type CharacterData struct {
 	Node
 }
 
-// CharacterDataFromJS is casting a js.Wrapper into CharacterData.
-func CharacterDataFromJS(value js.Wrapper) *CharacterData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CharacterDataFromJS is casting a js.Value into CharacterData.
+func CharacterDataFromJS(value js.Value) *CharacterData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CharacterData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CharacterDataFromJS is casting from something that holds a js.Value into CharacterData.
+func CharacterDataFromWrapper(input core.Wrapper) *CharacterData {
+	return CharacterDataFromJS(input.JSValue())
 }
 
 // Data returning attribute 'data' with
@@ -897,15 +902,19 @@ type Comment struct {
 	CharacterData
 }
 
-// CommentFromJS is casting a js.Wrapper into Comment.
-func CommentFromJS(value js.Wrapper) *Comment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CommentFromJS is casting a js.Value into Comment.
+func CommentFromJS(value js.Value) *Comment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Comment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CommentFromJS is casting from something that holds a js.Value into Comment.
+func CommentFromWrapper(input core.Wrapper) *Comment {
+	return CommentFromJS(input.JSValue())
 }
 
 func NewComment(data *string) (_result *Comment) {
@@ -944,15 +953,19 @@ func (_this *DeadFragmentInformation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DeadFragmentInformationFromJS is casting a js.Wrapper into DeadFragmentInformation.
-func DeadFragmentInformationFromJS(value js.Wrapper) *DeadFragmentInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeadFragmentInformationFromJS is casting a js.Value into DeadFragmentInformation.
+func DeadFragmentInformationFromJS(value js.Value) *DeadFragmentInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeadFragmentInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeadFragmentInformationFromJS is casting from something that holds a js.Value into DeadFragmentInformation.
+func DeadFragmentInformationFromWrapper(input core.Wrapper) *DeadFragmentInformation {
+	return DeadFragmentInformationFromJS(input.JSValue())
 }
 
 // Node returning attribute 'node' with
@@ -1069,15 +1082,19 @@ type DocumentFragment struct {
 	Node
 }
 
-// DocumentFragmentFromJS is casting a js.Wrapper into DocumentFragment.
-func DocumentFragmentFromJS(value js.Wrapper) *DocumentFragment {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentFragmentFromJS is casting a js.Value into DocumentFragment.
+func DocumentFragmentFromJS(value js.Value) *DocumentFragment {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentFragment{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentFragmentFromJS is casting from something that holds a js.Value into DocumentFragment.
+func DocumentFragmentFromWrapper(input core.Wrapper) *DocumentFragment {
+	return DocumentFragmentFromJS(input.JSValue())
 }
 
 func NewDocumentFragment() (_result *DocumentFragment) {
@@ -1223,15 +1240,19 @@ type DocumentType struct {
 	Node
 }
 
-// DocumentTypeFromJS is casting a js.Wrapper into DocumentType.
-func DocumentTypeFromJS(value js.Wrapper) *DocumentType {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentTypeFromJS is casting a js.Value into DocumentType.
+func DocumentTypeFromJS(value js.Value) *DocumentType {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DocumentType{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentTypeFromJS is casting from something that holds a js.Value into DocumentType.
+func DocumentTypeFromWrapper(input core.Wrapper) *DocumentType {
+	return DocumentTypeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1317,15 +1338,19 @@ type Element struct {
 	Node
 }
 
-// ElementFromJS is casting a js.Wrapper into Element.
-func ElementFromJS(value js.Wrapper) *Element {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ElementFromJS is casting a js.Value into Element.
+func ElementFromJS(value js.Value) *Element {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Element{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ElementFromJS is casting from something that holds a js.Value into Element.
+func ElementFromWrapper(input core.Wrapper) *Element {
+	return ElementFromJS(input.JSValue())
 }
 
 // NamespaceURI returning attribute 'namespaceURI' with
@@ -3844,15 +3869,19 @@ func (_this *HTMLCollection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HTMLCollectionFromJS is casting a js.Wrapper into HTMLCollection.
-func HTMLCollectionFromJS(value js.Wrapper) *HTMLCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLCollectionFromJS is casting a js.Value into HTMLCollection.
+func HTMLCollectionFromJS(value js.Value) *HTMLCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLCollectionFromJS is casting from something that holds a js.Value into HTMLCollection.
+func HTMLCollectionFromWrapper(input core.Wrapper) *HTMLCollection {
+	return HTMLCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -3950,15 +3979,19 @@ func (_this *NamedNodeMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NamedNodeMapFromJS is casting a js.Wrapper into NamedNodeMap.
-func NamedNodeMapFromJS(value js.Wrapper) *NamedNodeMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NamedNodeMapFromJS is casting a js.Value into NamedNodeMap.
+func NamedNodeMapFromJS(value js.Value) *NamedNodeMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NamedNodeMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NamedNodeMapFromJS is casting from something that holds a js.Value into NamedNodeMap.
+func NamedNodeMapFromWrapper(input core.Wrapper) *NamedNodeMap {
+	return NamedNodeMapFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -4160,15 +4193,19 @@ type Node struct {
 	domcore.EventTarget
 }
 
-// NodeFromJS is casting a js.Wrapper into Node.
-func NodeFromJS(value js.Wrapper) *Node {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeFromJS is casting a js.Value into Node.
+func NodeFromJS(value js.Value) *Node {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Node{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeFromJS is casting from something that holds a js.Value into Node.
+func NodeFromWrapper(input core.Wrapper) *Node {
+	return NodeFromJS(input.JSValue())
 }
 
 const (
@@ -4669,7 +4706,7 @@ type NodeFilter interface {
 }
 
 // NodeFilterValue is javascript reference value for callback interface NodeFilter.
-// This is holding the underlaying javascript object.
+// This is holding the underlying javascript object.
 type NodeFilterValue struct {
 	// Value is the underlying javascript object or function.
 	Value js.Value
@@ -4721,15 +4758,18 @@ func NewNodeFilterFunc(f func(node *Node) (_result int)) *NodeFilterValue {
 // NodeFilterFromJS is taking an javascript object that reference to a
 // callback interface and return a corresponding interface that can be used
 // to invoke on that element.
-func NodeFilterFromJS(value js.Wrapper) *NodeFilterValue {
-	input := value.JSValue()
-	if input.Type() == js.TypeObject {
-		return &NodeFilterValue{Value: input}
+func NodeFilterFromJS(value js.Value) *NodeFilterValue {
+	if value.Type() == js.TypeObject {
+		return &NodeFilterValue{Value: value}
 	}
-	if input.Type() == js.TypeFunction {
-		return &NodeFilterValue{Value: input, useInvoke: true}
+	if value.Type() == js.TypeFunction {
+		return &NodeFilterValue{Value: value, useInvoke: true}
 	}
 	panic("unsupported type")
+}
+
+func NodeFilterFromWrapper(input core.Wrapper) *NodeFilterValue {
+	return NodeFilterFromJS(input.JSValue())
 }
 
 func (t *NodeFilterValue) allocateAcceptNode() js.Func {
@@ -4789,15 +4829,19 @@ func (_this *NodeIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeIteratorFromJS is casting a js.Wrapper into NodeIterator.
-func NodeIteratorFromJS(value js.Wrapper) *NodeIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeIteratorFromJS is casting a js.Value into NodeIterator.
+func NodeIteratorFromJS(value js.Value) *NodeIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeIteratorFromJS is casting from something that holds a js.Value into NodeIterator.
+func NodeIteratorFromWrapper(input core.Wrapper) *NodeIterator {
+	return NodeIteratorFromJS(input.JSValue())
 }
 
 // Root returning attribute 'root' with
@@ -4898,15 +4942,19 @@ func (_this *NodeList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListFromJS is casting a js.Wrapper into NodeList.
-func NodeListFromJS(value js.Wrapper) *NodeList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListFromJS is casting a js.Value into NodeList.
+func NodeListFromJS(value js.Value) *NodeList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListFromJS is casting from something that holds a js.Value into NodeList.
+func NodeListFromWrapper(input core.Wrapper) *NodeList {
+	return NodeListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5032,15 +5080,19 @@ func (_this *NodeListEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListEntryIteratorFromJS is casting a js.Wrapper into NodeListEntryIterator.
-func NodeListEntryIteratorFromJS(value js.Wrapper) *NodeListEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListEntryIteratorFromJS is casting a js.Value into NodeListEntryIterator.
+func NodeListEntryIteratorFromJS(value js.Value) *NodeListEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListEntryIteratorFromJS is casting from something that holds a js.Value into NodeListEntryIterator.
+func NodeListEntryIteratorFromWrapper(input core.Wrapper) *NodeListEntryIterator {
+	return NodeListEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListEntryIterator) Next() (_result *NodeListEntryIteratorValue) {
@@ -5067,15 +5119,19 @@ func (_this *NodeListKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListKeyIteratorFromJS is casting a js.Wrapper into NodeListKeyIterator.
-func NodeListKeyIteratorFromJS(value js.Wrapper) *NodeListKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListKeyIteratorFromJS is casting a js.Value into NodeListKeyIterator.
+func NodeListKeyIteratorFromJS(value js.Value) *NodeListKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListKeyIteratorFromJS is casting from something that holds a js.Value into NodeListKeyIterator.
+func NodeListKeyIteratorFromWrapper(input core.Wrapper) *NodeListKeyIterator {
+	return NodeListKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListKeyIterator) Next() (_result *NodeListKeyIteratorValue) {
@@ -5102,15 +5158,19 @@ func (_this *NodeListValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NodeListValueIteratorFromJS is casting a js.Wrapper into NodeListValueIterator.
-func NodeListValueIteratorFromJS(value js.Wrapper) *NodeListValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NodeListValueIteratorFromJS is casting a js.Value into NodeListValueIterator.
+func NodeListValueIteratorFromJS(value js.Value) *NodeListValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NodeListValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NodeListValueIteratorFromJS is casting from something that holds a js.Value into NodeListValueIterator.
+func NodeListValueIteratorFromWrapper(input core.Wrapper) *NodeListValueIterator {
+	return NodeListValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *NodeListValueIterator) Next() (_result *NodeListValueIteratorValue) {
@@ -5132,15 +5192,19 @@ type ProcessingInstruction struct {
 	CharacterData
 }
 
-// ProcessingInstructionFromJS is casting a js.Wrapper into ProcessingInstruction.
-func ProcessingInstructionFromJS(value js.Wrapper) *ProcessingInstruction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProcessingInstructionFromJS is casting a js.Value into ProcessingInstruction.
+func ProcessingInstructionFromJS(value js.Value) *ProcessingInstruction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ProcessingInstruction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProcessingInstructionFromJS is casting from something that holds a js.Value into ProcessingInstruction.
+func ProcessingInstructionFromWrapper(input core.Wrapper) *ProcessingInstruction {
+	return ProcessingInstructionFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -5173,15 +5237,19 @@ func (_this *PromiseDeadFragmentInformation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDeadFragmentInformationFromJS is casting a js.Wrapper into PromiseDeadFragmentInformation.
-func PromiseDeadFragmentInformationFromJS(value js.Wrapper) *PromiseDeadFragmentInformation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDeadFragmentInformationFromJS is casting a js.Value into PromiseDeadFragmentInformation.
+func PromiseDeadFragmentInformationFromJS(value js.Value) *PromiseDeadFragmentInformation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDeadFragmentInformation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDeadFragmentInformationFromJS is casting from something that holds a js.Value into PromiseDeadFragmentInformation.
+func PromiseDeadFragmentInformationFromWrapper(input core.Wrapper) *PromiseDeadFragmentInformation {
+	return PromiseDeadFragmentInformationFromJS(input.JSValue())
 }
 
 func (_this *PromiseDeadFragmentInformation) Then(onFulfilled *PromiseDeadFragmentInformationOnFulfilled, onRejected *PromiseDeadFragmentInformationOnRejected) (_result *PromiseDeadFragmentInformation) {
@@ -5273,15 +5341,19 @@ type Range struct {
 	AbstractRange
 }
 
-// RangeFromJS is casting a js.Wrapper into Range.
-func RangeFromJS(value js.Wrapper) *Range {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RangeFromJS is casting a js.Value into Range.
+func RangeFromJS(value js.Value) *Range {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Range{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RangeFromJS is casting from something that holds a js.Value into Range.
+func RangeFromWrapper(input core.Wrapper) *Range {
+	return RangeFromJS(input.JSValue())
 }
 
 const (
@@ -5662,15 +5734,19 @@ type ShadowRoot struct {
 	DocumentFragment
 }
 
-// ShadowRootFromJS is casting a js.Wrapper into ShadowRoot.
-func ShadowRootFromJS(value js.Wrapper) *ShadowRoot {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShadowRootFromJS is casting a js.Value into ShadowRoot.
+func ShadowRootFromJS(value js.Value) *ShadowRoot {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShadowRoot{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShadowRootFromJS is casting from something that holds a js.Value into ShadowRoot.
+func ShadowRootFromWrapper(input core.Wrapper) *ShadowRoot {
+	return ShadowRootFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -5738,15 +5814,19 @@ type StaticRange struct {
 	AbstractRange
 }
 
-// StaticRangeFromJS is casting a js.Wrapper into StaticRange.
-func StaticRangeFromJS(value js.Wrapper) *StaticRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StaticRangeFromJS is casting a js.Value into StaticRange.
+func StaticRangeFromJS(value js.Value) *StaticRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StaticRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StaticRangeFromJS is casting from something that holds a js.Value into StaticRange.
+func StaticRangeFromWrapper(input core.Wrapper) *StaticRange {
+	return StaticRangeFromJS(input.JSValue())
 }
 
 // class: Text
@@ -5754,15 +5834,19 @@ type Text struct {
 	CharacterData
 }
 
-// TextFromJS is casting a js.Wrapper into Text.
-func TextFromJS(value js.Wrapper) *Text {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextFromJS is casting a js.Value into Text.
+func TextFromJS(value js.Value) *Text {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Text{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextFromJS is casting from something that holds a js.Value into Text.
+func TextFromWrapper(input core.Wrapper) *Text {
+	return TextFromJS(input.JSValue())
 }
 
 func NewText(data *string) (_result *Text) {
@@ -5938,15 +6022,19 @@ func (_this *TreeWalker) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TreeWalkerFromJS is casting a js.Wrapper into TreeWalker.
-func TreeWalkerFromJS(value js.Wrapper) *TreeWalker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TreeWalkerFromJS is casting a js.Value into TreeWalker.
+func TreeWalkerFromJS(value js.Value) *TreeWalker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TreeWalker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TreeWalkerFromJS is casting from something that holds a js.Value into TreeWalker.
+func TreeWalkerFromWrapper(input core.Wrapper) *TreeWalker {
+	return TreeWalkerFromJS(input.JSValue())
 }
 
 // Root returning attribute 'root' with

--- a/dom/domcore/domcore.go
+++ b/dom/domcore/domcore.go
@@ -7,6 +7,7 @@ package domcore
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -188,7 +189,7 @@ type AddEventListenerOptions struct {
 	Once    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddEventListenerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -202,21 +203,19 @@ func (_this *AddEventListenerOptions) JSValue() js.Value {
 }
 
 // AddEventListenerOptionsFromJS is allocating a new
-// AddEventListenerOptions object and copy all values from
-// input javascript object
-func AddEventListenerOptionsFromJS(value js.Wrapper) *AddEventListenerOptions {
-	input := value.JSValue()
+// AddEventListenerOptions object and copy all values in the value javascript object.
+func AddEventListenerOptionsFromJS(value js.Value) *AddEventListenerOptions {
 	var out AddEventListenerOptions
 	var (
 		value0 bool // javascript: boolean {capture Capture capture}
 		value1 bool // javascript: boolean {passive Passive passive}
 		value2 bool // javascript: boolean {once Once once}
 	)
-	value0 = (input.Get("capture")).Bool()
+	value0 = (value.Get("capture")).Bool()
 	out.Capture = value0
-	value1 = (input.Get("passive")).Bool()
+	value1 = (value.Get("passive")).Bool()
 	out.Passive = value1
-	value2 = (input.Get("once")).Bool()
+	value2 = (value.Get("once")).Bool()
 	out.Once = value2
 	return &out
 }
@@ -229,7 +228,7 @@ type CustomEventInit struct {
 	Detail     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CustomEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -245,10 +244,8 @@ func (_this *CustomEventInit) JSValue() js.Value {
 }
 
 // CustomEventInitFromJS is allocating a new
-// CustomEventInit object and copy all values from
-// input javascript object
-func CustomEventInitFromJS(value js.Wrapper) *CustomEventInit {
-	input := value.JSValue()
+// CustomEventInit object and copy all values in the value javascript object.
+func CustomEventInitFromJS(value js.Value) *CustomEventInit {
 	var out CustomEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -256,13 +253,13 @@ func CustomEventInitFromJS(value js.Wrapper) *CustomEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {detail Detail detail}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("detail")
+	value3 = value.Get("detail")
 	out.Detail = value3
 	return &out
 }
@@ -273,7 +270,7 @@ type DOMTokenListEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -289,26 +286,24 @@ func (_this *DOMTokenListEntryIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListEntryIteratorValueFromJS is allocating a new
-// DOMTokenListEntryIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListEntryIteratorValueFromJS(value js.Wrapper) *DOMTokenListEntryIteratorValue {
-	input := value.JSValue()
+// DOMTokenListEntryIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListEntryIteratorValueFromJS(value js.Value) *DOMTokenListEntryIteratorValue {
 	var out DOMTokenListEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -319,7 +314,7 @@ type DOMTokenListKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -331,18 +326,16 @@ func (_this *DOMTokenListKeyIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListKeyIteratorValueFromJS is allocating a new
-// DOMTokenListKeyIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListKeyIteratorValueFromJS(value js.Wrapper) *DOMTokenListKeyIteratorValue {
-	input := value.JSValue()
+// DOMTokenListKeyIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListKeyIteratorValueFromJS(value js.Value) *DOMTokenListKeyIteratorValue {
 	var out DOMTokenListKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -353,7 +346,7 @@ type DOMTokenListValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -365,18 +358,16 @@ func (_this *DOMTokenListValueIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListValueIteratorValueFromJS is allocating a new
-// DOMTokenListValueIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListValueIteratorValueFromJS(value js.Wrapper) *DOMTokenListValueIteratorValue {
-	input := value.JSValue()
+// DOMTokenListValueIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListValueIteratorValueFromJS(value js.Value) *DOMTokenListValueIteratorValue {
 	var out DOMTokenListValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -388,7 +379,7 @@ type EventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -402,21 +393,19 @@ func (_this *EventInit) JSValue() js.Value {
 }
 
 // EventInitFromJS is allocating a new
-// EventInit object and copy all values from
-// input javascript object
-func EventInitFromJS(value js.Wrapper) *EventInit {
-	input := value.JSValue()
+// EventInit object and copy all values in the value javascript object.
+func EventInitFromJS(value js.Value) *EventInit {
 	var out EventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -426,7 +415,7 @@ type EventListenerOptions struct {
 	Capture bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventListenerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -436,15 +425,13 @@ func (_this *EventListenerOptions) JSValue() js.Value {
 }
 
 // EventListenerOptionsFromJS is allocating a new
-// EventListenerOptions object and copy all values from
-// input javascript object
-func EventListenerOptionsFromJS(value js.Wrapper) *EventListenerOptions {
-	input := value.JSValue()
+// EventListenerOptions object and copy all values in the value javascript object.
+func EventListenerOptionsFromJS(value js.Value) *EventListenerOptions {
 	var out EventListenerOptions
 	var (
 		value0 bool // javascript: boolean {capture Capture capture}
 	)
-	value0 = (input.Get("capture")).Bool()
+	value0 = (value.Get("capture")).Bool()
 	out.Capture = value0
 	return &out
 }
@@ -456,7 +443,7 @@ type ExtendableEventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -470,21 +457,19 @@ func (_this *ExtendableEventInit) JSValue() js.Value {
 }
 
 // ExtendableEventInitFromJS is allocating a new
-// ExtendableEventInit object and copy all values from
-// input javascript object
-func ExtendableEventInitFromJS(value js.Wrapper) *ExtendableEventInit {
-	input := value.JSValue()
+// ExtendableEventInit object and copy all values in the value javascript object.
+func ExtendableEventInitFromJS(value js.Value) *ExtendableEventInit {
 	var out ExtendableEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -499,15 +484,19 @@ func (_this *AbortController) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AbortControllerFromJS is casting a js.Wrapper into AbortController.
-func AbortControllerFromJS(value js.Wrapper) *AbortController {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbortControllerFromJS is casting a js.Value into AbortController.
+func AbortControllerFromJS(value js.Value) *AbortController {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbortController{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbortControllerFromJS is casting from something that holds a js.Value into AbortController.
+func AbortControllerFromWrapper(input core.Wrapper) *AbortController {
+	return AbortControllerFromJS(input.JSValue())
 }
 
 func NewAbortController() (_result *AbortController) {
@@ -548,15 +537,19 @@ type AbortSignal struct {
 	EventTarget
 }
 
-// AbortSignalFromJS is casting a js.Wrapper into AbortSignal.
-func AbortSignalFromJS(value js.Wrapper) *AbortSignal {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbortSignalFromJS is casting a js.Value into AbortSignal.
+func AbortSignalFromJS(value js.Value) *AbortSignal {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbortSignal{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbortSignalFromJS is casting from something that holds a js.Value into AbortSignal.
+func AbortSignalFromWrapper(input core.Wrapper) *AbortSignal {
+	return AbortSignalFromJS(input.JSValue())
 }
 
 // Aborted returning attribute 'aborted' with
@@ -614,15 +607,19 @@ type CustomEvent struct {
 	Event
 }
 
-// CustomEventFromJS is casting a js.Wrapper into CustomEvent.
-func CustomEventFromJS(value js.Wrapper) *CustomEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CustomEventFromJS is casting a js.Value into CustomEvent.
+func CustomEventFromJS(value js.Value) *CustomEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CustomEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CustomEventFromJS is casting from something that holds a js.Value into CustomEvent.
+func CustomEventFromWrapper(input core.Wrapper) *CustomEvent {
+	return CustomEventFromJS(input.JSValue())
 }
 
 func NewCustomEvent(_type string, eventInitDict *CustomEventInit) (_result *CustomEvent) {
@@ -706,15 +703,19 @@ func (_this *DOMException) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMExceptionFromJS is casting a js.Wrapper into DOMException.
-func DOMExceptionFromJS(value js.Wrapper) *DOMException {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMExceptionFromJS is casting a js.Value into DOMException.
+func DOMExceptionFromJS(value js.Value) *DOMException {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMException{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMExceptionFromJS is casting from something that holds a js.Value into DOMException.
+func DOMExceptionFromWrapper(input core.Wrapper) *DOMException {
+	return DOMExceptionFromJS(input.JSValue())
 }
 
 const (
@@ -819,15 +820,19 @@ func (_this *DOMStringList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMStringListFromJS is casting a js.Wrapper into DOMStringList.
-func DOMStringListFromJS(value js.Wrapper) *DOMStringList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMStringListFromJS is casting a js.Value into DOMStringList.
+func DOMStringListFromJS(value js.Value) *DOMStringList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMStringList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMStringListFromJS is casting from something that holds a js.Value into DOMStringList.
+func DOMStringListFromWrapper(input core.Wrapper) *DOMStringList {
+	return DOMStringListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -906,15 +911,19 @@ func (_this *DOMStringMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMStringMapFromJS is casting a js.Wrapper into DOMStringMap.
-func DOMStringMapFromJS(value js.Wrapper) *DOMStringMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMStringMapFromJS is casting a js.Value into DOMStringMap.
+func DOMStringMapFromJS(value js.Value) *DOMStringMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMStringMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMStringMapFromJS is casting from something that holds a js.Value into DOMStringMap.
+func DOMStringMapFromWrapper(input core.Wrapper) *DOMStringMap {
+	return DOMStringMapFromJS(input.JSValue())
 }
 
 func (_this *DOMStringMap) Get(name string) (_result string) {
@@ -971,15 +980,19 @@ func (_this *DOMTokenList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListFromJS is casting a js.Wrapper into DOMTokenList.
-func DOMTokenListFromJS(value js.Wrapper) *DOMTokenList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListFromJS is casting a js.Value into DOMTokenList.
+func DOMTokenListFromJS(value js.Value) *DOMTokenList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListFromJS is casting from something that holds a js.Value into DOMTokenList.
+func DOMTokenListFromWrapper(input core.Wrapper) *DOMTokenList {
+	return DOMTokenListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1238,15 +1251,19 @@ func (_this *DOMTokenListEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListEntryIteratorFromJS is casting a js.Wrapper into DOMTokenListEntryIterator.
-func DOMTokenListEntryIteratorFromJS(value js.Wrapper) *DOMTokenListEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListEntryIteratorFromJS is casting a js.Value into DOMTokenListEntryIterator.
+func DOMTokenListEntryIteratorFromJS(value js.Value) *DOMTokenListEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListEntryIteratorFromJS is casting from something that holds a js.Value into DOMTokenListEntryIterator.
+func DOMTokenListEntryIteratorFromWrapper(input core.Wrapper) *DOMTokenListEntryIterator {
+	return DOMTokenListEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListEntryIterator) Next() (_result *DOMTokenListEntryIteratorValue) {
@@ -1273,15 +1290,19 @@ func (_this *DOMTokenListKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListKeyIteratorFromJS is casting a js.Wrapper into DOMTokenListKeyIterator.
-func DOMTokenListKeyIteratorFromJS(value js.Wrapper) *DOMTokenListKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListKeyIteratorFromJS is casting a js.Value into DOMTokenListKeyIterator.
+func DOMTokenListKeyIteratorFromJS(value js.Value) *DOMTokenListKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListKeyIteratorFromJS is casting from something that holds a js.Value into DOMTokenListKeyIterator.
+func DOMTokenListKeyIteratorFromWrapper(input core.Wrapper) *DOMTokenListKeyIterator {
+	return DOMTokenListKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListKeyIterator) Next() (_result *DOMTokenListKeyIteratorValue) {
@@ -1308,15 +1329,19 @@ func (_this *DOMTokenListValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListValueIteratorFromJS is casting a js.Wrapper into DOMTokenListValueIterator.
-func DOMTokenListValueIteratorFromJS(value js.Wrapper) *DOMTokenListValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListValueIteratorFromJS is casting a js.Value into DOMTokenListValueIterator.
+func DOMTokenListValueIteratorFromJS(value js.Value) *DOMTokenListValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListValueIteratorFromJS is casting from something that holds a js.Value into DOMTokenListValueIterator.
+func DOMTokenListValueIteratorFromWrapper(input core.Wrapper) *DOMTokenListValueIterator {
+	return DOMTokenListValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListValueIterator) Next() (_result *DOMTokenListValueIteratorValue) {
@@ -1343,15 +1368,19 @@ func (_this *Event) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventFromJS is casting a js.Wrapper into Event.
-func EventFromJS(value js.Wrapper) *Event {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventFromJS is casting a js.Value into Event.
+func EventFromJS(value js.Value) *Event {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Event{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventFromJS is casting from something that holds a js.Value into Event.
+func EventFromWrapper(input core.Wrapper) *Event {
+	return EventFromJS(input.JSValue())
 }
 
 const (
@@ -1610,7 +1639,7 @@ type EventListener interface {
 }
 
 // EventListenerValue is javascript reference value for callback interface EventListener.
-// This is holding the underlaying javascript object.
+// This is holding the underlying javascript object.
 type EventListenerValue struct {
 	// Value is the underlying javascript object or function.
 	Value js.Value
@@ -1662,15 +1691,18 @@ func NewEventListenerFunc(f func(event *Event)) *EventListenerValue {
 // EventListenerFromJS is taking an javascript object that reference to a
 // callback interface and return a corresponding interface that can be used
 // to invoke on that element.
-func EventListenerFromJS(value js.Wrapper) *EventListenerValue {
-	input := value.JSValue()
-	if input.Type() == js.TypeObject {
-		return &EventListenerValue{Value: input}
+func EventListenerFromJS(value js.Value) *EventListenerValue {
+	if value.Type() == js.TypeObject {
+		return &EventListenerValue{Value: value}
 	}
-	if input.Type() == js.TypeFunction {
-		return &EventListenerValue{Value: input, useInvoke: true}
+	if value.Type() == js.TypeFunction {
+		return &EventListenerValue{Value: value, useInvoke: true}
 	}
 	panic("unsupported type")
+}
+
+func EventListenerFromWrapper(input core.Wrapper) *EventListenerValue {
+	return EventListenerFromJS(input.JSValue())
 }
 
 func (t *EventListenerValue) allocateHandleEvent() js.Func {
@@ -1724,15 +1756,19 @@ func (_this *EventTarget) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventTargetFromJS is casting a js.Wrapper into EventTarget.
-func EventTargetFromJS(value js.Wrapper) *EventTarget {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventTargetFromJS is casting a js.Value into EventTarget.
+func EventTargetFromJS(value js.Value) *EventTarget {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventTarget{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventTargetFromJS is casting from something that holds a js.Value into EventTarget.
+func EventTargetFromWrapper(input core.Wrapper) *EventTarget {
+	return EventTargetFromJS(input.JSValue())
 }
 
 func NewEventTarget() (_result *EventTarget) {
@@ -1812,15 +1848,19 @@ type ExtendableEvent struct {
 	Event
 }
 
-// ExtendableEventFromJS is casting a js.Wrapper into ExtendableEvent.
-func ExtendableEventFromJS(value js.Wrapper) *ExtendableEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableEventFromJS is casting a js.Value into ExtendableEvent.
+func ExtendableEventFromJS(value js.Value) *ExtendableEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableEventFromJS is casting from something that holds a js.Value into ExtendableEvent.
+func ExtendableEventFromWrapper(input core.Wrapper) *ExtendableEvent {
+	return ExtendableEventFromJS(input.JSValue())
 }
 
 func NewExtendableEvent(_type string, eventInitDict *ExtendableEventInit) (_result *ExtendableEvent) {

--- a/dom/domcore/domcore_js.go
+++ b/dom/domcore/domcore_js.go
@@ -5,6 +5,7 @@ package domcore
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -186,7 +187,7 @@ type AddEventListenerOptions struct {
 	Once    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddEventListenerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -200,21 +201,19 @@ func (_this *AddEventListenerOptions) JSValue() js.Value {
 }
 
 // AddEventListenerOptionsFromJS is allocating a new
-// AddEventListenerOptions object and copy all values from
-// input javascript object
-func AddEventListenerOptionsFromJS(value js.Wrapper) *AddEventListenerOptions {
-	input := value.JSValue()
+// AddEventListenerOptions object and copy all values in the value javascript object.
+func AddEventListenerOptionsFromJS(value js.Value) *AddEventListenerOptions {
 	var out AddEventListenerOptions
 	var (
 		value0 bool // javascript: boolean {capture Capture capture}
 		value1 bool // javascript: boolean {passive Passive passive}
 		value2 bool // javascript: boolean {once Once once}
 	)
-	value0 = (input.Get("capture")).Bool()
+	value0 = (value.Get("capture")).Bool()
 	out.Capture = value0
-	value1 = (input.Get("passive")).Bool()
+	value1 = (value.Get("passive")).Bool()
 	out.Passive = value1
-	value2 = (input.Get("once")).Bool()
+	value2 = (value.Get("once")).Bool()
 	out.Once = value2
 	return &out
 }
@@ -227,7 +226,7 @@ type CustomEventInit struct {
 	Detail     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CustomEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -243,10 +242,8 @@ func (_this *CustomEventInit) JSValue() js.Value {
 }
 
 // CustomEventInitFromJS is allocating a new
-// CustomEventInit object and copy all values from
-// input javascript object
-func CustomEventInitFromJS(value js.Wrapper) *CustomEventInit {
-	input := value.JSValue()
+// CustomEventInit object and copy all values in the value javascript object.
+func CustomEventInitFromJS(value js.Value) *CustomEventInit {
 	var out CustomEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -254,13 +251,13 @@ func CustomEventInitFromJS(value js.Wrapper) *CustomEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {detail Detail detail}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("detail")
+	value3 = value.Get("detail")
 	out.Detail = value3
 	return &out
 }
@@ -271,7 +268,7 @@ type DOMTokenListEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -287,26 +284,24 @@ func (_this *DOMTokenListEntryIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListEntryIteratorValueFromJS is allocating a new
-// DOMTokenListEntryIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListEntryIteratorValueFromJS(value js.Wrapper) *DOMTokenListEntryIteratorValue {
-	input := value.JSValue()
+// DOMTokenListEntryIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListEntryIteratorValueFromJS(value js.Value) *DOMTokenListEntryIteratorValue {
 	var out DOMTokenListEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -317,7 +312,7 @@ type DOMTokenListKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -329,18 +324,16 @@ func (_this *DOMTokenListKeyIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListKeyIteratorValueFromJS is allocating a new
-// DOMTokenListKeyIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListKeyIteratorValueFromJS(value js.Wrapper) *DOMTokenListKeyIteratorValue {
-	input := value.JSValue()
+// DOMTokenListKeyIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListKeyIteratorValueFromJS(value js.Value) *DOMTokenListKeyIteratorValue {
 	var out DOMTokenListKeyIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -351,7 +344,7 @@ type DOMTokenListValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMTokenListValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -363,18 +356,16 @@ func (_this *DOMTokenListValueIteratorValue) JSValue() js.Value {
 }
 
 // DOMTokenListValueIteratorValueFromJS is allocating a new
-// DOMTokenListValueIteratorValue object and copy all values from
-// input javascript object
-func DOMTokenListValueIteratorValueFromJS(value js.Wrapper) *DOMTokenListValueIteratorValue {
-	input := value.JSValue()
+// DOMTokenListValueIteratorValue object and copy all values in the value javascript object.
+func DOMTokenListValueIteratorValueFromJS(value js.Value) *DOMTokenListValueIteratorValue {
 	var out DOMTokenListValueIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -386,7 +377,7 @@ type EventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -400,21 +391,19 @@ func (_this *EventInit) JSValue() js.Value {
 }
 
 // EventInitFromJS is allocating a new
-// EventInit object and copy all values from
-// input javascript object
-func EventInitFromJS(value js.Wrapper) *EventInit {
-	input := value.JSValue()
+// EventInit object and copy all values in the value javascript object.
+func EventInitFromJS(value js.Value) *EventInit {
 	var out EventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -424,7 +413,7 @@ type EventListenerOptions struct {
 	Capture bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventListenerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -434,15 +423,13 @@ func (_this *EventListenerOptions) JSValue() js.Value {
 }
 
 // EventListenerOptionsFromJS is allocating a new
-// EventListenerOptions object and copy all values from
-// input javascript object
-func EventListenerOptionsFromJS(value js.Wrapper) *EventListenerOptions {
-	input := value.JSValue()
+// EventListenerOptions object and copy all values in the value javascript object.
+func EventListenerOptionsFromJS(value js.Value) *EventListenerOptions {
 	var out EventListenerOptions
 	var (
 		value0 bool // javascript: boolean {capture Capture capture}
 	)
-	value0 = (input.Get("capture")).Bool()
+	value0 = (value.Get("capture")).Bool()
 	out.Capture = value0
 	return &out
 }
@@ -454,7 +441,7 @@ type ExtendableEventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -468,21 +455,19 @@ func (_this *ExtendableEventInit) JSValue() js.Value {
 }
 
 // ExtendableEventInitFromJS is allocating a new
-// ExtendableEventInit object and copy all values from
-// input javascript object
-func ExtendableEventInitFromJS(value js.Wrapper) *ExtendableEventInit {
-	input := value.JSValue()
+// ExtendableEventInit object and copy all values in the value javascript object.
+func ExtendableEventInitFromJS(value js.Value) *ExtendableEventInit {
 	var out ExtendableEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -497,15 +482,19 @@ func (_this *AbortController) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AbortControllerFromJS is casting a js.Wrapper into AbortController.
-func AbortControllerFromJS(value js.Wrapper) *AbortController {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbortControllerFromJS is casting a js.Value into AbortController.
+func AbortControllerFromJS(value js.Value) *AbortController {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbortController{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbortControllerFromJS is casting from something that holds a js.Value into AbortController.
+func AbortControllerFromWrapper(input core.Wrapper) *AbortController {
+	return AbortControllerFromJS(input.JSValue())
 }
 
 func NewAbortController() (_result *AbortController) {
@@ -546,15 +535,19 @@ type AbortSignal struct {
 	EventTarget
 }
 
-// AbortSignalFromJS is casting a js.Wrapper into AbortSignal.
-func AbortSignalFromJS(value js.Wrapper) *AbortSignal {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AbortSignalFromJS is casting a js.Value into AbortSignal.
+func AbortSignalFromJS(value js.Value) *AbortSignal {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AbortSignal{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AbortSignalFromJS is casting from something that holds a js.Value into AbortSignal.
+func AbortSignalFromWrapper(input core.Wrapper) *AbortSignal {
+	return AbortSignalFromJS(input.JSValue())
 }
 
 // Aborted returning attribute 'aborted' with
@@ -612,15 +605,19 @@ type CustomEvent struct {
 	Event
 }
 
-// CustomEventFromJS is casting a js.Wrapper into CustomEvent.
-func CustomEventFromJS(value js.Wrapper) *CustomEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CustomEventFromJS is casting a js.Value into CustomEvent.
+func CustomEventFromJS(value js.Value) *CustomEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CustomEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CustomEventFromJS is casting from something that holds a js.Value into CustomEvent.
+func CustomEventFromWrapper(input core.Wrapper) *CustomEvent {
+	return CustomEventFromJS(input.JSValue())
 }
 
 func NewCustomEvent(_type string, eventInitDict *CustomEventInit) (_result *CustomEvent) {
@@ -704,15 +701,19 @@ func (_this *DOMException) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMExceptionFromJS is casting a js.Wrapper into DOMException.
-func DOMExceptionFromJS(value js.Wrapper) *DOMException {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMExceptionFromJS is casting a js.Value into DOMException.
+func DOMExceptionFromJS(value js.Value) *DOMException {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMException{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMExceptionFromJS is casting from something that holds a js.Value into DOMException.
+func DOMExceptionFromWrapper(input core.Wrapper) *DOMException {
+	return DOMExceptionFromJS(input.JSValue())
 }
 
 const (
@@ -817,15 +818,19 @@ func (_this *DOMStringList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMStringListFromJS is casting a js.Wrapper into DOMStringList.
-func DOMStringListFromJS(value js.Wrapper) *DOMStringList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMStringListFromJS is casting a js.Value into DOMStringList.
+func DOMStringListFromJS(value js.Value) *DOMStringList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMStringList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMStringListFromJS is casting from something that holds a js.Value into DOMStringList.
+func DOMStringListFromWrapper(input core.Wrapper) *DOMStringList {
+	return DOMStringListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -904,15 +909,19 @@ func (_this *DOMStringMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMStringMapFromJS is casting a js.Wrapper into DOMStringMap.
-func DOMStringMapFromJS(value js.Wrapper) *DOMStringMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMStringMapFromJS is casting a js.Value into DOMStringMap.
+func DOMStringMapFromJS(value js.Value) *DOMStringMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMStringMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMStringMapFromJS is casting from something that holds a js.Value into DOMStringMap.
+func DOMStringMapFromWrapper(input core.Wrapper) *DOMStringMap {
+	return DOMStringMapFromJS(input.JSValue())
 }
 
 func (_this *DOMStringMap) Get(name string) (_result string) {
@@ -969,15 +978,19 @@ func (_this *DOMTokenList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListFromJS is casting a js.Wrapper into DOMTokenList.
-func DOMTokenListFromJS(value js.Wrapper) *DOMTokenList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListFromJS is casting a js.Value into DOMTokenList.
+func DOMTokenListFromJS(value js.Value) *DOMTokenList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListFromJS is casting from something that holds a js.Value into DOMTokenList.
+func DOMTokenListFromWrapper(input core.Wrapper) *DOMTokenList {
+	return DOMTokenListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1236,15 +1249,19 @@ func (_this *DOMTokenListEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListEntryIteratorFromJS is casting a js.Wrapper into DOMTokenListEntryIterator.
-func DOMTokenListEntryIteratorFromJS(value js.Wrapper) *DOMTokenListEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListEntryIteratorFromJS is casting a js.Value into DOMTokenListEntryIterator.
+func DOMTokenListEntryIteratorFromJS(value js.Value) *DOMTokenListEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListEntryIteratorFromJS is casting from something that holds a js.Value into DOMTokenListEntryIterator.
+func DOMTokenListEntryIteratorFromWrapper(input core.Wrapper) *DOMTokenListEntryIterator {
+	return DOMTokenListEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListEntryIterator) Next() (_result *DOMTokenListEntryIteratorValue) {
@@ -1271,15 +1288,19 @@ func (_this *DOMTokenListKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListKeyIteratorFromJS is casting a js.Wrapper into DOMTokenListKeyIterator.
-func DOMTokenListKeyIteratorFromJS(value js.Wrapper) *DOMTokenListKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListKeyIteratorFromJS is casting a js.Value into DOMTokenListKeyIterator.
+func DOMTokenListKeyIteratorFromJS(value js.Value) *DOMTokenListKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListKeyIteratorFromJS is casting from something that holds a js.Value into DOMTokenListKeyIterator.
+func DOMTokenListKeyIteratorFromWrapper(input core.Wrapper) *DOMTokenListKeyIterator {
+	return DOMTokenListKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListKeyIterator) Next() (_result *DOMTokenListKeyIteratorValue) {
@@ -1306,15 +1327,19 @@ func (_this *DOMTokenListValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMTokenListValueIteratorFromJS is casting a js.Wrapper into DOMTokenListValueIterator.
-func DOMTokenListValueIteratorFromJS(value js.Wrapper) *DOMTokenListValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMTokenListValueIteratorFromJS is casting a js.Value into DOMTokenListValueIterator.
+func DOMTokenListValueIteratorFromJS(value js.Value) *DOMTokenListValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMTokenListValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMTokenListValueIteratorFromJS is casting from something that holds a js.Value into DOMTokenListValueIterator.
+func DOMTokenListValueIteratorFromWrapper(input core.Wrapper) *DOMTokenListValueIterator {
+	return DOMTokenListValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *DOMTokenListValueIterator) Next() (_result *DOMTokenListValueIteratorValue) {
@@ -1341,15 +1366,19 @@ func (_this *Event) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventFromJS is casting a js.Wrapper into Event.
-func EventFromJS(value js.Wrapper) *Event {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventFromJS is casting a js.Value into Event.
+func EventFromJS(value js.Value) *Event {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Event{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventFromJS is casting from something that holds a js.Value into Event.
+func EventFromWrapper(input core.Wrapper) *Event {
+	return EventFromJS(input.JSValue())
 }
 
 const (
@@ -1608,7 +1637,7 @@ type EventListener interface {
 }
 
 // EventListenerValue is javascript reference value for callback interface EventListener.
-// This is holding the underlaying javascript object.
+// This is holding the underlying javascript object.
 type EventListenerValue struct {
 	// Value is the underlying javascript object or function.
 	Value js.Value
@@ -1660,15 +1689,18 @@ func NewEventListenerFunc(f func(event *Event)) *EventListenerValue {
 // EventListenerFromJS is taking an javascript object that reference to a
 // callback interface and return a corresponding interface that can be used
 // to invoke on that element.
-func EventListenerFromJS(value js.Wrapper) *EventListenerValue {
-	input := value.JSValue()
-	if input.Type() == js.TypeObject {
-		return &EventListenerValue{Value: input}
+func EventListenerFromJS(value js.Value) *EventListenerValue {
+	if value.Type() == js.TypeObject {
+		return &EventListenerValue{Value: value}
 	}
-	if input.Type() == js.TypeFunction {
-		return &EventListenerValue{Value: input, useInvoke: true}
+	if value.Type() == js.TypeFunction {
+		return &EventListenerValue{Value: value, useInvoke: true}
 	}
 	panic("unsupported type")
+}
+
+func EventListenerFromWrapper(input core.Wrapper) *EventListenerValue {
+	return EventListenerFromJS(input.JSValue())
 }
 
 func (t *EventListenerValue) allocateHandleEvent() js.Func {
@@ -1722,15 +1754,19 @@ func (_this *EventTarget) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventTargetFromJS is casting a js.Wrapper into EventTarget.
-func EventTargetFromJS(value js.Wrapper) *EventTarget {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventTargetFromJS is casting a js.Value into EventTarget.
+func EventTargetFromJS(value js.Value) *EventTarget {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventTarget{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventTargetFromJS is casting from something that holds a js.Value into EventTarget.
+func EventTargetFromWrapper(input core.Wrapper) *EventTarget {
+	return EventTargetFromJS(input.JSValue())
 }
 
 func NewEventTarget() (_result *EventTarget) {
@@ -1810,15 +1846,19 @@ type ExtendableEvent struct {
 	Event
 }
 
-// ExtendableEventFromJS is casting a js.Wrapper into ExtendableEvent.
-func ExtendableEventFromJS(value js.Wrapper) *ExtendableEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableEventFromJS is casting a js.Value into ExtendableEvent.
+func ExtendableEventFromJS(value js.Value) *ExtendableEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableEventFromJS is casting from something that holds a js.Value into ExtendableEvent.
+func ExtendableEventFromWrapper(input core.Wrapper) *ExtendableEvent {
+	return ExtendableEventFromJS(input.JSValue())
 }
 
 func NewExtendableEvent(_type string, eventInitDict *ExtendableEventInit) (_result *ExtendableEvent) {

--- a/dom/geometry/geometry.go
+++ b/dom/geometry/geometry.go
@@ -7,6 +7,7 @@ package geometry
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -54,7 +55,7 @@ type DOMMatrix2DInit struct {
 	M42 float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMMatrix2DInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -86,10 +87,8 @@ func (_this *DOMMatrix2DInit) JSValue() js.Value {
 }
 
 // DOMMatrix2DInitFromJS is allocating a new
-// DOMMatrix2DInit object and copy all values from
-// input javascript object
-func DOMMatrix2DInitFromJS(value js.Wrapper) *DOMMatrix2DInit {
-	input := value.JSValue()
+// DOMMatrix2DInit object and copy all values in the value javascript object.
+func DOMMatrix2DInitFromJS(value js.Value) *DOMMatrix2DInit {
 	var out DOMMatrix2DInit
 	var (
 		value0  float64 // javascript: unrestricted double {a A a}
@@ -105,29 +104,29 @@ func DOMMatrix2DInitFromJS(value js.Wrapper) *DOMMatrix2DInit {
 		value10 float64 // javascript: unrestricted double {m41 M41 m41}
 		value11 float64 // javascript: unrestricted double {m42 M42 m42}
 	)
-	value0 = (input.Get("a")).Float()
+	value0 = (value.Get("a")).Float()
 	out.A = value0
-	value1 = (input.Get("b")).Float()
+	value1 = (value.Get("b")).Float()
 	out.B = value1
-	value2 = (input.Get("c")).Float()
+	value2 = (value.Get("c")).Float()
 	out.C = value2
-	value3 = (input.Get("d")).Float()
+	value3 = (value.Get("d")).Float()
 	out.D = value3
-	value4 = (input.Get("e")).Float()
+	value4 = (value.Get("e")).Float()
 	out.E = value4
-	value5 = (input.Get("f")).Float()
+	value5 = (value.Get("f")).Float()
 	out.F = value5
-	value6 = (input.Get("m11")).Float()
+	value6 = (value.Get("m11")).Float()
 	out.M11 = value6
-	value7 = (input.Get("m12")).Float()
+	value7 = (value.Get("m12")).Float()
 	out.M12 = value7
-	value8 = (input.Get("m21")).Float()
+	value8 = (value.Get("m21")).Float()
 	out.M21 = value8
-	value9 = (input.Get("m22")).Float()
+	value9 = (value.Get("m22")).Float()
 	out.M22 = value9
-	value10 = (input.Get("m41")).Float()
+	value10 = (value.Get("m41")).Float()
 	out.M41 = value10
-	value11 = (input.Get("m42")).Float()
+	value11 = (value.Get("m42")).Float()
 	out.M42 = value11
 	return &out
 }
@@ -159,7 +158,7 @@ type DOMMatrixInit struct {
 	Is2D bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMMatrixInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -213,10 +212,8 @@ func (_this *DOMMatrixInit) JSValue() js.Value {
 }
 
 // DOMMatrixInitFromJS is allocating a new
-// DOMMatrixInit object and copy all values from
-// input javascript object
-func DOMMatrixInitFromJS(value js.Wrapper) *DOMMatrixInit {
-	input := value.JSValue()
+// DOMMatrixInit object and copy all values in the value javascript object.
+func DOMMatrixInitFromJS(value js.Value) *DOMMatrixInit {
 	var out DOMMatrixInit
 	var (
 		value0  float64 // javascript: unrestricted double {a A a}
@@ -243,51 +240,51 @@ func DOMMatrixInitFromJS(value js.Wrapper) *DOMMatrixInit {
 		value21 float64 // javascript: unrestricted double {m44 M44 m44}
 		value22 bool    // javascript: boolean {is2D Is2D is2D}
 	)
-	value0 = (input.Get("a")).Float()
+	value0 = (value.Get("a")).Float()
 	out.A = value0
-	value1 = (input.Get("b")).Float()
+	value1 = (value.Get("b")).Float()
 	out.B = value1
-	value2 = (input.Get("c")).Float()
+	value2 = (value.Get("c")).Float()
 	out.C = value2
-	value3 = (input.Get("d")).Float()
+	value3 = (value.Get("d")).Float()
 	out.D = value3
-	value4 = (input.Get("e")).Float()
+	value4 = (value.Get("e")).Float()
 	out.E = value4
-	value5 = (input.Get("f")).Float()
+	value5 = (value.Get("f")).Float()
 	out.F = value5
-	value6 = (input.Get("m11")).Float()
+	value6 = (value.Get("m11")).Float()
 	out.M11 = value6
-	value7 = (input.Get("m12")).Float()
+	value7 = (value.Get("m12")).Float()
 	out.M12 = value7
-	value8 = (input.Get("m21")).Float()
+	value8 = (value.Get("m21")).Float()
 	out.M21 = value8
-	value9 = (input.Get("m22")).Float()
+	value9 = (value.Get("m22")).Float()
 	out.M22 = value9
-	value10 = (input.Get("m41")).Float()
+	value10 = (value.Get("m41")).Float()
 	out.M41 = value10
-	value11 = (input.Get("m42")).Float()
+	value11 = (value.Get("m42")).Float()
 	out.M42 = value11
-	value12 = (input.Get("m13")).Float()
+	value12 = (value.Get("m13")).Float()
 	out.M13 = value12
-	value13 = (input.Get("m14")).Float()
+	value13 = (value.Get("m14")).Float()
 	out.M14 = value13
-	value14 = (input.Get("m23")).Float()
+	value14 = (value.Get("m23")).Float()
 	out.M23 = value14
-	value15 = (input.Get("m24")).Float()
+	value15 = (value.Get("m24")).Float()
 	out.M24 = value15
-	value16 = (input.Get("m31")).Float()
+	value16 = (value.Get("m31")).Float()
 	out.M31 = value16
-	value17 = (input.Get("m32")).Float()
+	value17 = (value.Get("m32")).Float()
 	out.M32 = value17
-	value18 = (input.Get("m33")).Float()
+	value18 = (value.Get("m33")).Float()
 	out.M33 = value18
-	value19 = (input.Get("m34")).Float()
+	value19 = (value.Get("m34")).Float()
 	out.M34 = value19
-	value20 = (input.Get("m43")).Float()
+	value20 = (value.Get("m43")).Float()
 	out.M43 = value20
-	value21 = (input.Get("m44")).Float()
+	value21 = (value.Get("m44")).Float()
 	out.M44 = value21
-	value22 = (input.Get("is2D")).Bool()
+	value22 = (value.Get("is2D")).Bool()
 	out.Is2D = value22
 	return &out
 }
@@ -300,7 +297,7 @@ type DOMPointInit struct {
 	W float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMPointInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -316,10 +313,8 @@ func (_this *DOMPointInit) JSValue() js.Value {
 }
 
 // DOMPointInitFromJS is allocating a new
-// DOMPointInit object and copy all values from
-// input javascript object
-func DOMPointInitFromJS(value js.Wrapper) *DOMPointInit {
-	input := value.JSValue()
+// DOMPointInit object and copy all values in the value javascript object.
+func DOMPointInitFromJS(value js.Value) *DOMPointInit {
 	var out DOMPointInit
 	var (
 		value0 float64 // javascript: unrestricted double {x X x}
@@ -327,13 +322,13 @@ func DOMPointInitFromJS(value js.Wrapper) *DOMPointInit {
 		value2 float64 // javascript: unrestricted double {z Z z}
 		value3 float64 // javascript: unrestricted double {w W w}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
-	value2 = (input.Get("z")).Float()
+	value2 = (value.Get("z")).Float()
 	out.Z = value2
-	value3 = (input.Get("w")).Float()
+	value3 = (value.Get("w")).Float()
 	out.W = value3
 	return &out
 }
@@ -346,7 +341,7 @@ type DOMQuadInit struct {
 	P4 *DOMPointInit
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMQuadInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -362,10 +357,8 @@ func (_this *DOMQuadInit) JSValue() js.Value {
 }
 
 // DOMQuadInitFromJS is allocating a new
-// DOMQuadInit object and copy all values from
-// input javascript object
-func DOMQuadInitFromJS(value js.Wrapper) *DOMQuadInit {
-	input := value.JSValue()
+// DOMQuadInit object and copy all values in the value javascript object.
+func DOMQuadInitFromJS(value js.Value) *DOMQuadInit {
 	var out DOMQuadInit
 	var (
 		value0 *DOMPointInit // javascript: DOMPointInit {p1 P1 p1}
@@ -373,13 +366,13 @@ func DOMQuadInitFromJS(value js.Wrapper) *DOMQuadInit {
 		value2 *DOMPointInit // javascript: DOMPointInit {p3 P3 p3}
 		value3 *DOMPointInit // javascript: DOMPointInit {p4 P4 p4}
 	)
-	value0 = DOMPointInitFromJS(input.Get("p1"))
+	value0 = DOMPointInitFromJS(value.Get("p1"))
 	out.P1 = value0
-	value1 = DOMPointInitFromJS(input.Get("p2"))
+	value1 = DOMPointInitFromJS(value.Get("p2"))
 	out.P2 = value1
-	value2 = DOMPointInitFromJS(input.Get("p3"))
+	value2 = DOMPointInitFromJS(value.Get("p3"))
 	out.P3 = value2
-	value3 = DOMPointInitFromJS(input.Get("p4"))
+	value3 = DOMPointInitFromJS(value.Get("p4"))
 	out.P4 = value3
 	return &out
 }
@@ -392,7 +385,7 @@ type DOMRectInit struct {
 	Height float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMRectInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -408,10 +401,8 @@ func (_this *DOMRectInit) JSValue() js.Value {
 }
 
 // DOMRectInitFromJS is allocating a new
-// DOMRectInit object and copy all values from
-// input javascript object
-func DOMRectInitFromJS(value js.Wrapper) *DOMRectInit {
-	input := value.JSValue()
+// DOMRectInit object and copy all values in the value javascript object.
+func DOMRectInitFromJS(value js.Value) *DOMRectInit {
 	var out DOMRectInit
 	var (
 		value0 float64 // javascript: unrestricted double {x X x}
@@ -419,13 +410,13 @@ func DOMRectInitFromJS(value js.Wrapper) *DOMRectInit {
 		value2 float64 // javascript: unrestricted double {width Width width}
 		value3 float64 // javascript: unrestricted double {height Height height}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
-	value2 = (input.Get("width")).Float()
+	value2 = (value.Get("width")).Float()
 	out.Width = value2
-	value3 = (input.Get("height")).Float()
+	value3 = (value.Get("height")).Float()
 	out.Height = value3
 	return &out
 }
@@ -435,15 +426,19 @@ type DOMMatrix struct {
 	DOMMatrixReadOnly
 }
 
-// DOMMatrixFromJS is casting a js.Wrapper into DOMMatrix.
-func DOMMatrixFromJS(value js.Wrapper) *DOMMatrix {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMMatrixFromJS is casting a js.Value into DOMMatrix.
+func DOMMatrixFromJS(value js.Value) *DOMMatrix {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMMatrix{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMMatrixFromJS is casting from something that holds a js.Value into DOMMatrix.
+func DOMMatrixFromWrapper(input core.Wrapper) *DOMMatrix {
+	return DOMMatrixFromJS(input.JSValue())
 }
 
 func FromMatrix(other *DOMMatrixInit) (_result *DOMMatrix) {
@@ -1332,15 +1327,19 @@ func (_this *DOMMatrixReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMMatrixReadOnlyFromJS is casting a js.Wrapper into DOMMatrixReadOnly.
-func DOMMatrixReadOnlyFromJS(value js.Wrapper) *DOMMatrixReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMMatrixReadOnlyFromJS is casting a js.Value into DOMMatrixReadOnly.
+func DOMMatrixReadOnlyFromJS(value js.Value) *DOMMatrixReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMMatrixReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMMatrixReadOnlyFromJS is casting from something that holds a js.Value into DOMMatrixReadOnly.
+func DOMMatrixReadOnlyFromWrapper(input core.Wrapper) *DOMMatrixReadOnly {
+	return DOMMatrixReadOnlyFromJS(input.JSValue())
 }
 
 func FromMatrix2(other *DOMMatrixInit) (_result *DOMMatrixReadOnly) {
@@ -2191,15 +2190,19 @@ type DOMPoint struct {
 	DOMPointReadOnly
 }
 
-// DOMPointFromJS is casting a js.Wrapper into DOMPoint.
-func DOMPointFromJS(value js.Wrapper) *DOMPoint {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMPointFromJS is casting a js.Value into DOMPoint.
+func DOMPointFromJS(value js.Value) *DOMPoint {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMPoint{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMPointFromJS is casting from something that holds a js.Value into DOMPoint.
+func DOMPointFromWrapper(input core.Wrapper) *DOMPoint {
+	return DOMPointFromJS(input.JSValue())
 }
 
 func FromPoint(other *DOMPointInit) (_result *DOMPoint) {
@@ -2356,15 +2359,19 @@ func (_this *DOMPointReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMPointReadOnlyFromJS is casting a js.Wrapper into DOMPointReadOnly.
-func DOMPointReadOnlyFromJS(value js.Wrapper) *DOMPointReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMPointReadOnlyFromJS is casting a js.Value into DOMPointReadOnly.
+func DOMPointReadOnlyFromJS(value js.Value) *DOMPointReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMPointReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMPointReadOnlyFromJS is casting from something that holds a js.Value into DOMPointReadOnly.
+func DOMPointReadOnlyFromWrapper(input core.Wrapper) *DOMPointReadOnly {
+	return DOMPointReadOnlyFromJS(input.JSValue())
 }
 
 func FromPoint2(other *DOMPointInit) (_result *DOMPointReadOnly) {
@@ -2526,15 +2533,19 @@ func (_this *DOMQuad) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMQuadFromJS is casting a js.Wrapper into DOMQuad.
-func DOMQuadFromJS(value js.Wrapper) *DOMQuad {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMQuadFromJS is casting a js.Value into DOMQuad.
+func DOMQuadFromJS(value js.Value) *DOMQuad {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMQuad{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMQuadFromJS is casting from something that holds a js.Value into DOMQuad.
+func DOMQuadFromWrapper(input core.Wrapper) *DOMQuad {
+	return DOMQuadFromJS(input.JSValue())
 }
 
 func FromRect(other *DOMRectInit) (_result *DOMQuad) {
@@ -2683,15 +2694,19 @@ type DOMRect struct {
 	DOMRectReadOnly
 }
 
-// DOMRectFromJS is casting a js.Wrapper into DOMRect.
-func DOMRectFromJS(value js.Wrapper) *DOMRect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectFromJS is casting a js.Value into DOMRect.
+func DOMRectFromJS(value js.Value) *DOMRect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectFromJS is casting from something that holds a js.Value into DOMRect.
+func DOMRectFromWrapper(input core.Wrapper) *DOMRect {
+	return DOMRectFromJS(input.JSValue())
 }
 
 func FromRect2(other *DOMRectInit) (_result *DOMRect) {
@@ -2848,15 +2863,19 @@ func (_this *DOMRectList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMRectListFromJS is casting a js.Wrapper into DOMRectList.
-func DOMRectListFromJS(value js.Wrapper) *DOMRectList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectListFromJS is casting a js.Value into DOMRectList.
+func DOMRectListFromJS(value js.Value) *DOMRectList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRectList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectListFromJS is casting from something that holds a js.Value into DOMRectList.
+func DOMRectListFromWrapper(input core.Wrapper) *DOMRectList {
+	return DOMRectListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2916,15 +2935,19 @@ func (_this *DOMRectReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMRectReadOnlyFromJS is casting a js.Wrapper into DOMRectReadOnly.
-func DOMRectReadOnlyFromJS(value js.Wrapper) *DOMRectReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectReadOnlyFromJS is casting a js.Value into DOMRectReadOnly.
+func DOMRectReadOnlyFromJS(value js.Value) *DOMRectReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRectReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectReadOnlyFromJS is casting from something that holds a js.Value into DOMRectReadOnly.
+func DOMRectReadOnlyFromWrapper(input core.Wrapper) *DOMRectReadOnly {
+	return DOMRectReadOnlyFromJS(input.JSValue())
 }
 
 func FromRect3(other *DOMRectInit) (_result *DOMRectReadOnly) {

--- a/dom/geometry/geometry_js.go
+++ b/dom/geometry/geometry_js.go
@@ -5,6 +5,7 @@ package geometry
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -52,7 +53,7 @@ type DOMMatrix2DInit struct {
 	M42 float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMMatrix2DInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -84,10 +85,8 @@ func (_this *DOMMatrix2DInit) JSValue() js.Value {
 }
 
 // DOMMatrix2DInitFromJS is allocating a new
-// DOMMatrix2DInit object and copy all values from
-// input javascript object
-func DOMMatrix2DInitFromJS(value js.Wrapper) *DOMMatrix2DInit {
-	input := value.JSValue()
+// DOMMatrix2DInit object and copy all values in the value javascript object.
+func DOMMatrix2DInitFromJS(value js.Value) *DOMMatrix2DInit {
 	var out DOMMatrix2DInit
 	var (
 		value0  float64 // javascript: unrestricted double {a A a}
@@ -103,29 +102,29 @@ func DOMMatrix2DInitFromJS(value js.Wrapper) *DOMMatrix2DInit {
 		value10 float64 // javascript: unrestricted double {m41 M41 m41}
 		value11 float64 // javascript: unrestricted double {m42 M42 m42}
 	)
-	value0 = (input.Get("a")).Float()
+	value0 = (value.Get("a")).Float()
 	out.A = value0
-	value1 = (input.Get("b")).Float()
+	value1 = (value.Get("b")).Float()
 	out.B = value1
-	value2 = (input.Get("c")).Float()
+	value2 = (value.Get("c")).Float()
 	out.C = value2
-	value3 = (input.Get("d")).Float()
+	value3 = (value.Get("d")).Float()
 	out.D = value3
-	value4 = (input.Get("e")).Float()
+	value4 = (value.Get("e")).Float()
 	out.E = value4
-	value5 = (input.Get("f")).Float()
+	value5 = (value.Get("f")).Float()
 	out.F = value5
-	value6 = (input.Get("m11")).Float()
+	value6 = (value.Get("m11")).Float()
 	out.M11 = value6
-	value7 = (input.Get("m12")).Float()
+	value7 = (value.Get("m12")).Float()
 	out.M12 = value7
-	value8 = (input.Get("m21")).Float()
+	value8 = (value.Get("m21")).Float()
 	out.M21 = value8
-	value9 = (input.Get("m22")).Float()
+	value9 = (value.Get("m22")).Float()
 	out.M22 = value9
-	value10 = (input.Get("m41")).Float()
+	value10 = (value.Get("m41")).Float()
 	out.M41 = value10
-	value11 = (input.Get("m42")).Float()
+	value11 = (value.Get("m42")).Float()
 	out.M42 = value11
 	return &out
 }
@@ -157,7 +156,7 @@ type DOMMatrixInit struct {
 	Is2D bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMMatrixInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -211,10 +210,8 @@ func (_this *DOMMatrixInit) JSValue() js.Value {
 }
 
 // DOMMatrixInitFromJS is allocating a new
-// DOMMatrixInit object and copy all values from
-// input javascript object
-func DOMMatrixInitFromJS(value js.Wrapper) *DOMMatrixInit {
-	input := value.JSValue()
+// DOMMatrixInit object and copy all values in the value javascript object.
+func DOMMatrixInitFromJS(value js.Value) *DOMMatrixInit {
 	var out DOMMatrixInit
 	var (
 		value0  float64 // javascript: unrestricted double {a A a}
@@ -241,51 +238,51 @@ func DOMMatrixInitFromJS(value js.Wrapper) *DOMMatrixInit {
 		value21 float64 // javascript: unrestricted double {m44 M44 m44}
 		value22 bool    // javascript: boolean {is2D Is2D is2D}
 	)
-	value0 = (input.Get("a")).Float()
+	value0 = (value.Get("a")).Float()
 	out.A = value0
-	value1 = (input.Get("b")).Float()
+	value1 = (value.Get("b")).Float()
 	out.B = value1
-	value2 = (input.Get("c")).Float()
+	value2 = (value.Get("c")).Float()
 	out.C = value2
-	value3 = (input.Get("d")).Float()
+	value3 = (value.Get("d")).Float()
 	out.D = value3
-	value4 = (input.Get("e")).Float()
+	value4 = (value.Get("e")).Float()
 	out.E = value4
-	value5 = (input.Get("f")).Float()
+	value5 = (value.Get("f")).Float()
 	out.F = value5
-	value6 = (input.Get("m11")).Float()
+	value6 = (value.Get("m11")).Float()
 	out.M11 = value6
-	value7 = (input.Get("m12")).Float()
+	value7 = (value.Get("m12")).Float()
 	out.M12 = value7
-	value8 = (input.Get("m21")).Float()
+	value8 = (value.Get("m21")).Float()
 	out.M21 = value8
-	value9 = (input.Get("m22")).Float()
+	value9 = (value.Get("m22")).Float()
 	out.M22 = value9
-	value10 = (input.Get("m41")).Float()
+	value10 = (value.Get("m41")).Float()
 	out.M41 = value10
-	value11 = (input.Get("m42")).Float()
+	value11 = (value.Get("m42")).Float()
 	out.M42 = value11
-	value12 = (input.Get("m13")).Float()
+	value12 = (value.Get("m13")).Float()
 	out.M13 = value12
-	value13 = (input.Get("m14")).Float()
+	value13 = (value.Get("m14")).Float()
 	out.M14 = value13
-	value14 = (input.Get("m23")).Float()
+	value14 = (value.Get("m23")).Float()
 	out.M23 = value14
-	value15 = (input.Get("m24")).Float()
+	value15 = (value.Get("m24")).Float()
 	out.M24 = value15
-	value16 = (input.Get("m31")).Float()
+	value16 = (value.Get("m31")).Float()
 	out.M31 = value16
-	value17 = (input.Get("m32")).Float()
+	value17 = (value.Get("m32")).Float()
 	out.M32 = value17
-	value18 = (input.Get("m33")).Float()
+	value18 = (value.Get("m33")).Float()
 	out.M33 = value18
-	value19 = (input.Get("m34")).Float()
+	value19 = (value.Get("m34")).Float()
 	out.M34 = value19
-	value20 = (input.Get("m43")).Float()
+	value20 = (value.Get("m43")).Float()
 	out.M43 = value20
-	value21 = (input.Get("m44")).Float()
+	value21 = (value.Get("m44")).Float()
 	out.M44 = value21
-	value22 = (input.Get("is2D")).Bool()
+	value22 = (value.Get("is2D")).Bool()
 	out.Is2D = value22
 	return &out
 }
@@ -298,7 +295,7 @@ type DOMPointInit struct {
 	W float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMPointInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -314,10 +311,8 @@ func (_this *DOMPointInit) JSValue() js.Value {
 }
 
 // DOMPointInitFromJS is allocating a new
-// DOMPointInit object and copy all values from
-// input javascript object
-func DOMPointInitFromJS(value js.Wrapper) *DOMPointInit {
-	input := value.JSValue()
+// DOMPointInit object and copy all values in the value javascript object.
+func DOMPointInitFromJS(value js.Value) *DOMPointInit {
 	var out DOMPointInit
 	var (
 		value0 float64 // javascript: unrestricted double {x X x}
@@ -325,13 +320,13 @@ func DOMPointInitFromJS(value js.Wrapper) *DOMPointInit {
 		value2 float64 // javascript: unrestricted double {z Z z}
 		value3 float64 // javascript: unrestricted double {w W w}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
-	value2 = (input.Get("z")).Float()
+	value2 = (value.Get("z")).Float()
 	out.Z = value2
-	value3 = (input.Get("w")).Float()
+	value3 = (value.Get("w")).Float()
 	out.W = value3
 	return &out
 }
@@ -344,7 +339,7 @@ type DOMQuadInit struct {
 	P4 *DOMPointInit
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMQuadInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -360,10 +355,8 @@ func (_this *DOMQuadInit) JSValue() js.Value {
 }
 
 // DOMQuadInitFromJS is allocating a new
-// DOMQuadInit object and copy all values from
-// input javascript object
-func DOMQuadInitFromJS(value js.Wrapper) *DOMQuadInit {
-	input := value.JSValue()
+// DOMQuadInit object and copy all values in the value javascript object.
+func DOMQuadInitFromJS(value js.Value) *DOMQuadInit {
 	var out DOMQuadInit
 	var (
 		value0 *DOMPointInit // javascript: DOMPointInit {p1 P1 p1}
@@ -371,13 +364,13 @@ func DOMQuadInitFromJS(value js.Wrapper) *DOMQuadInit {
 		value2 *DOMPointInit // javascript: DOMPointInit {p3 P3 p3}
 		value3 *DOMPointInit // javascript: DOMPointInit {p4 P4 p4}
 	)
-	value0 = DOMPointInitFromJS(input.Get("p1"))
+	value0 = DOMPointInitFromJS(value.Get("p1"))
 	out.P1 = value0
-	value1 = DOMPointInitFromJS(input.Get("p2"))
+	value1 = DOMPointInitFromJS(value.Get("p2"))
 	out.P2 = value1
-	value2 = DOMPointInitFromJS(input.Get("p3"))
+	value2 = DOMPointInitFromJS(value.Get("p3"))
 	out.P3 = value2
-	value3 = DOMPointInitFromJS(input.Get("p4"))
+	value3 = DOMPointInitFromJS(value.Get("p4"))
 	out.P4 = value3
 	return &out
 }
@@ -390,7 +383,7 @@ type DOMRectInit struct {
 	Height float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DOMRectInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -406,10 +399,8 @@ func (_this *DOMRectInit) JSValue() js.Value {
 }
 
 // DOMRectInitFromJS is allocating a new
-// DOMRectInit object and copy all values from
-// input javascript object
-func DOMRectInitFromJS(value js.Wrapper) *DOMRectInit {
-	input := value.JSValue()
+// DOMRectInit object and copy all values in the value javascript object.
+func DOMRectInitFromJS(value js.Value) *DOMRectInit {
 	var out DOMRectInit
 	var (
 		value0 float64 // javascript: unrestricted double {x X x}
@@ -417,13 +408,13 @@ func DOMRectInitFromJS(value js.Wrapper) *DOMRectInit {
 		value2 float64 // javascript: unrestricted double {width Width width}
 		value3 float64 // javascript: unrestricted double {height Height height}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
-	value2 = (input.Get("width")).Float()
+	value2 = (value.Get("width")).Float()
 	out.Width = value2
-	value3 = (input.Get("height")).Float()
+	value3 = (value.Get("height")).Float()
 	out.Height = value3
 	return &out
 }
@@ -433,15 +424,19 @@ type DOMMatrix struct {
 	DOMMatrixReadOnly
 }
 
-// DOMMatrixFromJS is casting a js.Wrapper into DOMMatrix.
-func DOMMatrixFromJS(value js.Wrapper) *DOMMatrix {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMMatrixFromJS is casting a js.Value into DOMMatrix.
+func DOMMatrixFromJS(value js.Value) *DOMMatrix {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMMatrix{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMMatrixFromJS is casting from something that holds a js.Value into DOMMatrix.
+func DOMMatrixFromWrapper(input core.Wrapper) *DOMMatrix {
+	return DOMMatrixFromJS(input.JSValue())
 }
 
 func FromMatrix(other *DOMMatrixInit) (_result *DOMMatrix) {
@@ -1330,15 +1325,19 @@ func (_this *DOMMatrixReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMMatrixReadOnlyFromJS is casting a js.Wrapper into DOMMatrixReadOnly.
-func DOMMatrixReadOnlyFromJS(value js.Wrapper) *DOMMatrixReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMMatrixReadOnlyFromJS is casting a js.Value into DOMMatrixReadOnly.
+func DOMMatrixReadOnlyFromJS(value js.Value) *DOMMatrixReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMMatrixReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMMatrixReadOnlyFromJS is casting from something that holds a js.Value into DOMMatrixReadOnly.
+func DOMMatrixReadOnlyFromWrapper(input core.Wrapper) *DOMMatrixReadOnly {
+	return DOMMatrixReadOnlyFromJS(input.JSValue())
 }
 
 func FromMatrix2(other *DOMMatrixInit) (_result *DOMMatrixReadOnly) {
@@ -2189,15 +2188,19 @@ type DOMPoint struct {
 	DOMPointReadOnly
 }
 
-// DOMPointFromJS is casting a js.Wrapper into DOMPoint.
-func DOMPointFromJS(value js.Wrapper) *DOMPoint {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMPointFromJS is casting a js.Value into DOMPoint.
+func DOMPointFromJS(value js.Value) *DOMPoint {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMPoint{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMPointFromJS is casting from something that holds a js.Value into DOMPoint.
+func DOMPointFromWrapper(input core.Wrapper) *DOMPoint {
+	return DOMPointFromJS(input.JSValue())
 }
 
 func FromPoint(other *DOMPointInit) (_result *DOMPoint) {
@@ -2354,15 +2357,19 @@ func (_this *DOMPointReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMPointReadOnlyFromJS is casting a js.Wrapper into DOMPointReadOnly.
-func DOMPointReadOnlyFromJS(value js.Wrapper) *DOMPointReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMPointReadOnlyFromJS is casting a js.Value into DOMPointReadOnly.
+func DOMPointReadOnlyFromJS(value js.Value) *DOMPointReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMPointReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMPointReadOnlyFromJS is casting from something that holds a js.Value into DOMPointReadOnly.
+func DOMPointReadOnlyFromWrapper(input core.Wrapper) *DOMPointReadOnly {
+	return DOMPointReadOnlyFromJS(input.JSValue())
 }
 
 func FromPoint2(other *DOMPointInit) (_result *DOMPointReadOnly) {
@@ -2524,15 +2531,19 @@ func (_this *DOMQuad) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMQuadFromJS is casting a js.Wrapper into DOMQuad.
-func DOMQuadFromJS(value js.Wrapper) *DOMQuad {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMQuadFromJS is casting a js.Value into DOMQuad.
+func DOMQuadFromJS(value js.Value) *DOMQuad {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMQuad{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMQuadFromJS is casting from something that holds a js.Value into DOMQuad.
+func DOMQuadFromWrapper(input core.Wrapper) *DOMQuad {
+	return DOMQuadFromJS(input.JSValue())
 }
 
 func FromRect(other *DOMRectInit) (_result *DOMQuad) {
@@ -2681,15 +2692,19 @@ type DOMRect struct {
 	DOMRectReadOnly
 }
 
-// DOMRectFromJS is casting a js.Wrapper into DOMRect.
-func DOMRectFromJS(value js.Wrapper) *DOMRect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectFromJS is casting a js.Value into DOMRect.
+func DOMRectFromJS(value js.Value) *DOMRect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectFromJS is casting from something that holds a js.Value into DOMRect.
+func DOMRectFromWrapper(input core.Wrapper) *DOMRect {
+	return DOMRectFromJS(input.JSValue())
 }
 
 func FromRect2(other *DOMRectInit) (_result *DOMRect) {
@@ -2846,15 +2861,19 @@ func (_this *DOMRectList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMRectListFromJS is casting a js.Wrapper into DOMRectList.
-func DOMRectListFromJS(value js.Wrapper) *DOMRectList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectListFromJS is casting a js.Value into DOMRectList.
+func DOMRectListFromJS(value js.Value) *DOMRectList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRectList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectListFromJS is casting from something that holds a js.Value into DOMRectList.
+func DOMRectListFromWrapper(input core.Wrapper) *DOMRectList {
+	return DOMRectListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2914,15 +2933,19 @@ func (_this *DOMRectReadOnly) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMRectReadOnlyFromJS is casting a js.Wrapper into DOMRectReadOnly.
-func DOMRectReadOnlyFromJS(value js.Wrapper) *DOMRectReadOnly {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMRectReadOnlyFromJS is casting a js.Value into DOMRectReadOnly.
+func DOMRectReadOnlyFromJS(value js.Value) *DOMRectReadOnly {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMRectReadOnly{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMRectReadOnlyFromJS is casting from something that holds a js.Value into DOMRectReadOnly.
+func DOMRectReadOnlyFromWrapper(input core.Wrapper) *DOMRectReadOnly {
+	return DOMRectReadOnlyFromJS(input.JSValue())
 }
 
 func FromRect3(other *DOMRectInit) (_result *DOMRectReadOnly) {

--- a/dom/intersection/intersection.go
+++ b/dom/intersection/intersection.go
@@ -7,6 +7,7 @@ package intersection
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/javascript"
@@ -109,7 +110,7 @@ type IntersectionObserverEntryInit struct {
 	Target             *dom.Element
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntersectionObserverEntryInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -131,10 +132,8 @@ func (_this *IntersectionObserverEntryInit) JSValue() js.Value {
 }
 
 // IntersectionObserverEntryInitFromJS is allocating a new
-// IntersectionObserverEntryInit object and copy all values from
-// input javascript object
-func IntersectionObserverEntryInitFromJS(value js.Wrapper) *IntersectionObserverEntryInit {
-	input := value.JSValue()
+// IntersectionObserverEntryInit object and copy all values in the value javascript object.
+func IntersectionObserverEntryInitFromJS(value js.Value) *IntersectionObserverEntryInit {
 	var out IntersectionObserverEntryInit
 	var (
 		value0 float64               // javascript: double {time Time time}
@@ -145,21 +144,21 @@ func IntersectionObserverEntryInitFromJS(value js.Wrapper) *IntersectionObserver
 		value5 float64               // javascript: double {intersectionRatio IntersectionRatio intersectionRatio}
 		value6 *dom.Element          // javascript: Element {target Target target}
 	)
-	value0 = (input.Get("time")).Float()
+	value0 = (value.Get("time")).Float()
 	out.Time = value0
-	if input.Get("rootBounds").Type() != js.TypeNull && input.Get("rootBounds").Type() != js.TypeUndefined {
-		value1 = geometry.DOMRectInitFromJS(input.Get("rootBounds"))
+	if value.Get("rootBounds").Type() != js.TypeNull && value.Get("rootBounds").Type() != js.TypeUndefined {
+		value1 = geometry.DOMRectInitFromJS(value.Get("rootBounds"))
 	}
 	out.RootBounds = value1
-	value2 = geometry.DOMRectInitFromJS(input.Get("boundingClientRect"))
+	value2 = geometry.DOMRectInitFromJS(value.Get("boundingClientRect"))
 	out.BoundingClientRect = value2
-	value3 = geometry.DOMRectInitFromJS(input.Get("intersectionRect"))
+	value3 = geometry.DOMRectInitFromJS(value.Get("intersectionRect"))
 	out.IntersectionRect = value3
-	value4 = (input.Get("isIntersecting")).Bool()
+	value4 = (value.Get("isIntersecting")).Bool()
 	out.IsIntersecting = value4
-	value5 = (input.Get("intersectionRatio")).Float()
+	value5 = (value.Get("intersectionRatio")).Float()
 	out.IntersectionRatio = value5
-	value6 = dom.ElementFromJS(input.Get("target"))
+	value6 = dom.ElementFromJS(value.Get("target"))
 	out.Target = value6
 	return &out
 }
@@ -171,7 +170,7 @@ type IntersectionObserverInit struct {
 	Threshold  *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntersectionObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -185,23 +184,21 @@ func (_this *IntersectionObserverInit) JSValue() js.Value {
 }
 
 // IntersectionObserverInitFromJS is allocating a new
-// IntersectionObserverInit object and copy all values from
-// input javascript object
-func IntersectionObserverInitFromJS(value js.Wrapper) *IntersectionObserverInit {
-	input := value.JSValue()
+// IntersectionObserverInit object and copy all values in the value javascript object.
+func IntersectionObserverInitFromJS(value js.Value) *IntersectionObserverInit {
 	var out IntersectionObserverInit
 	var (
 		value0 *dom.Element // javascript: Element {root Root root}
 		value1 string       // javascript: DOMString {rootMargin RootMargin rootMargin}
 		value2 *Union       // javascript: Union {threshold Threshold threshold}
 	)
-	if input.Get("root").Type() != js.TypeNull && input.Get("root").Type() != js.TypeUndefined {
-		value0 = dom.ElementFromJS(input.Get("root"))
+	if value.Get("root").Type() != js.TypeNull && value.Get("root").Type() != js.TypeUndefined {
+		value0 = dom.ElementFromJS(value.Get("root"))
 	}
 	out.Root = value0
-	value1 = (input.Get("rootMargin")).String()
+	value1 = (value.Get("rootMargin")).String()
 	out.RootMargin = value1
-	value2 = UnionFromJS(input.Get("threshold"))
+	value2 = UnionFromJS(value.Get("threshold"))
 	out.Threshold = value2
 	return &out
 }
@@ -216,15 +213,19 @@ func (_this *IntersectionObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntersectionObserverFromJS is casting a js.Wrapper into IntersectionObserver.
-func IntersectionObserverFromJS(value js.Wrapper) *IntersectionObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntersectionObserverFromJS is casting a js.Value into IntersectionObserver.
+func IntersectionObserverFromJS(value js.Value) *IntersectionObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntersectionObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntersectionObserverFromJS is casting from something that holds a js.Value into IntersectionObserver.
+func IntersectionObserverFromWrapper(input core.Wrapper) *IntersectionObserver {
+	return IntersectionObserverFromJS(input.JSValue())
 }
 
 func NewIntersectionObserver(callback *IntersectionObserverCallback, options *IntersectionObserverInit) (_result *IntersectionObserver) {
@@ -351,15 +352,19 @@ func (_this *IntersectionObserverEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntersectionObserverEntryFromJS is casting a js.Wrapper into IntersectionObserverEntry.
-func IntersectionObserverEntryFromJS(value js.Wrapper) *IntersectionObserverEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntersectionObserverEntryFromJS is casting a js.Value into IntersectionObserverEntry.
+func IntersectionObserverEntryFromJS(value js.Value) *IntersectionObserverEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntersectionObserverEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntersectionObserverEntryFromJS is casting from something that holds a js.Value into IntersectionObserverEntry.
+func IntersectionObserverEntryFromWrapper(input core.Wrapper) *IntersectionObserverEntry {
+	return IntersectionObserverEntryFromJS(input.JSValue())
 }
 
 func NewIntersectionObserverEntry(intersectionObserverEntryInit *IntersectionObserverEntryInit) (_result *IntersectionObserverEntry) {

--- a/dom/intersection/intersection_js.go
+++ b/dom/intersection/intersection_js.go
@@ -5,6 +5,7 @@ package intersection
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/javascript"
@@ -107,7 +108,7 @@ type IntersectionObserverEntryInit struct {
 	Target             *dom.Element
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntersectionObserverEntryInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -129,10 +130,8 @@ func (_this *IntersectionObserverEntryInit) JSValue() js.Value {
 }
 
 // IntersectionObserverEntryInitFromJS is allocating a new
-// IntersectionObserverEntryInit object and copy all values from
-// input javascript object
-func IntersectionObserverEntryInitFromJS(value js.Wrapper) *IntersectionObserverEntryInit {
-	input := value.JSValue()
+// IntersectionObserverEntryInit object and copy all values in the value javascript object.
+func IntersectionObserverEntryInitFromJS(value js.Value) *IntersectionObserverEntryInit {
 	var out IntersectionObserverEntryInit
 	var (
 		value0 float64               // javascript: double {time Time time}
@@ -143,21 +142,21 @@ func IntersectionObserverEntryInitFromJS(value js.Wrapper) *IntersectionObserver
 		value5 float64               // javascript: double {intersectionRatio IntersectionRatio intersectionRatio}
 		value6 *dom.Element          // javascript: Element {target Target target}
 	)
-	value0 = (input.Get("time")).Float()
+	value0 = (value.Get("time")).Float()
 	out.Time = value0
-	if input.Get("rootBounds").Type() != js.TypeNull && input.Get("rootBounds").Type() != js.TypeUndefined {
-		value1 = geometry.DOMRectInitFromJS(input.Get("rootBounds"))
+	if value.Get("rootBounds").Type() != js.TypeNull && value.Get("rootBounds").Type() != js.TypeUndefined {
+		value1 = geometry.DOMRectInitFromJS(value.Get("rootBounds"))
 	}
 	out.RootBounds = value1
-	value2 = geometry.DOMRectInitFromJS(input.Get("boundingClientRect"))
+	value2 = geometry.DOMRectInitFromJS(value.Get("boundingClientRect"))
 	out.BoundingClientRect = value2
-	value3 = geometry.DOMRectInitFromJS(input.Get("intersectionRect"))
+	value3 = geometry.DOMRectInitFromJS(value.Get("intersectionRect"))
 	out.IntersectionRect = value3
-	value4 = (input.Get("isIntersecting")).Bool()
+	value4 = (value.Get("isIntersecting")).Bool()
 	out.IsIntersecting = value4
-	value5 = (input.Get("intersectionRatio")).Float()
+	value5 = (value.Get("intersectionRatio")).Float()
 	out.IntersectionRatio = value5
-	value6 = dom.ElementFromJS(input.Get("target"))
+	value6 = dom.ElementFromJS(value.Get("target"))
 	out.Target = value6
 	return &out
 }
@@ -169,7 +168,7 @@ type IntersectionObserverInit struct {
 	Threshold  *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IntersectionObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -183,23 +182,21 @@ func (_this *IntersectionObserverInit) JSValue() js.Value {
 }
 
 // IntersectionObserverInitFromJS is allocating a new
-// IntersectionObserverInit object and copy all values from
-// input javascript object
-func IntersectionObserverInitFromJS(value js.Wrapper) *IntersectionObserverInit {
-	input := value.JSValue()
+// IntersectionObserverInit object and copy all values in the value javascript object.
+func IntersectionObserverInitFromJS(value js.Value) *IntersectionObserverInit {
 	var out IntersectionObserverInit
 	var (
 		value0 *dom.Element // javascript: Element {root Root root}
 		value1 string       // javascript: DOMString {rootMargin RootMargin rootMargin}
 		value2 *Union       // javascript: Union {threshold Threshold threshold}
 	)
-	if input.Get("root").Type() != js.TypeNull && input.Get("root").Type() != js.TypeUndefined {
-		value0 = dom.ElementFromJS(input.Get("root"))
+	if value.Get("root").Type() != js.TypeNull && value.Get("root").Type() != js.TypeUndefined {
+		value0 = dom.ElementFromJS(value.Get("root"))
 	}
 	out.Root = value0
-	value1 = (input.Get("rootMargin")).String()
+	value1 = (value.Get("rootMargin")).String()
 	out.RootMargin = value1
-	value2 = UnionFromJS(input.Get("threshold"))
+	value2 = UnionFromJS(value.Get("threshold"))
 	out.Threshold = value2
 	return &out
 }
@@ -214,15 +211,19 @@ func (_this *IntersectionObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntersectionObserverFromJS is casting a js.Wrapper into IntersectionObserver.
-func IntersectionObserverFromJS(value js.Wrapper) *IntersectionObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntersectionObserverFromJS is casting a js.Value into IntersectionObserver.
+func IntersectionObserverFromJS(value js.Value) *IntersectionObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntersectionObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntersectionObserverFromJS is casting from something that holds a js.Value into IntersectionObserver.
+func IntersectionObserverFromWrapper(input core.Wrapper) *IntersectionObserver {
+	return IntersectionObserverFromJS(input.JSValue())
 }
 
 func NewIntersectionObserver(callback *IntersectionObserverCallback, options *IntersectionObserverInit) (_result *IntersectionObserver) {
@@ -349,15 +350,19 @@ func (_this *IntersectionObserverEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IntersectionObserverEntryFromJS is casting a js.Wrapper into IntersectionObserverEntry.
-func IntersectionObserverEntryFromJS(value js.Wrapper) *IntersectionObserverEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IntersectionObserverEntryFromJS is casting a js.Value into IntersectionObserverEntry.
+func IntersectionObserverEntryFromJS(value js.Value) *IntersectionObserverEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IntersectionObserverEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IntersectionObserverEntryFromJS is casting from something that holds a js.Value into IntersectionObserverEntry.
+func IntersectionObserverEntryFromWrapper(input core.Wrapper) *IntersectionObserverEntry {
+	return IntersectionObserverEntryFromJS(input.JSValue())
 }
 
 func NewIntersectionObserverEntry(intersectionObserverEntryInit *IntersectionObserverEntryInit) (_result *IntersectionObserverEntry) {

--- a/dom/parser/parser.go
+++ b/dom/parser/parser.go
@@ -8,6 +8,7 @@ import js "github.com/gowebapi/webapi/core/js"
 
 import (
 	"github.com/gowebapi/webapi"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 )
 
@@ -93,15 +94,19 @@ func (_this *DOMParser) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMParserFromJS is casting a js.Wrapper into DOMParser.
-func DOMParserFromJS(value js.Wrapper) *DOMParser {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMParserFromJS is casting a js.Value into DOMParser.
+func DOMParserFromJS(value js.Value) *DOMParser {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMParser{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMParserFromJS is casting from something that holds a js.Value into DOMParser.
+func DOMParserFromWrapper(input core.Wrapper) *DOMParser {
+	return DOMParserFromJS(input.JSValue())
 }
 
 func NewDOMParser() (_result *DOMParser) {
@@ -149,15 +154,19 @@ func (_this *XMLSerializer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XMLSerializerFromJS is casting a js.Wrapper into XMLSerializer.
-func XMLSerializerFromJS(value js.Wrapper) *XMLSerializer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLSerializerFromJS is casting a js.Value into XMLSerializer.
+func XMLSerializerFromJS(value js.Value) *XMLSerializer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLSerializer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLSerializerFromJS is casting from something that holds a js.Value into XMLSerializer.
+func XMLSerializerFromWrapper(input core.Wrapper) *XMLSerializer {
+	return XMLSerializerFromJS(input.JSValue())
 }
 
 func NewXMLSerializer() (_result *XMLSerializer) {

--- a/dom/parser/parser_js.go
+++ b/dom/parser/parser_js.go
@@ -6,6 +6,7 @@ import "syscall/js"
 
 import (
 	"github.com/gowebapi/webapi"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 )
 
@@ -91,15 +92,19 @@ func (_this *DOMParser) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMParserFromJS is casting a js.Wrapper into DOMParser.
-func DOMParserFromJS(value js.Wrapper) *DOMParser {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMParserFromJS is casting a js.Value into DOMParser.
+func DOMParserFromJS(value js.Value) *DOMParser {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMParser{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMParserFromJS is casting from something that holds a js.Value into DOMParser.
+func DOMParserFromWrapper(input core.Wrapper) *DOMParser {
+	return DOMParserFromJS(input.JSValue())
 }
 
 func NewDOMParser() (_result *DOMParser) {
@@ -147,15 +152,19 @@ func (_this *XMLSerializer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// XMLSerializerFromJS is casting a js.Wrapper into XMLSerializer.
-func XMLSerializerFromJS(value js.Wrapper) *XMLSerializer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLSerializerFromJS is casting a js.Value into XMLSerializer.
+func XMLSerializerFromJS(value js.Value) *XMLSerializer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLSerializer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLSerializerFromJS is casting from something that holds a js.Value into XMLSerializer.
+func XMLSerializerFromWrapper(input core.Wrapper) *XMLSerializer {
+	return XMLSerializerFromJS(input.JSValue())
 }
 
 func NewXMLSerializer() (_result *XMLSerializer) {

--- a/dom/permissions/permissions.go
+++ b/dom/permissions/permissions.go
@@ -7,6 +7,7 @@ package permissions
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -172,7 +173,7 @@ type DevicePermissionDescriptor struct {
 	DeviceId string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DevicePermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -184,18 +185,16 @@ func (_this *DevicePermissionDescriptor) JSValue() js.Value {
 }
 
 // DevicePermissionDescriptorFromJS is allocating a new
-// DevicePermissionDescriptor object and copy all values from
-// input javascript object
-func DevicePermissionDescriptorFromJS(value js.Wrapper) *DevicePermissionDescriptor {
-	input := value.JSValue()
+// DevicePermissionDescriptor object and copy all values in the value javascript object.
+func DevicePermissionDescriptorFromJS(value js.Value) *DevicePermissionDescriptor {
 	var out DevicePermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {deviceId DeviceId deviceId}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("deviceId")).String()
+	value1 = (value.Get("deviceId")).String()
 	out.DeviceId = value1
 	return &out
 }
@@ -206,7 +205,7 @@ type MidiPermissionDescriptor struct {
 	Sysex bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MidiPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -218,18 +217,16 @@ func (_this *MidiPermissionDescriptor) JSValue() js.Value {
 }
 
 // MidiPermissionDescriptorFromJS is allocating a new
-// MidiPermissionDescriptor object and copy all values from
-// input javascript object
-func MidiPermissionDescriptorFromJS(value js.Wrapper) *MidiPermissionDescriptor {
-	input := value.JSValue()
+// MidiPermissionDescriptor object and copy all values in the value javascript object.
+func MidiPermissionDescriptorFromJS(value js.Value) *MidiPermissionDescriptor {
 	var out MidiPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {sysex Sysex sysex}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("sysex")).Bool()
+	value1 = (value.Get("sysex")).Bool()
 	out.Sysex = value1
 	return &out
 }
@@ -239,7 +236,7 @@ type PermissionDescriptor struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -249,15 +246,13 @@ func (_this *PermissionDescriptor) JSValue() js.Value {
 }
 
 // PermissionDescriptorFromJS is allocating a new
-// PermissionDescriptor object and copy all values from
-// input javascript object
-func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
-	input := value.JSValue()
+// PermissionDescriptor object and copy all values in the value javascript object.
+func PermissionDescriptorFromJS(value js.Value) *PermissionDescriptor {
 	var out PermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -269,7 +264,7 @@ type PermissionSetParameters struct {
 	OneRealm   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionSetParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -283,21 +278,19 @@ func (_this *PermissionSetParameters) JSValue() js.Value {
 }
 
 // PermissionSetParametersFromJS is allocating a new
-// PermissionSetParameters object and copy all values from
-// input javascript object
-func PermissionSetParametersFromJS(value js.Wrapper) *PermissionSetParameters {
-	input := value.JSValue()
+// PermissionSetParameters object and copy all values in the value javascript object.
+func PermissionSetParametersFromJS(value js.Value) *PermissionSetParameters {
 	var out PermissionSetParameters
 	var (
 		value0 *PermissionDescriptor // javascript: PermissionDescriptor {descriptor Descriptor descriptor}
 		value1 PermissionState       // javascript: PermissionState {state State state}
 		value2 bool                  // javascript: boolean {oneRealm OneRealm oneRealm}
 	)
-	value0 = PermissionDescriptorFromJS(input.Get("descriptor"))
+	value0 = PermissionDescriptorFromJS(value.Get("descriptor"))
 	out.Descriptor = value0
-	value1 = PermissionStateFromJS(input.Get("state"))
+	value1 = PermissionStateFromJS(value.Get("state"))
 	out.State = value1
-	value2 = (input.Get("oneRealm")).Bool()
+	value2 = (value.Get("oneRealm")).Bool()
 	out.OneRealm = value2
 	return &out
 }
@@ -308,7 +301,7 @@ type PushPermissionDescriptor struct {
 	UserVisibleOnly bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PushPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -320,18 +313,16 @@ func (_this *PushPermissionDescriptor) JSValue() js.Value {
 }
 
 // PushPermissionDescriptorFromJS is allocating a new
-// PushPermissionDescriptor object and copy all values from
-// input javascript object
-func PushPermissionDescriptorFromJS(value js.Wrapper) *PushPermissionDescriptor {
-	input := value.JSValue()
+// PushPermissionDescriptor object and copy all values in the value javascript object.
+func PushPermissionDescriptorFromJS(value js.Value) *PushPermissionDescriptor {
 	var out PushPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {userVisibleOnly UserVisibleOnly userVisibleOnly}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("userVisibleOnly")).Bool()
+	value1 = (value.Get("userVisibleOnly")).Bool()
 	out.UserVisibleOnly = value1
 	return &out
 }
@@ -341,15 +332,19 @@ type PermissionStatus struct {
 	domcore.EventTarget
 }
 
-// PermissionStatusFromJS is casting a js.Wrapper into PermissionStatus.
-func PermissionStatusFromJS(value js.Wrapper) *PermissionStatus {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionStatusFromJS is casting a js.Value into PermissionStatus.
+func PermissionStatusFromJS(value js.Value) *PermissionStatus {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PermissionStatus{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionStatusFromJS is casting from something that holds a js.Value into PermissionStatus.
+func PermissionStatusFromWrapper(input core.Wrapper) *PermissionStatus {
+	return PermissionStatusFromJS(input.JSValue())
 }
 
 // State returning attribute 'state' with
@@ -412,15 +407,19 @@ func (_this *Permissions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PermissionsFromJS is casting a js.Wrapper into Permissions.
-func PermissionsFromJS(value js.Wrapper) *Permissions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionsFromJS is casting a js.Value into Permissions.
+func PermissionsFromJS(value js.Value) *Permissions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Permissions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionsFromJS is casting from something that holds a js.Value into Permissions.
+func PermissionsFromWrapper(input core.Wrapper) *Permissions {
+	return PermissionsFromJS(input.JSValue())
 }
 
 func (_this *Permissions) Query(permissionDesc *javascript.Object) (_result *PromisePermissionStatus) {
@@ -450,15 +449,19 @@ func (_this *PromisePermissionStatus) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionStatusFromJS is casting a js.Wrapper into PromisePermissionStatus.
-func PromisePermissionStatusFromJS(value js.Wrapper) *PromisePermissionStatus {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionStatusFromJS is casting a js.Value into PromisePermissionStatus.
+func PromisePermissionStatusFromJS(value js.Value) *PromisePermissionStatus {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionStatus{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionStatusFromJS is casting from something that holds a js.Value into PromisePermissionStatus.
+func PromisePermissionStatusFromWrapper(input core.Wrapper) *PromisePermissionStatus {
+	return PromisePermissionStatusFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionStatus) Then(onFulfilled *PromisePermissionStatusOnFulfilled, onRejected *PromisePermissionStatusOnRejected) (_result *PromisePermissionStatus) {

--- a/dom/permissions/permissions_js.go
+++ b/dom/permissions/permissions_js.go
@@ -5,6 +5,7 @@ package permissions
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -170,7 +171,7 @@ type DevicePermissionDescriptor struct {
 	DeviceId string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DevicePermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -182,18 +183,16 @@ func (_this *DevicePermissionDescriptor) JSValue() js.Value {
 }
 
 // DevicePermissionDescriptorFromJS is allocating a new
-// DevicePermissionDescriptor object and copy all values from
-// input javascript object
-func DevicePermissionDescriptorFromJS(value js.Wrapper) *DevicePermissionDescriptor {
-	input := value.JSValue()
+// DevicePermissionDescriptor object and copy all values in the value javascript object.
+func DevicePermissionDescriptorFromJS(value js.Value) *DevicePermissionDescriptor {
 	var out DevicePermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 string // javascript: DOMString {deviceId DeviceId deviceId}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("deviceId")).String()
+	value1 = (value.Get("deviceId")).String()
 	out.DeviceId = value1
 	return &out
 }
@@ -204,7 +203,7 @@ type MidiPermissionDescriptor struct {
 	Sysex bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MidiPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -216,18 +215,16 @@ func (_this *MidiPermissionDescriptor) JSValue() js.Value {
 }
 
 // MidiPermissionDescriptorFromJS is allocating a new
-// MidiPermissionDescriptor object and copy all values from
-// input javascript object
-func MidiPermissionDescriptorFromJS(value js.Wrapper) *MidiPermissionDescriptor {
-	input := value.JSValue()
+// MidiPermissionDescriptor object and copy all values in the value javascript object.
+func MidiPermissionDescriptorFromJS(value js.Value) *MidiPermissionDescriptor {
 	var out MidiPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {sysex Sysex sysex}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("sysex")).Bool()
+	value1 = (value.Get("sysex")).Bool()
 	out.Sysex = value1
 	return &out
 }
@@ -237,7 +234,7 @@ type PermissionDescriptor struct {
 	Name string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -247,15 +244,13 @@ func (_this *PermissionDescriptor) JSValue() js.Value {
 }
 
 // PermissionDescriptorFromJS is allocating a new
-// PermissionDescriptor object and copy all values from
-// input javascript object
-func PermissionDescriptorFromJS(value js.Wrapper) *PermissionDescriptor {
-	input := value.JSValue()
+// PermissionDescriptor object and copy all values in the value javascript object.
+func PermissionDescriptorFromJS(value js.Value) *PermissionDescriptor {
 	var out PermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
 	return &out
 }
@@ -267,7 +262,7 @@ type PermissionSetParameters struct {
 	OneRealm   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PermissionSetParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -281,21 +276,19 @@ func (_this *PermissionSetParameters) JSValue() js.Value {
 }
 
 // PermissionSetParametersFromJS is allocating a new
-// PermissionSetParameters object and copy all values from
-// input javascript object
-func PermissionSetParametersFromJS(value js.Wrapper) *PermissionSetParameters {
-	input := value.JSValue()
+// PermissionSetParameters object and copy all values in the value javascript object.
+func PermissionSetParametersFromJS(value js.Value) *PermissionSetParameters {
 	var out PermissionSetParameters
 	var (
 		value0 *PermissionDescriptor // javascript: PermissionDescriptor {descriptor Descriptor descriptor}
 		value1 PermissionState       // javascript: PermissionState {state State state}
 		value2 bool                  // javascript: boolean {oneRealm OneRealm oneRealm}
 	)
-	value0 = PermissionDescriptorFromJS(input.Get("descriptor"))
+	value0 = PermissionDescriptorFromJS(value.Get("descriptor"))
 	out.Descriptor = value0
-	value1 = PermissionStateFromJS(input.Get("state"))
+	value1 = PermissionStateFromJS(value.Get("state"))
 	out.State = value1
-	value2 = (input.Get("oneRealm")).Bool()
+	value2 = (value.Get("oneRealm")).Bool()
 	out.OneRealm = value2
 	return &out
 }
@@ -306,7 +299,7 @@ type PushPermissionDescriptor struct {
 	UserVisibleOnly bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PushPermissionDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -318,18 +311,16 @@ func (_this *PushPermissionDescriptor) JSValue() js.Value {
 }
 
 // PushPermissionDescriptorFromJS is allocating a new
-// PushPermissionDescriptor object and copy all values from
-// input javascript object
-func PushPermissionDescriptorFromJS(value js.Wrapper) *PushPermissionDescriptor {
-	input := value.JSValue()
+// PushPermissionDescriptor object and copy all values in the value javascript object.
+func PushPermissionDescriptorFromJS(value js.Value) *PushPermissionDescriptor {
 	var out PushPermissionDescriptor
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 bool   // javascript: boolean {userVisibleOnly UserVisibleOnly userVisibleOnly}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("userVisibleOnly")).Bool()
+	value1 = (value.Get("userVisibleOnly")).Bool()
 	out.UserVisibleOnly = value1
 	return &out
 }
@@ -339,15 +330,19 @@ type PermissionStatus struct {
 	domcore.EventTarget
 }
 
-// PermissionStatusFromJS is casting a js.Wrapper into PermissionStatus.
-func PermissionStatusFromJS(value js.Wrapper) *PermissionStatus {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionStatusFromJS is casting a js.Value into PermissionStatus.
+func PermissionStatusFromJS(value js.Value) *PermissionStatus {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PermissionStatus{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionStatusFromJS is casting from something that holds a js.Value into PermissionStatus.
+func PermissionStatusFromWrapper(input core.Wrapper) *PermissionStatus {
+	return PermissionStatusFromJS(input.JSValue())
 }
 
 // State returning attribute 'state' with
@@ -410,15 +405,19 @@ func (_this *Permissions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PermissionsFromJS is casting a js.Wrapper into Permissions.
-func PermissionsFromJS(value js.Wrapper) *Permissions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PermissionsFromJS is casting a js.Value into Permissions.
+func PermissionsFromJS(value js.Value) *Permissions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Permissions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PermissionsFromJS is casting from something that holds a js.Value into Permissions.
+func PermissionsFromWrapper(input core.Wrapper) *Permissions {
+	return PermissionsFromJS(input.JSValue())
 }
 
 func (_this *Permissions) Query(permissionDesc *javascript.Object) (_result *PromisePermissionStatus) {
@@ -448,15 +447,19 @@ func (_this *PromisePermissionStatus) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionStatusFromJS is casting a js.Wrapper into PromisePermissionStatus.
-func PromisePermissionStatusFromJS(value js.Wrapper) *PromisePermissionStatus {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionStatusFromJS is casting a js.Value into PromisePermissionStatus.
+func PromisePermissionStatusFromJS(value js.Value) *PromisePermissionStatus {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionStatus{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionStatusFromJS is casting from something that holds a js.Value into PromisePermissionStatus.
+func PromisePermissionStatusFromWrapper(input core.Wrapper) *PromisePermissionStatus {
+	return PromisePermissionStatusFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionStatus) Then(onFulfilled *PromisePermissionStatusOnFulfilled, onRejected *PromisePermissionStatusOnRejected) (_result *PromisePermissionStatus) {

--- a/dom/text/text.go
+++ b/dom/text/text.go
@@ -7,6 +7,7 @@ package text
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/javascript/missingtypes"
 	"github.com/gowebapi/webapi/patch"
@@ -45,7 +46,7 @@ type DecodeOptions struct {
 	Stream bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DecodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -55,15 +56,13 @@ func (_this *DecodeOptions) JSValue() js.Value {
 }
 
 // DecodeOptionsFromJS is allocating a new
-// DecodeOptions object and copy all values from
-// input javascript object
-func DecodeOptionsFromJS(value js.Wrapper) *DecodeOptions {
-	input := value.JSValue()
+// DecodeOptions object and copy all values in the value javascript object.
+func DecodeOptionsFromJS(value js.Value) *DecodeOptions {
 	var out DecodeOptions
 	var (
 		value0 bool // javascript: boolean {stream Stream stream}
 	)
-	value0 = (input.Get("stream")).Bool()
+	value0 = (value.Get("stream")).Bool()
 	out.Stream = value0
 	return &out
 }
@@ -74,7 +73,7 @@ type DecoderOptions struct {
 	IgnoreBOM bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DecoderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -86,18 +85,16 @@ func (_this *DecoderOptions) JSValue() js.Value {
 }
 
 // DecoderOptionsFromJS is allocating a new
-// DecoderOptions object and copy all values from
-// input javascript object
-func DecoderOptionsFromJS(value js.Wrapper) *DecoderOptions {
-	input := value.JSValue()
+// DecoderOptions object and copy all values in the value javascript object.
+func DecoderOptionsFromJS(value js.Value) *DecoderOptions {
 	var out DecoderOptions
 	var (
 		value0 bool // javascript: boolean {fatal Fatal fatal}
 		value1 bool // javascript: boolean {ignoreBOM IgnoreBOM ignoreBOM}
 	)
-	value0 = (input.Get("fatal")).Bool()
+	value0 = (value.Get("fatal")).Bool()
 	out.Fatal = value0
-	value1 = (input.Get("ignoreBOM")).Bool()
+	value1 = (value.Get("ignoreBOM")).Bool()
 	out.IgnoreBOM = value1
 	return &out
 }
@@ -108,7 +105,7 @@ type EncoderEncodeIntoResult struct {
 	Written int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EncoderEncodeIntoResult) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -120,18 +117,16 @@ func (_this *EncoderEncodeIntoResult) JSValue() js.Value {
 }
 
 // EncoderEncodeIntoResultFromJS is allocating a new
-// EncoderEncodeIntoResult object and copy all values from
-// input javascript object
-func EncoderEncodeIntoResultFromJS(value js.Wrapper) *EncoderEncodeIntoResult {
-	input := value.JSValue()
+// EncoderEncodeIntoResult object and copy all values in the value javascript object.
+func EncoderEncodeIntoResultFromJS(value js.Value) *EncoderEncodeIntoResult {
 	var out EncoderEncodeIntoResult
 	var (
 		value0 int // javascript: unsigned long long {read Read read}
 		value1 int // javascript: unsigned long long {written Written written}
 	)
-	value0 = (input.Get("read")).Int()
+	value0 = (value.Get("read")).Int()
 	out.Read = value0
-	value1 = (input.Get("written")).Int()
+	value1 = (value.Get("written")).Int()
 	out.Written = value1
 	return &out
 }
@@ -146,15 +141,19 @@ func (_this *Decoder) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DecoderFromJS is casting a js.Wrapper into Decoder.
-func DecoderFromJS(value js.Wrapper) *Decoder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DecoderFromJS is casting a js.Value into Decoder.
+func DecoderFromJS(value js.Value) *Decoder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Decoder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DecoderFromJS is casting from something that holds a js.Value into Decoder.
+func DecoderFromWrapper(input core.Wrapper) *Decoder {
+	return DecoderFromJS(input.JSValue())
 }
 
 func NewTextDecoder(label *string, options *DecoderOptions) (_result *Decoder) {
@@ -249,15 +248,19 @@ func (_this *DecoderStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DecoderStreamFromJS is casting a js.Wrapper into DecoderStream.
-func DecoderStreamFromJS(value js.Wrapper) *DecoderStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DecoderStreamFromJS is casting a js.Value into DecoderStream.
+func DecoderStreamFromJS(value js.Value) *DecoderStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DecoderStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DecoderStreamFromJS is casting from something that holds a js.Value into DecoderStream.
+func DecoderStreamFromWrapper(input core.Wrapper) *DecoderStream {
+	return DecoderStreamFromJS(input.JSValue())
 }
 
 func NewTextDecoderStream(label *string, options *DecoderOptions) (_result *DecoderStream) {
@@ -346,15 +349,19 @@ func (_this *Encoder) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EncoderFromJS is casting a js.Wrapper into Encoder.
-func EncoderFromJS(value js.Wrapper) *Encoder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EncoderFromJS is casting a js.Value into Encoder.
+func EncoderFromJS(value js.Value) *Encoder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Encoder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EncoderFromJS is casting from something that holds a js.Value into Encoder.
+func EncoderFromWrapper(input core.Wrapper) *Encoder {
+	return EncoderFromJS(input.JSValue())
 }
 
 func NewTextEncoder() (_result *Encoder) {
@@ -436,15 +443,19 @@ func (_this *EncoderStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EncoderStreamFromJS is casting a js.Wrapper into EncoderStream.
-func EncoderStreamFromJS(value js.Wrapper) *EncoderStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EncoderStreamFromJS is casting a js.Value into EncoderStream.
+func EncoderStreamFromJS(value js.Value) *EncoderStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EncoderStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EncoderStreamFromJS is casting from something that holds a js.Value into EncoderStream.
+func EncoderStreamFromWrapper(input core.Wrapper) *EncoderStream {
+	return EncoderStreamFromJS(input.JSValue())
 }
 
 func NewTextEncoderStream() (_result *EncoderStream) {

--- a/dom/text/text_js.go
+++ b/dom/text/text_js.go
@@ -5,6 +5,7 @@ package text
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/javascript/missingtypes"
 	"github.com/gowebapi/webapi/patch"
@@ -43,7 +44,7 @@ type DecodeOptions struct {
 	Stream bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DecodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -53,15 +54,13 @@ func (_this *DecodeOptions) JSValue() js.Value {
 }
 
 // DecodeOptionsFromJS is allocating a new
-// DecodeOptions object and copy all values from
-// input javascript object
-func DecodeOptionsFromJS(value js.Wrapper) *DecodeOptions {
-	input := value.JSValue()
+// DecodeOptions object and copy all values in the value javascript object.
+func DecodeOptionsFromJS(value js.Value) *DecodeOptions {
 	var out DecodeOptions
 	var (
 		value0 bool // javascript: boolean {stream Stream stream}
 	)
-	value0 = (input.Get("stream")).Bool()
+	value0 = (value.Get("stream")).Bool()
 	out.Stream = value0
 	return &out
 }
@@ -72,7 +71,7 @@ type DecoderOptions struct {
 	IgnoreBOM bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DecoderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -84,18 +83,16 @@ func (_this *DecoderOptions) JSValue() js.Value {
 }
 
 // DecoderOptionsFromJS is allocating a new
-// DecoderOptions object and copy all values from
-// input javascript object
-func DecoderOptionsFromJS(value js.Wrapper) *DecoderOptions {
-	input := value.JSValue()
+// DecoderOptions object and copy all values in the value javascript object.
+func DecoderOptionsFromJS(value js.Value) *DecoderOptions {
 	var out DecoderOptions
 	var (
 		value0 bool // javascript: boolean {fatal Fatal fatal}
 		value1 bool // javascript: boolean {ignoreBOM IgnoreBOM ignoreBOM}
 	)
-	value0 = (input.Get("fatal")).Bool()
+	value0 = (value.Get("fatal")).Bool()
 	out.Fatal = value0
-	value1 = (input.Get("ignoreBOM")).Bool()
+	value1 = (value.Get("ignoreBOM")).Bool()
 	out.IgnoreBOM = value1
 	return &out
 }
@@ -106,7 +103,7 @@ type EncoderEncodeIntoResult struct {
 	Written int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EncoderEncodeIntoResult) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -118,18 +115,16 @@ func (_this *EncoderEncodeIntoResult) JSValue() js.Value {
 }
 
 // EncoderEncodeIntoResultFromJS is allocating a new
-// EncoderEncodeIntoResult object and copy all values from
-// input javascript object
-func EncoderEncodeIntoResultFromJS(value js.Wrapper) *EncoderEncodeIntoResult {
-	input := value.JSValue()
+// EncoderEncodeIntoResult object and copy all values in the value javascript object.
+func EncoderEncodeIntoResultFromJS(value js.Value) *EncoderEncodeIntoResult {
 	var out EncoderEncodeIntoResult
 	var (
 		value0 int // javascript: unsigned long long {read Read read}
 		value1 int // javascript: unsigned long long {written Written written}
 	)
-	value0 = (input.Get("read")).Int()
+	value0 = (value.Get("read")).Int()
 	out.Read = value0
-	value1 = (input.Get("written")).Int()
+	value1 = (value.Get("written")).Int()
 	out.Written = value1
 	return &out
 }
@@ -144,15 +139,19 @@ func (_this *Decoder) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DecoderFromJS is casting a js.Wrapper into Decoder.
-func DecoderFromJS(value js.Wrapper) *Decoder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DecoderFromJS is casting a js.Value into Decoder.
+func DecoderFromJS(value js.Value) *Decoder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Decoder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DecoderFromJS is casting from something that holds a js.Value into Decoder.
+func DecoderFromWrapper(input core.Wrapper) *Decoder {
+	return DecoderFromJS(input.JSValue())
 }
 
 func NewTextDecoder(label *string, options *DecoderOptions) (_result *Decoder) {
@@ -247,15 +246,19 @@ func (_this *DecoderStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DecoderStreamFromJS is casting a js.Wrapper into DecoderStream.
-func DecoderStreamFromJS(value js.Wrapper) *DecoderStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DecoderStreamFromJS is casting a js.Value into DecoderStream.
+func DecoderStreamFromJS(value js.Value) *DecoderStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DecoderStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DecoderStreamFromJS is casting from something that holds a js.Value into DecoderStream.
+func DecoderStreamFromWrapper(input core.Wrapper) *DecoderStream {
+	return DecoderStreamFromJS(input.JSValue())
 }
 
 func NewTextDecoderStream(label *string, options *DecoderOptions) (_result *DecoderStream) {
@@ -344,15 +347,19 @@ func (_this *Encoder) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EncoderFromJS is casting a js.Wrapper into Encoder.
-func EncoderFromJS(value js.Wrapper) *Encoder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EncoderFromJS is casting a js.Value into Encoder.
+func EncoderFromJS(value js.Value) *Encoder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Encoder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EncoderFromJS is casting from something that holds a js.Value into Encoder.
+func EncoderFromWrapper(input core.Wrapper) *Encoder {
+	return EncoderFromJS(input.JSValue())
 }
 
 func NewTextEncoder() (_result *Encoder) {
@@ -434,15 +441,19 @@ func (_this *EncoderStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EncoderStreamFromJS is casting a js.Wrapper into EncoderStream.
-func EncoderStreamFromJS(value js.Wrapper) *EncoderStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EncoderStreamFromJS is casting a js.Value into EncoderStream.
+func EncoderStreamFromJS(value js.Value) *EncoderStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EncoderStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EncoderStreamFromJS is casting from something that holds a js.Value into EncoderStream.
+func EncoderStreamFromWrapper(input core.Wrapper) *EncoderStream {
+	return EncoderStreamFromJS(input.JSValue())
 }
 
 func NewTextEncoderStream() (_result *EncoderStream) {

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,7 @@ import (
 
 func Example_buttonTest() {
 	element := webapi.GetWindow().Document().GetElementById("foo")
-	button := html.HTMLButtonElementFromJS(element)
+	button := html.HTMLButtonElementFromWrapper(element)
 	button.SetInnerText("Press me!")
 
 	count := 1

--- a/featurepolicy/featurepolicy.go
+++ b/featurepolicy/featurepolicy.go
@@ -7,6 +7,7 @@ package featurepolicy
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/reporting"
 )
 
@@ -46,15 +47,19 @@ func (_this *FeaturePolicy) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FeaturePolicyFromJS is casting a js.Wrapper into FeaturePolicy.
-func FeaturePolicyFromJS(value js.Wrapper) *FeaturePolicy {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FeaturePolicyFromJS is casting a js.Value into FeaturePolicy.
+func FeaturePolicyFromJS(value js.Value) *FeaturePolicy {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FeaturePolicy{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FeaturePolicyFromJS is casting from something that holds a js.Value into FeaturePolicy.
+func FeaturePolicyFromWrapper(input core.Wrapper) *FeaturePolicy {
+	return FeaturePolicyFromJS(input.JSValue())
 }
 
 func (_this *FeaturePolicy) AllowsFeature(feature string, origin *string) (_result bool) {
@@ -159,15 +164,19 @@ type ViolationReportBody struct {
 	reporting.ReportBody
 }
 
-// ViolationReportBodyFromJS is casting a js.Wrapper into ViolationReportBody.
-func ViolationReportBodyFromJS(value js.Wrapper) *ViolationReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ViolationReportBodyFromJS is casting a js.Value into ViolationReportBody.
+func ViolationReportBodyFromJS(value js.Value) *ViolationReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ViolationReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ViolationReportBodyFromJS is casting from something that holds a js.Value into ViolationReportBody.
+func ViolationReportBodyFromWrapper(input core.Wrapper) *ViolationReportBody {
+	return ViolationReportBodyFromJS(input.JSValue())
 }
 
 // FeatureId returning attribute 'featureId' with

--- a/featurepolicy/featurepolicy_js.go
+++ b/featurepolicy/featurepolicy_js.go
@@ -5,6 +5,7 @@ package featurepolicy
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/reporting"
 )
 
@@ -44,15 +45,19 @@ func (_this *FeaturePolicy) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FeaturePolicyFromJS is casting a js.Wrapper into FeaturePolicy.
-func FeaturePolicyFromJS(value js.Wrapper) *FeaturePolicy {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FeaturePolicyFromJS is casting a js.Value into FeaturePolicy.
+func FeaturePolicyFromJS(value js.Value) *FeaturePolicy {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FeaturePolicy{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FeaturePolicyFromJS is casting from something that holds a js.Value into FeaturePolicy.
+func FeaturePolicyFromWrapper(input core.Wrapper) *FeaturePolicy {
+	return FeaturePolicyFromJS(input.JSValue())
 }
 
 func (_this *FeaturePolicy) AllowsFeature(feature string, origin *string) (_result bool) {
@@ -157,15 +162,19 @@ type ViolationReportBody struct {
 	reporting.ReportBody
 }
 
-// ViolationReportBodyFromJS is casting a js.Wrapper into ViolationReportBody.
-func ViolationReportBodyFromJS(value js.Wrapper) *ViolationReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ViolationReportBodyFromJS is casting a js.Value into ViolationReportBody.
+func ViolationReportBodyFromJS(value js.Value) *ViolationReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ViolationReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ViolationReportBodyFromJS is casting from something that holds a js.Value into ViolationReportBody.
+func ViolationReportBodyFromWrapper(input core.Wrapper) *ViolationReportBody {
+	return ViolationReportBodyFromJS(input.JSValue())
 }
 
 // FeatureId returning attribute 'featureId' with

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -7,6 +7,7 @@ package fetch
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html"
@@ -517,7 +518,7 @@ type HeadersEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -533,26 +534,24 @@ func (_this *HeadersEntryIteratorValue) JSValue() js.Value {
 }
 
 // HeadersEntryIteratorValueFromJS is allocating a new
-// HeadersEntryIteratorValue object and copy all values from
-// input javascript object
-func HeadersEntryIteratorValueFromJS(value js.Wrapper) *HeadersEntryIteratorValue {
-	input := value.JSValue()
+// HeadersEntryIteratorValue object and copy all values in the value javascript object.
+func HeadersEntryIteratorValueFromJS(value js.Value) *HeadersEntryIteratorValue {
 	var out HeadersEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -563,7 +562,7 @@ type HeadersKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -575,18 +574,16 @@ func (_this *HeadersKeyIteratorValue) JSValue() js.Value {
 }
 
 // HeadersKeyIteratorValueFromJS is allocating a new
-// HeadersKeyIteratorValue object and copy all values from
-// input javascript object
-func HeadersKeyIteratorValueFromJS(value js.Wrapper) *HeadersKeyIteratorValue {
-	input := value.JSValue()
+// HeadersKeyIteratorValue object and copy all values in the value javascript object.
+func HeadersKeyIteratorValueFromJS(value js.Value) *HeadersKeyIteratorValue {
 	var out HeadersKeyIteratorValue
 	var (
 		value0 *patch.ByteString // javascript: ByteString {value Value value}
 		value1 bool              // javascript: boolean {done Done done}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("value"))
+	value0 = patch.ByteStringFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -597,7 +594,7 @@ type HeadersValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -609,18 +606,16 @@ func (_this *HeadersValueIteratorValue) JSValue() js.Value {
 }
 
 // HeadersValueIteratorValueFromJS is allocating a new
-// HeadersValueIteratorValue object and copy all values from
-// input javascript object
-func HeadersValueIteratorValueFromJS(value js.Wrapper) *HeadersValueIteratorValue {
-	input := value.JSValue()
+// HeadersValueIteratorValue object and copy all values in the value javascript object.
+func HeadersValueIteratorValueFromJS(value js.Value) *HeadersValueIteratorValue {
 	var out HeadersValueIteratorValue
 	var (
 		value0 *patch.ByteString // javascript: ByteString {value Value value}
 		value1 bool              // javascript: boolean {done Done done}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("value"))
+	value0 = patch.ByteStringFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -642,7 +637,7 @@ type RequestInit struct {
 	Window         js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RequestInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -684,10 +679,8 @@ func (_this *RequestInit) JSValue() js.Value {
 }
 
 // RequestInitFromJS is allocating a new
-// RequestInit object and copy all values from
-// input javascript object
-func RequestInitFromJS(value js.Wrapper) *RequestInit {
-	input := value.JSValue()
+// RequestInit object and copy all values in the value javascript object.
+func RequestInitFromJS(value js.Value) *RequestInit {
 	var out RequestInit
 	var (
 		value0  *patch.ByteString     // javascript: ByteString {method Method method}
@@ -704,13 +697,13 @@ func RequestInitFromJS(value js.Wrapper) *RequestInit {
 		value11 *domcore.AbortSignal  // javascript: AbortSignal {signal Signal signal}
 		value12 js.Value              // javascript: any {window Window window}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("method"))
+	value0 = patch.ByteStringFromJS(value.Get("method"))
 	out.Method = value0
-	__length1 := input.Get("headers").Length()
+	__length1 := value.Get("headers").Length()
 	__array1 := make([][]*patch.ByteString, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 []*patch.ByteString
-		__seq_in1 := input.Get("headers").Index(__idx1)
+		__seq_in1 := value.Get("headers").Index(__idx1)
 		__length2 := __seq_in1.Length()
 		__array2 := make([]*patch.ByteString, __length2, __length2)
 		for __idx2 := 0; __idx2 < __length2; __idx2++ {
@@ -724,31 +717,31 @@ func RequestInitFromJS(value js.Wrapper) *RequestInit {
 	}
 	value1 = __array1
 	out.Headers = value1
-	if input.Get("body").Type() != js.TypeNull && input.Get("body").Type() != js.TypeUndefined {
-		value2 = UnionFromJS(input.Get("body"))
+	if value.Get("body").Type() != js.TypeNull && value.Get("body").Type() != js.TypeUndefined {
+		value2 = UnionFromJS(value.Get("body"))
 	}
 	out.Body = value2
-	value3 = (input.Get("referrer")).String()
+	value3 = (value.Get("referrer")).String()
 	out.Referrer = value3
-	value4 = ReferrerPolicyFromJS(input.Get("referrerPolicy"))
+	value4 = ReferrerPolicyFromJS(value.Get("referrerPolicy"))
 	out.ReferrerPolicy = value4
-	value5 = RequestModeFromJS(input.Get("mode"))
+	value5 = RequestModeFromJS(value.Get("mode"))
 	out.Mode = value5
-	value6 = RequestCredentialsFromJS(input.Get("credentials"))
+	value6 = RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value6
-	value7 = RequestCacheFromJS(input.Get("cache"))
+	value7 = RequestCacheFromJS(value.Get("cache"))
 	out.Cache = value7
-	value8 = RequestRedirectFromJS(input.Get("redirect"))
+	value8 = RequestRedirectFromJS(value.Get("redirect"))
 	out.Redirect = value8
-	value9 = (input.Get("integrity")).String()
+	value9 = (value.Get("integrity")).String()
 	out.Integrity = value9
-	value10 = (input.Get("keepalive")).Bool()
+	value10 = (value.Get("keepalive")).Bool()
 	out.Keepalive = value10
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value11 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value11 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value11
-	value12 = input.Get("window")
+	value12 = value.Get("window")
 	out.Window = value12
 	return &out
 }
@@ -760,7 +753,7 @@ type ResponseInit struct {
 	Headers    [][]*patch.ByteString
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ResponseInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -782,25 +775,23 @@ func (_this *ResponseInit) JSValue() js.Value {
 }
 
 // ResponseInitFromJS is allocating a new
-// ResponseInit object and copy all values from
-// input javascript object
-func ResponseInitFromJS(value js.Wrapper) *ResponseInit {
-	input := value.JSValue()
+// ResponseInit object and copy all values in the value javascript object.
+func ResponseInitFromJS(value js.Value) *ResponseInit {
 	var out ResponseInit
 	var (
 		value0 int                   // javascript: unsigned short {status Status status}
 		value1 *patch.ByteString     // javascript: ByteString {statusText StatusText statusText}
 		value2 [][]*patch.ByteString // javascript: sequence<sequence<ByteString>> {headers Headers headers}
 	)
-	value0 = (input.Get("status")).Int()
+	value0 = (value.Get("status")).Int()
 	out.Status = value0
-	value1 = patch.ByteStringFromJS(input.Get("statusText"))
+	value1 = patch.ByteStringFromJS(value.Get("statusText"))
 	out.StatusText = value1
-	__length2 := input.Get("headers").Length()
+	__length2 := value.Get("headers").Length()
 	__array2 := make([][]*patch.ByteString, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 []*patch.ByteString
-		__seq_in2 := input.Get("headers").Index(__idx2)
+		__seq_in2 := value.Get("headers").Index(__idx2)
 		__length3 := __seq_in2.Length()
 		__array3 := make([]*patch.ByteString, __length3, __length3)
 		for __idx3 := 0; __idx3 < __length3; __idx3++ {
@@ -827,15 +818,19 @@ func (_this *Headers) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersFromJS is casting a js.Wrapper into Headers.
-func HeadersFromJS(value js.Wrapper) *Headers {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersFromJS is casting a js.Value into Headers.
+func HeadersFromJS(value js.Value) *Headers {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Headers{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersFromJS is casting from something that holds a js.Value into Headers.
+func HeadersFromWrapper(input core.Wrapper) *Headers {
+	return HeadersFromJS(input.JSValue())
 }
 
 func NewHeaders(init [][]*patch.ByteString) (_result *Headers) {
@@ -1020,15 +1015,19 @@ func (_this *HeadersEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersEntryIteratorFromJS is casting a js.Wrapper into HeadersEntryIterator.
-func HeadersEntryIteratorFromJS(value js.Wrapper) *HeadersEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersEntryIteratorFromJS is casting a js.Value into HeadersEntryIterator.
+func HeadersEntryIteratorFromJS(value js.Value) *HeadersEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersEntryIteratorFromJS is casting from something that holds a js.Value into HeadersEntryIterator.
+func HeadersEntryIteratorFromWrapper(input core.Wrapper) *HeadersEntryIterator {
+	return HeadersEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersEntryIterator) Next() (_result *HeadersEntryIteratorValue) {
@@ -1055,15 +1054,19 @@ func (_this *HeadersKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersKeyIteratorFromJS is casting a js.Wrapper into HeadersKeyIterator.
-func HeadersKeyIteratorFromJS(value js.Wrapper) *HeadersKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersKeyIteratorFromJS is casting a js.Value into HeadersKeyIterator.
+func HeadersKeyIteratorFromJS(value js.Value) *HeadersKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersKeyIteratorFromJS is casting from something that holds a js.Value into HeadersKeyIterator.
+func HeadersKeyIteratorFromWrapper(input core.Wrapper) *HeadersKeyIterator {
+	return HeadersKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersKeyIterator) Next() (_result *HeadersKeyIteratorValue) {
@@ -1090,15 +1093,19 @@ func (_this *HeadersValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersValueIteratorFromJS is casting a js.Wrapper into HeadersValueIterator.
-func HeadersValueIteratorFromJS(value js.Wrapper) *HeadersValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersValueIteratorFromJS is casting a js.Value into HeadersValueIterator.
+func HeadersValueIteratorFromJS(value js.Value) *HeadersValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersValueIteratorFromJS is casting from something that holds a js.Value into HeadersValueIterator.
+func HeadersValueIteratorFromWrapper(input core.Wrapper) *HeadersValueIterator {
+	return HeadersValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersValueIterator) Next() (_result *HeadersValueIteratorValue) {
@@ -1125,15 +1132,19 @@ func (_this *PromiseResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseResponseFromJS is casting a js.Wrapper into PromiseResponse.
-func PromiseResponseFromJS(value js.Wrapper) *PromiseResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseResponseFromJS is casting a js.Value into PromiseResponse.
+func PromiseResponseFromJS(value js.Value) *PromiseResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseResponseFromJS is casting from something that holds a js.Value into PromiseResponse.
+func PromiseResponseFromWrapper(input core.Wrapper) *PromiseResponse {
+	return PromiseResponseFromJS(input.JSValue())
 }
 
 func (_this *PromiseResponse) Then(onFulfilled *PromiseResponseOnFulfilled, onRejected *PromiseResponseOnRejected) (_result *PromiseResponse) {
@@ -1230,15 +1241,19 @@ func (_this *Request) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RequestFromJS is casting a js.Wrapper into Request.
-func RequestFromJS(value js.Wrapper) *Request {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RequestFromJS is casting a js.Value into Request.
+func RequestFromJS(value js.Value) *Request {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Request{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RequestFromJS is casting from something that holds a js.Value into Request.
+func RequestFromWrapper(input core.Wrapper) *Request {
+	return RequestFromJS(input.JSValue())
 }
 
 func NewRequest(input *Union, init *RequestInit) (_result *Request) {
@@ -1513,15 +1528,19 @@ func (_this *Response) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResponseFromJS is casting a js.Wrapper into Response.
-func ResponseFromJS(value js.Wrapper) *Response {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResponseFromJS is casting a js.Value into Response.
+func ResponseFromJS(value js.Value) *Response {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Response{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResponseFromJS is casting from something that holds a js.Value into Response.
+func ResponseFromWrapper(input core.Wrapper) *Response {
+	return ResponseFromJS(input.JSValue())
 }
 
 func Error() (_result *Response) {

--- a/fetch/fetch_js.go
+++ b/fetch/fetch_js.go
@@ -5,6 +5,7 @@ package fetch
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html"
@@ -515,7 +516,7 @@ type HeadersEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -531,26 +532,24 @@ func (_this *HeadersEntryIteratorValue) JSValue() js.Value {
 }
 
 // HeadersEntryIteratorValueFromJS is allocating a new
-// HeadersEntryIteratorValue object and copy all values from
-// input javascript object
-func HeadersEntryIteratorValueFromJS(value js.Wrapper) *HeadersEntryIteratorValue {
-	input := value.JSValue()
+// HeadersEntryIteratorValue object and copy all values in the value javascript object.
+func HeadersEntryIteratorValueFromJS(value js.Value) *HeadersEntryIteratorValue {
 	var out HeadersEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -561,7 +560,7 @@ type HeadersKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -573,18 +572,16 @@ func (_this *HeadersKeyIteratorValue) JSValue() js.Value {
 }
 
 // HeadersKeyIteratorValueFromJS is allocating a new
-// HeadersKeyIteratorValue object and copy all values from
-// input javascript object
-func HeadersKeyIteratorValueFromJS(value js.Wrapper) *HeadersKeyIteratorValue {
-	input := value.JSValue()
+// HeadersKeyIteratorValue object and copy all values in the value javascript object.
+func HeadersKeyIteratorValueFromJS(value js.Value) *HeadersKeyIteratorValue {
 	var out HeadersKeyIteratorValue
 	var (
 		value0 *patch.ByteString // javascript: ByteString {value Value value}
 		value1 bool              // javascript: boolean {done Done done}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("value"))
+	value0 = patch.ByteStringFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -595,7 +592,7 @@ type HeadersValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HeadersValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -607,18 +604,16 @@ func (_this *HeadersValueIteratorValue) JSValue() js.Value {
 }
 
 // HeadersValueIteratorValueFromJS is allocating a new
-// HeadersValueIteratorValue object and copy all values from
-// input javascript object
-func HeadersValueIteratorValueFromJS(value js.Wrapper) *HeadersValueIteratorValue {
-	input := value.JSValue()
+// HeadersValueIteratorValue object and copy all values in the value javascript object.
+func HeadersValueIteratorValueFromJS(value js.Value) *HeadersValueIteratorValue {
 	var out HeadersValueIteratorValue
 	var (
 		value0 *patch.ByteString // javascript: ByteString {value Value value}
 		value1 bool              // javascript: boolean {done Done done}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("value"))
+	value0 = patch.ByteStringFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -640,7 +635,7 @@ type RequestInit struct {
 	Window         js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RequestInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -682,10 +677,8 @@ func (_this *RequestInit) JSValue() js.Value {
 }
 
 // RequestInitFromJS is allocating a new
-// RequestInit object and copy all values from
-// input javascript object
-func RequestInitFromJS(value js.Wrapper) *RequestInit {
-	input := value.JSValue()
+// RequestInit object and copy all values in the value javascript object.
+func RequestInitFromJS(value js.Value) *RequestInit {
 	var out RequestInit
 	var (
 		value0  *patch.ByteString     // javascript: ByteString {method Method method}
@@ -702,13 +695,13 @@ func RequestInitFromJS(value js.Wrapper) *RequestInit {
 		value11 *domcore.AbortSignal  // javascript: AbortSignal {signal Signal signal}
 		value12 js.Value              // javascript: any {window Window window}
 	)
-	value0 = patch.ByteStringFromJS(input.Get("method"))
+	value0 = patch.ByteStringFromJS(value.Get("method"))
 	out.Method = value0
-	__length1 := input.Get("headers").Length()
+	__length1 := value.Get("headers").Length()
 	__array1 := make([][]*patch.ByteString, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 []*patch.ByteString
-		__seq_in1 := input.Get("headers").Index(__idx1)
+		__seq_in1 := value.Get("headers").Index(__idx1)
 		__length2 := __seq_in1.Length()
 		__array2 := make([]*patch.ByteString, __length2, __length2)
 		for __idx2 := 0; __idx2 < __length2; __idx2++ {
@@ -722,31 +715,31 @@ func RequestInitFromJS(value js.Wrapper) *RequestInit {
 	}
 	value1 = __array1
 	out.Headers = value1
-	if input.Get("body").Type() != js.TypeNull && input.Get("body").Type() != js.TypeUndefined {
-		value2 = UnionFromJS(input.Get("body"))
+	if value.Get("body").Type() != js.TypeNull && value.Get("body").Type() != js.TypeUndefined {
+		value2 = UnionFromJS(value.Get("body"))
 	}
 	out.Body = value2
-	value3 = (input.Get("referrer")).String()
+	value3 = (value.Get("referrer")).String()
 	out.Referrer = value3
-	value4 = ReferrerPolicyFromJS(input.Get("referrerPolicy"))
+	value4 = ReferrerPolicyFromJS(value.Get("referrerPolicy"))
 	out.ReferrerPolicy = value4
-	value5 = RequestModeFromJS(input.Get("mode"))
+	value5 = RequestModeFromJS(value.Get("mode"))
 	out.Mode = value5
-	value6 = RequestCredentialsFromJS(input.Get("credentials"))
+	value6 = RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value6
-	value7 = RequestCacheFromJS(input.Get("cache"))
+	value7 = RequestCacheFromJS(value.Get("cache"))
 	out.Cache = value7
-	value8 = RequestRedirectFromJS(input.Get("redirect"))
+	value8 = RequestRedirectFromJS(value.Get("redirect"))
 	out.Redirect = value8
-	value9 = (input.Get("integrity")).String()
+	value9 = (value.Get("integrity")).String()
 	out.Integrity = value9
-	value10 = (input.Get("keepalive")).Bool()
+	value10 = (value.Get("keepalive")).Bool()
 	out.Keepalive = value10
-	if input.Get("signal").Type() != js.TypeNull && input.Get("signal").Type() != js.TypeUndefined {
-		value11 = domcore.AbortSignalFromJS(input.Get("signal"))
+	if value.Get("signal").Type() != js.TypeNull && value.Get("signal").Type() != js.TypeUndefined {
+		value11 = domcore.AbortSignalFromJS(value.Get("signal"))
 	}
 	out.Signal = value11
-	value12 = input.Get("window")
+	value12 = value.Get("window")
 	out.Window = value12
 	return &out
 }
@@ -758,7 +751,7 @@ type ResponseInit struct {
 	Headers    [][]*patch.ByteString
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ResponseInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -780,25 +773,23 @@ func (_this *ResponseInit) JSValue() js.Value {
 }
 
 // ResponseInitFromJS is allocating a new
-// ResponseInit object and copy all values from
-// input javascript object
-func ResponseInitFromJS(value js.Wrapper) *ResponseInit {
-	input := value.JSValue()
+// ResponseInit object and copy all values in the value javascript object.
+func ResponseInitFromJS(value js.Value) *ResponseInit {
 	var out ResponseInit
 	var (
 		value0 int                   // javascript: unsigned short {status Status status}
 		value1 *patch.ByteString     // javascript: ByteString {statusText StatusText statusText}
 		value2 [][]*patch.ByteString // javascript: sequence<sequence<ByteString>> {headers Headers headers}
 	)
-	value0 = (input.Get("status")).Int()
+	value0 = (value.Get("status")).Int()
 	out.Status = value0
-	value1 = patch.ByteStringFromJS(input.Get("statusText"))
+	value1 = patch.ByteStringFromJS(value.Get("statusText"))
 	out.StatusText = value1
-	__length2 := input.Get("headers").Length()
+	__length2 := value.Get("headers").Length()
 	__array2 := make([][]*patch.ByteString, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 []*patch.ByteString
-		__seq_in2 := input.Get("headers").Index(__idx2)
+		__seq_in2 := value.Get("headers").Index(__idx2)
 		__length3 := __seq_in2.Length()
 		__array3 := make([]*patch.ByteString, __length3, __length3)
 		for __idx3 := 0; __idx3 < __length3; __idx3++ {
@@ -825,15 +816,19 @@ func (_this *Headers) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersFromJS is casting a js.Wrapper into Headers.
-func HeadersFromJS(value js.Wrapper) *Headers {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersFromJS is casting a js.Value into Headers.
+func HeadersFromJS(value js.Value) *Headers {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Headers{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersFromJS is casting from something that holds a js.Value into Headers.
+func HeadersFromWrapper(input core.Wrapper) *Headers {
+	return HeadersFromJS(input.JSValue())
 }
 
 func NewHeaders(init [][]*patch.ByteString) (_result *Headers) {
@@ -1018,15 +1013,19 @@ func (_this *HeadersEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersEntryIteratorFromJS is casting a js.Wrapper into HeadersEntryIterator.
-func HeadersEntryIteratorFromJS(value js.Wrapper) *HeadersEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersEntryIteratorFromJS is casting a js.Value into HeadersEntryIterator.
+func HeadersEntryIteratorFromJS(value js.Value) *HeadersEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersEntryIteratorFromJS is casting from something that holds a js.Value into HeadersEntryIterator.
+func HeadersEntryIteratorFromWrapper(input core.Wrapper) *HeadersEntryIterator {
+	return HeadersEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersEntryIterator) Next() (_result *HeadersEntryIteratorValue) {
@@ -1053,15 +1052,19 @@ func (_this *HeadersKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersKeyIteratorFromJS is casting a js.Wrapper into HeadersKeyIterator.
-func HeadersKeyIteratorFromJS(value js.Wrapper) *HeadersKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersKeyIteratorFromJS is casting a js.Value into HeadersKeyIterator.
+func HeadersKeyIteratorFromJS(value js.Value) *HeadersKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersKeyIteratorFromJS is casting from something that holds a js.Value into HeadersKeyIterator.
+func HeadersKeyIteratorFromWrapper(input core.Wrapper) *HeadersKeyIterator {
+	return HeadersKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersKeyIterator) Next() (_result *HeadersKeyIteratorValue) {
@@ -1088,15 +1091,19 @@ func (_this *HeadersValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HeadersValueIteratorFromJS is casting a js.Wrapper into HeadersValueIterator.
-func HeadersValueIteratorFromJS(value js.Wrapper) *HeadersValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HeadersValueIteratorFromJS is casting a js.Value into HeadersValueIterator.
+func HeadersValueIteratorFromJS(value js.Value) *HeadersValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HeadersValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HeadersValueIteratorFromJS is casting from something that holds a js.Value into HeadersValueIterator.
+func HeadersValueIteratorFromWrapper(input core.Wrapper) *HeadersValueIterator {
+	return HeadersValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *HeadersValueIterator) Next() (_result *HeadersValueIteratorValue) {
@@ -1123,15 +1130,19 @@ func (_this *PromiseResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseResponseFromJS is casting a js.Wrapper into PromiseResponse.
-func PromiseResponseFromJS(value js.Wrapper) *PromiseResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseResponseFromJS is casting a js.Value into PromiseResponse.
+func PromiseResponseFromJS(value js.Value) *PromiseResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseResponseFromJS is casting from something that holds a js.Value into PromiseResponse.
+func PromiseResponseFromWrapper(input core.Wrapper) *PromiseResponse {
+	return PromiseResponseFromJS(input.JSValue())
 }
 
 func (_this *PromiseResponse) Then(onFulfilled *PromiseResponseOnFulfilled, onRejected *PromiseResponseOnRejected) (_result *PromiseResponse) {
@@ -1228,15 +1239,19 @@ func (_this *Request) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RequestFromJS is casting a js.Wrapper into Request.
-func RequestFromJS(value js.Wrapper) *Request {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RequestFromJS is casting a js.Value into Request.
+func RequestFromJS(value js.Value) *Request {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Request{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RequestFromJS is casting from something that holds a js.Value into Request.
+func RequestFromWrapper(input core.Wrapper) *Request {
+	return RequestFromJS(input.JSValue())
 }
 
 func NewRequest(input *Union, init *RequestInit) (_result *Request) {
@@ -1511,15 +1526,19 @@ func (_this *Response) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ResponseFromJS is casting a js.Wrapper into Response.
-func ResponseFromJS(value js.Wrapper) *Response {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResponseFromJS is casting a js.Value into Response.
+func ResponseFromJS(value js.Value) *Response {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Response{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResponseFromJS is casting from something that holds a js.Value into Response.
+func ResponseFromWrapper(input core.Wrapper) *Response {
+	return ResponseFromJS(input.JSValue())
 }
 
 func Error() (_result *Response) {

--- a/file/entries/entries.go
+++ b/file/entries/entries.go
@@ -7,6 +7,7 @@ package entries
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 )
@@ -216,7 +217,7 @@ type FileSystemFlags struct {
 	Exclusive bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FileSystemFlags) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -228,18 +229,16 @@ func (_this *FileSystemFlags) JSValue() js.Value {
 }
 
 // FileSystemFlagsFromJS is allocating a new
-// FileSystemFlags object and copy all values from
-// input javascript object
-func FileSystemFlagsFromJS(value js.Wrapper) *FileSystemFlags {
-	input := value.JSValue()
+// FileSystemFlags object and copy all values in the value javascript object.
+func FileSystemFlagsFromJS(value js.Value) *FileSystemFlags {
 	var out FileSystemFlags
 	var (
 		value0 bool // javascript: boolean {create Create create}
 		value1 bool // javascript: boolean {exclusive Exclusive exclusive}
 	)
-	value0 = (input.Get("create")).Bool()
+	value0 = (value.Get("create")).Bool()
 	out.Create = value0
-	value1 = (input.Get("exclusive")).Bool()
+	value1 = (value.Get("exclusive")).Bool()
 	out.Exclusive = value1
 	return &out
 }
@@ -254,15 +253,19 @@ func (_this *FileSystem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemFromJS is casting a js.Wrapper into FileSystem.
-func FileSystemFromJS(value js.Wrapper) *FileSystem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemFromJS is casting a js.Value into FileSystem.
+func FileSystemFromJS(value js.Value) *FileSystem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemFromJS is casting from something that holds a js.Value into FileSystem.
+func FileSystemFromWrapper(input core.Wrapper) *FileSystem {
+	return FileSystemFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -288,15 +291,19 @@ type FileSystemDirectoryEntry struct {
 	FileSystemEntry
 }
 
-// FileSystemDirectoryEntryFromJS is casting a js.Wrapper into FileSystemDirectoryEntry.
-func FileSystemDirectoryEntryFromJS(value js.Wrapper) *FileSystemDirectoryEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemDirectoryEntryFromJS is casting a js.Value into FileSystemDirectoryEntry.
+func FileSystemDirectoryEntryFromJS(value js.Value) *FileSystemDirectoryEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemDirectoryEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemDirectoryEntryFromJS is casting from something that holds a js.Value into FileSystemDirectoryEntry.
+func FileSystemDirectoryEntryFromWrapper(input core.Wrapper) *FileSystemDirectoryEntry {
+	return FileSystemDirectoryEntryFromJS(input.JSValue())
 }
 
 func (_this *FileSystemDirectoryEntry) CreateReader() (_result *FileSystemDirectoryReader) {
@@ -421,15 +428,19 @@ func (_this *FileSystemDirectoryReader) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemDirectoryReaderFromJS is casting a js.Wrapper into FileSystemDirectoryReader.
-func FileSystemDirectoryReaderFromJS(value js.Wrapper) *FileSystemDirectoryReader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemDirectoryReaderFromJS is casting a js.Value into FileSystemDirectoryReader.
+func FileSystemDirectoryReaderFromJS(value js.Value) *FileSystemDirectoryReader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemDirectoryReader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemDirectoryReaderFromJS is casting from something that holds a js.Value into FileSystemDirectoryReader.
+func FileSystemDirectoryReaderFromWrapper(input core.Wrapper) *FileSystemDirectoryReader {
+	return FileSystemDirectoryReaderFromJS(input.JSValue())
 }
 
 func (_this *FileSystemDirectoryReader) ReadEntries(successCallback *FileSystemEntriesCallback, errorCallback *ErrorCallback) {
@@ -473,15 +484,19 @@ func (_this *FileSystemEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemEntryFromJS is casting a js.Wrapper into FileSystemEntry.
-func FileSystemEntryFromJS(value js.Wrapper) *FileSystemEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemEntryFromJS is casting a js.Value into FileSystemEntry.
+func FileSystemEntryFromJS(value js.Value) *FileSystemEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemEntryFromJS is casting from something that holds a js.Value into FileSystemEntry.
+func FileSystemEntryFromWrapper(input core.Wrapper) *FileSystemEntry {
+	return FileSystemEntryFromJS(input.JSValue())
 }
 
 // IsFile returning attribute 'isFile' with
@@ -567,15 +582,19 @@ type FileSystemFileEntry struct {
 	FileSystemEntry
 }
 
-// FileSystemFileEntryFromJS is casting a js.Wrapper into FileSystemFileEntry.
-func FileSystemFileEntryFromJS(value js.Wrapper) *FileSystemFileEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemFileEntryFromJS is casting a js.Value into FileSystemFileEntry.
+func FileSystemFileEntryFromJS(value js.Value) *FileSystemFileEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemFileEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemFileEntryFromJS is casting from something that holds a js.Value into FileSystemFileEntry.
+func FileSystemFileEntryFromWrapper(input core.Wrapper) *FileSystemFileEntry {
+	return FileSystemFileEntryFromJS(input.JSValue())
 }
 
 func (_this *FileSystemFileEntry) File(successCallback *FileCallback, errorCallback *ErrorCallback) {

--- a/file/entries/entries_js.go
+++ b/file/entries/entries_js.go
@@ -5,6 +5,7 @@ package entries
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 )
@@ -214,7 +215,7 @@ type FileSystemFlags struct {
 	Exclusive bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FileSystemFlags) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -226,18 +227,16 @@ func (_this *FileSystemFlags) JSValue() js.Value {
 }
 
 // FileSystemFlagsFromJS is allocating a new
-// FileSystemFlags object and copy all values from
-// input javascript object
-func FileSystemFlagsFromJS(value js.Wrapper) *FileSystemFlags {
-	input := value.JSValue()
+// FileSystemFlags object and copy all values in the value javascript object.
+func FileSystemFlagsFromJS(value js.Value) *FileSystemFlags {
 	var out FileSystemFlags
 	var (
 		value0 bool // javascript: boolean {create Create create}
 		value1 bool // javascript: boolean {exclusive Exclusive exclusive}
 	)
-	value0 = (input.Get("create")).Bool()
+	value0 = (value.Get("create")).Bool()
 	out.Create = value0
-	value1 = (input.Get("exclusive")).Bool()
+	value1 = (value.Get("exclusive")).Bool()
 	out.Exclusive = value1
 	return &out
 }
@@ -252,15 +251,19 @@ func (_this *FileSystem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemFromJS is casting a js.Wrapper into FileSystem.
-func FileSystemFromJS(value js.Wrapper) *FileSystem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemFromJS is casting a js.Value into FileSystem.
+func FileSystemFromJS(value js.Value) *FileSystem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemFromJS is casting from something that holds a js.Value into FileSystem.
+func FileSystemFromWrapper(input core.Wrapper) *FileSystem {
+	return FileSystemFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -286,15 +289,19 @@ type FileSystemDirectoryEntry struct {
 	FileSystemEntry
 }
 
-// FileSystemDirectoryEntryFromJS is casting a js.Wrapper into FileSystemDirectoryEntry.
-func FileSystemDirectoryEntryFromJS(value js.Wrapper) *FileSystemDirectoryEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemDirectoryEntryFromJS is casting a js.Value into FileSystemDirectoryEntry.
+func FileSystemDirectoryEntryFromJS(value js.Value) *FileSystemDirectoryEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemDirectoryEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemDirectoryEntryFromJS is casting from something that holds a js.Value into FileSystemDirectoryEntry.
+func FileSystemDirectoryEntryFromWrapper(input core.Wrapper) *FileSystemDirectoryEntry {
+	return FileSystemDirectoryEntryFromJS(input.JSValue())
 }
 
 func (_this *FileSystemDirectoryEntry) CreateReader() (_result *FileSystemDirectoryReader) {
@@ -419,15 +426,19 @@ func (_this *FileSystemDirectoryReader) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemDirectoryReaderFromJS is casting a js.Wrapper into FileSystemDirectoryReader.
-func FileSystemDirectoryReaderFromJS(value js.Wrapper) *FileSystemDirectoryReader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemDirectoryReaderFromJS is casting a js.Value into FileSystemDirectoryReader.
+func FileSystemDirectoryReaderFromJS(value js.Value) *FileSystemDirectoryReader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemDirectoryReader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemDirectoryReaderFromJS is casting from something that holds a js.Value into FileSystemDirectoryReader.
+func FileSystemDirectoryReaderFromWrapper(input core.Wrapper) *FileSystemDirectoryReader {
+	return FileSystemDirectoryReaderFromJS(input.JSValue())
 }
 
 func (_this *FileSystemDirectoryReader) ReadEntries(successCallback *FileSystemEntriesCallback, errorCallback *ErrorCallback) {
@@ -471,15 +482,19 @@ func (_this *FileSystemEntry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileSystemEntryFromJS is casting a js.Wrapper into FileSystemEntry.
-func FileSystemEntryFromJS(value js.Wrapper) *FileSystemEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemEntryFromJS is casting a js.Value into FileSystemEntry.
+func FileSystemEntryFromJS(value js.Value) *FileSystemEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemEntryFromJS is casting from something that holds a js.Value into FileSystemEntry.
+func FileSystemEntryFromWrapper(input core.Wrapper) *FileSystemEntry {
+	return FileSystemEntryFromJS(input.JSValue())
 }
 
 // IsFile returning attribute 'isFile' with
@@ -565,15 +580,19 @@ type FileSystemFileEntry struct {
 	FileSystemEntry
 }
 
-// FileSystemFileEntryFromJS is casting a js.Wrapper into FileSystemFileEntry.
-func FileSystemFileEntryFromJS(value js.Wrapper) *FileSystemFileEntry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileSystemFileEntryFromJS is casting a js.Value into FileSystemFileEntry.
+func FileSystemFileEntryFromJS(value js.Value) *FileSystemFileEntry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileSystemFileEntry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileSystemFileEntryFromJS is casting from something that holds a js.Value into FileSystemFileEntry.
+func FileSystemFileEntryFromWrapper(input core.Wrapper) *FileSystemFileEntry {
+	return FileSystemFileEntryFromJS(input.JSValue())
 }
 
 func (_this *FileSystemFileEntry) File(successCallback *FileCallback, errorCallback *ErrorCallback) {

--- a/file/file.go
+++ b/file/file.go
@@ -8,6 +8,7 @@ import js "github.com/gowebapi/webapi/core/js"
 
 import (
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -217,7 +218,7 @@ type BlobPropertyBag struct {
 	Endings EndingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BlobPropertyBag) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -229,18 +230,16 @@ func (_this *BlobPropertyBag) JSValue() js.Value {
 }
 
 // BlobPropertyBagFromJS is allocating a new
-// BlobPropertyBag object and copy all values from
-// input javascript object
-func BlobPropertyBagFromJS(value js.Wrapper) *BlobPropertyBag {
-	input := value.JSValue()
+// BlobPropertyBag object and copy all values in the value javascript object.
+func BlobPropertyBagFromJS(value js.Value) *BlobPropertyBag {
 	var out BlobPropertyBag
 	var (
 		value0 string     // javascript: DOMString {type Type _type}
 		value1 EndingType // javascript: EndingType {endings Endings endings}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = EndingTypeFromJS(input.Get("endings"))
+	value1 = EndingTypeFromJS(value.Get("endings"))
 	out.Endings = value1
 	return &out
 }
@@ -252,7 +251,7 @@ type FilePropertyBag struct {
 	LastModified int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FilePropertyBag) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -266,21 +265,19 @@ func (_this *FilePropertyBag) JSValue() js.Value {
 }
 
 // FilePropertyBagFromJS is allocating a new
-// FilePropertyBag object and copy all values from
-// input javascript object
-func FilePropertyBagFromJS(value js.Wrapper) *FilePropertyBag {
-	input := value.JSValue()
+// FilePropertyBag object and copy all values in the value javascript object.
+func FilePropertyBagFromJS(value js.Value) *FilePropertyBag {
 	var out FilePropertyBag
 	var (
 		value0 string     // javascript: DOMString {type Type _type}
 		value1 EndingType // javascript: EndingType {endings Endings endings}
 		value2 int        // javascript: long long {lastModified LastModified lastModified}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = EndingTypeFromJS(input.Get("endings"))
+	value1 = EndingTypeFromJS(value.Get("endings"))
 	out.Endings = value1
-	value2 = (input.Get("lastModified")).Int()
+	value2 = (value.Get("lastModified")).Int()
 	out.LastModified = value2
 	return &out
 }
@@ -295,15 +292,19 @@ func (_this *Blob) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BlobFromJS is casting a js.Wrapper into Blob.
-func BlobFromJS(value js.Wrapper) *Blob {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BlobFromJS is casting a js.Value into Blob.
+func BlobFromJS(value js.Value) *Blob {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Blob{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BlobFromJS is casting from something that holds a js.Value into Blob.
+func BlobFromWrapper(input core.Wrapper) *Blob {
+	return BlobFromJS(input.JSValue())
 }
 
 func NewBlob(blobParts []*Union, options *BlobPropertyBag) (_result *Blob) {
@@ -405,15 +406,19 @@ type File struct {
 	Blob
 }
 
-// FileFromJS is casting a js.Wrapper into File.
-func FileFromJS(value js.Wrapper) *File {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileFromJS is casting a js.Value into File.
+func FileFromJS(value js.Value) *File {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &File{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileFromJS is casting from something that holds a js.Value into File.
+func FileFromWrapper(input core.Wrapper) *File {
+	return FileFromJS(input.JSValue())
 }
 
 func NewFile(fileBits []*Union, fileName string, options *FilePropertyBag) (_result *File) {
@@ -483,15 +488,19 @@ func (_this *FileList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileListFromJS is casting a js.Wrapper into FileList.
-func FileListFromJS(value js.Wrapper) *FileList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileListFromJS is casting a js.Value into FileList.
+func FileListFromJS(value js.Value) *FileList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileListFromJS is casting from something that holds a js.Value into FileList.
+func FileListFromWrapper(input core.Wrapper) *FileList {
+	return FileListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -546,15 +555,19 @@ type FileReader struct {
 	domcore.EventTarget
 }
 
-// FileReaderFromJS is casting a js.Wrapper into FileReader.
-func FileReaderFromJS(value js.Wrapper) *FileReader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileReaderFromJS is casting a js.Value into FileReader.
+func FileReaderFromJS(value js.Value) *FileReader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileReader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileReaderFromJS is casting from something that holds a js.Value into FileReader.
+func FileReaderFromWrapper(input core.Wrapper) *FileReader {
+	return FileReaderFromJS(input.JSValue())
 }
 
 const (
@@ -863,15 +876,19 @@ func (_this *FileReaderSync) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileReaderSyncFromJS is casting a js.Wrapper into FileReaderSync.
-func FileReaderSyncFromJS(value js.Wrapper) *FileReaderSync {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileReaderSyncFromJS is casting a js.Value into FileReaderSync.
+func FileReaderSyncFromJS(value js.Value) *FileReaderSync {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileReaderSync{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileReaderSyncFromJS is casting from something that holds a js.Value into FileReaderSync.
+func FileReaderSyncFromWrapper(input core.Wrapper) *FileReaderSync {
+	return FileReaderSyncFromJS(input.JSValue())
 }
 
 func NewFileReaderSync() (_result *FileReaderSync) {
@@ -978,15 +995,19 @@ func (_this *PromiseBlob) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBlobFromJS is casting a js.Wrapper into PromiseBlob.
-func PromiseBlobFromJS(value js.Wrapper) *PromiseBlob {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBlobFromJS is casting a js.Value into PromiseBlob.
+func PromiseBlobFromJS(value js.Value) *PromiseBlob {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBlob{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBlobFromJS is casting from something that holds a js.Value into PromiseBlob.
+func PromiseBlobFromWrapper(input core.Wrapper) *PromiseBlob {
+	return PromiseBlobFromJS(input.JSValue())
 }
 
 func (_this *PromiseBlob) Then(onFulfilled *PromiseBlobOnFulfilled, onRejected *PromiseBlobOnRejected) (_result *PromiseBlob) {

--- a/file/file_js.go
+++ b/file/file_js.go
@@ -6,6 +6,7 @@ import "syscall/js"
 
 import (
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -215,7 +216,7 @@ type BlobPropertyBag struct {
 	Endings EndingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BlobPropertyBag) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -227,18 +228,16 @@ func (_this *BlobPropertyBag) JSValue() js.Value {
 }
 
 // BlobPropertyBagFromJS is allocating a new
-// BlobPropertyBag object and copy all values from
-// input javascript object
-func BlobPropertyBagFromJS(value js.Wrapper) *BlobPropertyBag {
-	input := value.JSValue()
+// BlobPropertyBag object and copy all values in the value javascript object.
+func BlobPropertyBagFromJS(value js.Value) *BlobPropertyBag {
 	var out BlobPropertyBag
 	var (
 		value0 string     // javascript: DOMString {type Type _type}
 		value1 EndingType // javascript: EndingType {endings Endings endings}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = EndingTypeFromJS(input.Get("endings"))
+	value1 = EndingTypeFromJS(value.Get("endings"))
 	out.Endings = value1
 	return &out
 }
@@ -250,7 +249,7 @@ type FilePropertyBag struct {
 	LastModified int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FilePropertyBag) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -264,21 +263,19 @@ func (_this *FilePropertyBag) JSValue() js.Value {
 }
 
 // FilePropertyBagFromJS is allocating a new
-// FilePropertyBag object and copy all values from
-// input javascript object
-func FilePropertyBagFromJS(value js.Wrapper) *FilePropertyBag {
-	input := value.JSValue()
+// FilePropertyBag object and copy all values in the value javascript object.
+func FilePropertyBagFromJS(value js.Value) *FilePropertyBag {
 	var out FilePropertyBag
 	var (
 		value0 string     // javascript: DOMString {type Type _type}
 		value1 EndingType // javascript: EndingType {endings Endings endings}
 		value2 int        // javascript: long long {lastModified LastModified lastModified}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = EndingTypeFromJS(input.Get("endings"))
+	value1 = EndingTypeFromJS(value.Get("endings"))
 	out.Endings = value1
-	value2 = (input.Get("lastModified")).Int()
+	value2 = (value.Get("lastModified")).Int()
 	out.LastModified = value2
 	return &out
 }
@@ -293,15 +290,19 @@ func (_this *Blob) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BlobFromJS is casting a js.Wrapper into Blob.
-func BlobFromJS(value js.Wrapper) *Blob {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BlobFromJS is casting a js.Value into Blob.
+func BlobFromJS(value js.Value) *Blob {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Blob{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BlobFromJS is casting from something that holds a js.Value into Blob.
+func BlobFromWrapper(input core.Wrapper) *Blob {
+	return BlobFromJS(input.JSValue())
 }
 
 func NewBlob(blobParts []*Union, options *BlobPropertyBag) (_result *Blob) {
@@ -403,15 +404,19 @@ type File struct {
 	Blob
 }
 
-// FileFromJS is casting a js.Wrapper into File.
-func FileFromJS(value js.Wrapper) *File {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileFromJS is casting a js.Value into File.
+func FileFromJS(value js.Value) *File {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &File{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileFromJS is casting from something that holds a js.Value into File.
+func FileFromWrapper(input core.Wrapper) *File {
+	return FileFromJS(input.JSValue())
 }
 
 func NewFile(fileBits []*Union, fileName string, options *FilePropertyBag) (_result *File) {
@@ -481,15 +486,19 @@ func (_this *FileList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileListFromJS is casting a js.Wrapper into FileList.
-func FileListFromJS(value js.Wrapper) *FileList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileListFromJS is casting a js.Value into FileList.
+func FileListFromJS(value js.Value) *FileList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileListFromJS is casting from something that holds a js.Value into FileList.
+func FileListFromWrapper(input core.Wrapper) *FileList {
+	return FileListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -544,15 +553,19 @@ type FileReader struct {
 	domcore.EventTarget
 }
 
-// FileReaderFromJS is casting a js.Wrapper into FileReader.
-func FileReaderFromJS(value js.Wrapper) *FileReader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileReaderFromJS is casting a js.Value into FileReader.
+func FileReaderFromJS(value js.Value) *FileReader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileReader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileReaderFromJS is casting from something that holds a js.Value into FileReader.
+func FileReaderFromWrapper(input core.Wrapper) *FileReader {
+	return FileReaderFromJS(input.JSValue())
 }
 
 const (
@@ -861,15 +874,19 @@ func (_this *FileReaderSync) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FileReaderSyncFromJS is casting a js.Wrapper into FileReaderSync.
-func FileReaderSyncFromJS(value js.Wrapper) *FileReaderSync {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FileReaderSyncFromJS is casting a js.Value into FileReaderSync.
+func FileReaderSyncFromJS(value js.Value) *FileReaderSync {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FileReaderSync{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FileReaderSyncFromJS is casting from something that holds a js.Value into FileReaderSync.
+func FileReaderSyncFromWrapper(input core.Wrapper) *FileReaderSync {
+	return FileReaderSyncFromJS(input.JSValue())
 }
 
 func NewFileReaderSync() (_result *FileReaderSync) {
@@ -976,15 +993,19 @@ func (_this *PromiseBlob) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBlobFromJS is casting a js.Wrapper into PromiseBlob.
-func PromiseBlobFromJS(value js.Wrapper) *PromiseBlob {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBlobFromJS is casting a js.Value into PromiseBlob.
+func PromiseBlobFromJS(value js.Value) *PromiseBlob {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBlob{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBlobFromJS is casting from something that holds a js.Value into PromiseBlob.
+func PromiseBlobFromWrapper(input core.Wrapper) *PromiseBlob {
+	return PromiseBlobFromJS(input.JSValue())
 }
 
 func (_this *PromiseBlob) Then(onFulfilled *PromiseBlobOnFulfilled, onRejected *PromiseBlobOnRejected) (_result *PromiseBlob) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/gowebapi/webapi
 
-go 1.15
+go 1.18
+
+require github.com/gowebapi/webapi v0.0.0-20210130090710-704d94b49d10

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/gowebapi/webapi
 
 go 1.18
-
-require github.com/gowebapi/webapi v0.0.0-20210130090710-704d94b49d10

--- a/graphics/filtereffects/filtereffects.go
+++ b/graphics/filtereffects/filtereffects.go
@@ -7,6 +7,7 @@ package filtereffects
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/svg"
 )
 
@@ -49,15 +50,19 @@ type SVGComponentTransferFunctionElement struct {
 	svg.SVGElement
 }
 
-// SVGComponentTransferFunctionElementFromJS is casting a js.Wrapper into SVGComponentTransferFunctionElement.
-func SVGComponentTransferFunctionElementFromJS(value js.Wrapper) *SVGComponentTransferFunctionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGComponentTransferFunctionElementFromJS is casting a js.Value into SVGComponentTransferFunctionElement.
+func SVGComponentTransferFunctionElementFromJS(value js.Value) *SVGComponentTransferFunctionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGComponentTransferFunctionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGComponentTransferFunctionElementFromJS is casting from something that holds a js.Value into SVGComponentTransferFunctionElement.
+func SVGComponentTransferFunctionElementFromWrapper(input core.Wrapper) *SVGComponentTransferFunctionElement {
+	return SVGComponentTransferFunctionElementFromJS(input.JSValue())
 }
 
 const (
@@ -137,15 +142,19 @@ type SVGFEBlendElement struct {
 	svg.SVGElement
 }
 
-// SVGFEBlendElementFromJS is casting a js.Wrapper into SVGFEBlendElement.
-func SVGFEBlendElementFromJS(value js.Wrapper) *SVGFEBlendElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEBlendElementFromJS is casting a js.Value into SVGFEBlendElement.
+func SVGFEBlendElementFromJS(value js.Value) *SVGFEBlendElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEBlendElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEBlendElementFromJS is casting from something that holds a js.Value into SVGFEBlendElement.
+func SVGFEBlendElementFromWrapper(input core.Wrapper) *SVGFEBlendElement {
+	return SVGFEBlendElementFromJS(input.JSValue())
 }
 
 const (
@@ -245,15 +254,19 @@ type SVGFEColorMatrixElement struct {
 	svg.SVGElement
 }
 
-// SVGFEColorMatrixElementFromJS is casting a js.Wrapper into SVGFEColorMatrixElement.
-func SVGFEColorMatrixElementFromJS(value js.Wrapper) *SVGFEColorMatrixElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEColorMatrixElementFromJS is casting a js.Value into SVGFEColorMatrixElement.
+func SVGFEColorMatrixElementFromJS(value js.Value) *SVGFEColorMatrixElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEColorMatrixElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEColorMatrixElementFromJS is casting from something that holds a js.Value into SVGFEColorMatrixElement.
+func SVGFEColorMatrixElementFromWrapper(input core.Wrapper) *SVGFEColorMatrixElement {
+	return SVGFEColorMatrixElementFromJS(input.JSValue())
 }
 
 const (
@@ -341,15 +354,19 @@ type SVGFEComponentTransferElement struct {
 	svg.SVGElement
 }
 
-// SVGFEComponentTransferElementFromJS is casting a js.Wrapper into SVGFEComponentTransferElement.
-func SVGFEComponentTransferElementFromJS(value js.Wrapper) *SVGFEComponentTransferElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEComponentTransferElementFromJS is casting a js.Value into SVGFEComponentTransferElement.
+func SVGFEComponentTransferElementFromJS(value js.Value) *SVGFEComponentTransferElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEComponentTransferElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEComponentTransferElementFromJS is casting from something that holds a js.Value into SVGFEComponentTransferElement.
+func SVGFEComponentTransferElementFromWrapper(input core.Wrapper) *SVGFEComponentTransferElement {
+	return SVGFEComponentTransferElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -411,15 +428,19 @@ type SVGFECompositeElement struct {
 	svg.SVGElement
 }
 
-// SVGFECompositeElementFromJS is casting a js.Wrapper into SVGFECompositeElement.
-func SVGFECompositeElementFromJS(value js.Wrapper) *SVGFECompositeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFECompositeElementFromJS is casting a js.Value into SVGFECompositeElement.
+func SVGFECompositeElementFromJS(value js.Value) *SVGFECompositeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFECompositeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFECompositeElementFromJS is casting from something that holds a js.Value into SVGFECompositeElement.
+func SVGFECompositeElementFromWrapper(input core.Wrapper) *SVGFECompositeElement {
+	return SVGFECompositeElementFromJS(input.JSValue())
 }
 
 const (
@@ -545,15 +566,19 @@ type SVGFEConvolveMatrixElement struct {
 	svg.SVGElement
 }
 
-// SVGFEConvolveMatrixElementFromJS is casting a js.Wrapper into SVGFEConvolveMatrixElement.
-func SVGFEConvolveMatrixElementFromJS(value js.Wrapper) *SVGFEConvolveMatrixElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEConvolveMatrixElementFromJS is casting a js.Value into SVGFEConvolveMatrixElement.
+func SVGFEConvolveMatrixElementFromJS(value js.Value) *SVGFEConvolveMatrixElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEConvolveMatrixElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEConvolveMatrixElementFromJS is casting from something that holds a js.Value into SVGFEConvolveMatrixElement.
+func SVGFEConvolveMatrixElementFromWrapper(input core.Wrapper) *SVGFEConvolveMatrixElement {
+	return SVGFEConvolveMatrixElementFromJS(input.JSValue())
 }
 
 const (
@@ -721,15 +746,19 @@ type SVGFEDiffuseLightingElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDiffuseLightingElementFromJS is casting a js.Wrapper into SVGFEDiffuseLightingElement.
-func SVGFEDiffuseLightingElementFromJS(value js.Wrapper) *SVGFEDiffuseLightingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDiffuseLightingElementFromJS is casting a js.Value into SVGFEDiffuseLightingElement.
+func SVGFEDiffuseLightingElementFromJS(value js.Value) *SVGFEDiffuseLightingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDiffuseLightingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDiffuseLightingElementFromJS is casting from something that holds a js.Value into SVGFEDiffuseLightingElement.
+func SVGFEDiffuseLightingElementFromWrapper(input core.Wrapper) *SVGFEDiffuseLightingElement {
+	return SVGFEDiffuseLightingElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -827,15 +856,19 @@ type SVGFEDisplacementMapElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDisplacementMapElementFromJS is casting a js.Wrapper into SVGFEDisplacementMapElement.
-func SVGFEDisplacementMapElementFromJS(value js.Wrapper) *SVGFEDisplacementMapElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDisplacementMapElementFromJS is casting a js.Value into SVGFEDisplacementMapElement.
+func SVGFEDisplacementMapElementFromJS(value js.Value) *SVGFEDisplacementMapElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDisplacementMapElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDisplacementMapElementFromJS is casting from something that holds a js.Value into SVGFEDisplacementMapElement.
+func SVGFEDisplacementMapElementFromWrapper(input core.Wrapper) *SVGFEDisplacementMapElement {
+	return SVGFEDisplacementMapElementFromJS(input.JSValue())
 }
 
 const (
@@ -941,15 +974,19 @@ type SVGFEDistantLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDistantLightElementFromJS is casting a js.Wrapper into SVGFEDistantLightElement.
-func SVGFEDistantLightElementFromJS(value js.Wrapper) *SVGFEDistantLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDistantLightElementFromJS is casting a js.Value into SVGFEDistantLightElement.
+func SVGFEDistantLightElementFromJS(value js.Value) *SVGFEDistantLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDistantLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDistantLightElementFromJS is casting from something that holds a js.Value into SVGFEDistantLightElement.
+func SVGFEDistantLightElementFromWrapper(input core.Wrapper) *SVGFEDistantLightElement {
+	return SVGFEDistantLightElementFromJS(input.JSValue())
 }
 
 // Azimuth returning attribute 'azimuth' with
@@ -975,15 +1012,19 @@ type SVGFEDropShadowElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDropShadowElementFromJS is casting a js.Wrapper into SVGFEDropShadowElement.
-func SVGFEDropShadowElementFromJS(value js.Wrapper) *SVGFEDropShadowElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDropShadowElementFromJS is casting a js.Value into SVGFEDropShadowElement.
+func SVGFEDropShadowElementFromJS(value js.Value) *SVGFEDropShadowElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDropShadowElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDropShadowElementFromJS is casting from something that holds a js.Value into SVGFEDropShadowElement.
+func SVGFEDropShadowElementFromWrapper(input core.Wrapper) *SVGFEDropShadowElement {
+	return SVGFEDropShadowElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1096,15 +1137,19 @@ type SVGFEFloodElement struct {
 	svg.SVGElement
 }
 
-// SVGFEFloodElementFromJS is casting a js.Wrapper into SVGFEFloodElement.
-func SVGFEFloodElementFromJS(value js.Wrapper) *SVGFEFloodElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFloodElementFromJS is casting a js.Value into SVGFEFloodElement.
+func SVGFEFloodElementFromJS(value js.Value) *SVGFEFloodElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFloodElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFloodElementFromJS is casting from something that holds a js.Value into SVGFEFloodElement.
+func SVGFEFloodElementFromWrapper(input core.Wrapper) *SVGFEFloodElement {
+	return SVGFEFloodElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1157,15 +1202,19 @@ type SVGFEFuncAElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncAElementFromJS is casting a js.Wrapper into SVGFEFuncAElement.
-func SVGFEFuncAElementFromJS(value js.Wrapper) *SVGFEFuncAElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncAElementFromJS is casting a js.Value into SVGFEFuncAElement.
+func SVGFEFuncAElementFromJS(value js.Value) *SVGFEFuncAElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncAElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncAElementFromJS is casting from something that holds a js.Value into SVGFEFuncAElement.
+func SVGFEFuncAElementFromWrapper(input core.Wrapper) *SVGFEFuncAElement {
+	return SVGFEFuncAElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncBElement
@@ -1173,15 +1222,19 @@ type SVGFEFuncBElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncBElementFromJS is casting a js.Wrapper into SVGFEFuncBElement.
-func SVGFEFuncBElementFromJS(value js.Wrapper) *SVGFEFuncBElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncBElementFromJS is casting a js.Value into SVGFEFuncBElement.
+func SVGFEFuncBElementFromJS(value js.Value) *SVGFEFuncBElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncBElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncBElementFromJS is casting from something that holds a js.Value into SVGFEFuncBElement.
+func SVGFEFuncBElementFromWrapper(input core.Wrapper) *SVGFEFuncBElement {
+	return SVGFEFuncBElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncGElement
@@ -1189,15 +1242,19 @@ type SVGFEFuncGElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncGElementFromJS is casting a js.Wrapper into SVGFEFuncGElement.
-func SVGFEFuncGElementFromJS(value js.Wrapper) *SVGFEFuncGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncGElementFromJS is casting a js.Value into SVGFEFuncGElement.
+func SVGFEFuncGElementFromJS(value js.Value) *SVGFEFuncGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncGElementFromJS is casting from something that holds a js.Value into SVGFEFuncGElement.
+func SVGFEFuncGElementFromWrapper(input core.Wrapper) *SVGFEFuncGElement {
+	return SVGFEFuncGElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncRElement
@@ -1205,15 +1262,19 @@ type SVGFEFuncRElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncRElementFromJS is casting a js.Wrapper into SVGFEFuncRElement.
-func SVGFEFuncRElementFromJS(value js.Wrapper) *SVGFEFuncRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncRElementFromJS is casting a js.Value into SVGFEFuncRElement.
+func SVGFEFuncRElementFromJS(value js.Value) *SVGFEFuncRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncRElementFromJS is casting from something that holds a js.Value into SVGFEFuncRElement.
+func SVGFEFuncRElementFromWrapper(input core.Wrapper) *SVGFEFuncRElement {
+	return SVGFEFuncRElementFromJS(input.JSValue())
 }
 
 // class: SVGFEGaussianBlurElement
@@ -1221,15 +1282,19 @@ type SVGFEGaussianBlurElement struct {
 	svg.SVGElement
 }
 
-// SVGFEGaussianBlurElementFromJS is casting a js.Wrapper into SVGFEGaussianBlurElement.
-func SVGFEGaussianBlurElementFromJS(value js.Wrapper) *SVGFEGaussianBlurElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEGaussianBlurElementFromJS is casting a js.Value into SVGFEGaussianBlurElement.
+func SVGFEGaussianBlurElementFromJS(value js.Value) *SVGFEGaussianBlurElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEGaussianBlurElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEGaussianBlurElementFromJS is casting from something that holds a js.Value into SVGFEGaussianBlurElement.
+func SVGFEGaussianBlurElementFromWrapper(input core.Wrapper) *SVGFEGaussianBlurElement {
+	return SVGFEGaussianBlurElementFromJS(input.JSValue())
 }
 
 const (
@@ -1340,15 +1405,19 @@ type SVGFEImageElement struct {
 	svg.SVGElement
 }
 
-// SVGFEImageElementFromJS is casting a js.Wrapper into SVGFEImageElement.
-func SVGFEImageElementFromJS(value js.Wrapper) *SVGFEImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEImageElementFromJS is casting a js.Value into SVGFEImageElement.
+func SVGFEImageElementFromJS(value js.Value) *SVGFEImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEImageElementFromJS is casting from something that holds a js.Value into SVGFEImageElement.
+func SVGFEImageElementFromWrapper(input core.Wrapper) *SVGFEImageElement {
+	return SVGFEImageElementFromJS(input.JSValue())
 }
 
 // PreserveAspectRatio returning attribute 'preserveAspectRatio' with
@@ -1428,15 +1497,19 @@ type SVGFEMergeElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMergeElementFromJS is casting a js.Wrapper into SVGFEMergeElement.
-func SVGFEMergeElementFromJS(value js.Wrapper) *SVGFEMergeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMergeElementFromJS is casting a js.Value into SVGFEMergeElement.
+func SVGFEMergeElementFromJS(value js.Value) *SVGFEMergeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMergeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMergeElementFromJS is casting from something that holds a js.Value into SVGFEMergeElement.
+func SVGFEMergeElementFromWrapper(input core.Wrapper) *SVGFEMergeElement {
+	return SVGFEMergeElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1489,15 +1562,19 @@ type SVGFEMergeNodeElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMergeNodeElementFromJS is casting a js.Wrapper into SVGFEMergeNodeElement.
-func SVGFEMergeNodeElementFromJS(value js.Wrapper) *SVGFEMergeNodeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMergeNodeElementFromJS is casting a js.Value into SVGFEMergeNodeElement.
+func SVGFEMergeNodeElementFromJS(value js.Value) *SVGFEMergeNodeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMergeNodeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMergeNodeElementFromJS is casting from something that holds a js.Value into SVGFEMergeNodeElement.
+func SVGFEMergeNodeElementFromWrapper(input core.Wrapper) *SVGFEMergeNodeElement {
+	return SVGFEMergeNodeElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1514,15 +1591,19 @@ type SVGFEMorphologyElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMorphologyElementFromJS is casting a js.Wrapper into SVGFEMorphologyElement.
-func SVGFEMorphologyElementFromJS(value js.Wrapper) *SVGFEMorphologyElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMorphologyElementFromJS is casting a js.Value into SVGFEMorphologyElement.
+func SVGFEMorphologyElementFromJS(value js.Value) *SVGFEMorphologyElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMorphologyElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMorphologyElementFromJS is casting from something that holds a js.Value into SVGFEMorphologyElement.
+func SVGFEMorphologyElementFromWrapper(input core.Wrapper) *SVGFEMorphologyElement {
+	return SVGFEMorphologyElementFromJS(input.JSValue())
 }
 
 const (
@@ -1617,15 +1698,19 @@ type SVGFEOffsetElement struct {
 	svg.SVGElement
 }
 
-// SVGFEOffsetElementFromJS is casting a js.Wrapper into SVGFEOffsetElement.
-func SVGFEOffsetElementFromJS(value js.Wrapper) *SVGFEOffsetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEOffsetElementFromJS is casting a js.Value into SVGFEOffsetElement.
+func SVGFEOffsetElementFromJS(value js.Value) *SVGFEOffsetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEOffsetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEOffsetElementFromJS is casting from something that holds a js.Value into SVGFEOffsetElement.
+func SVGFEOffsetElementFromWrapper(input core.Wrapper) *SVGFEOffsetElement {
+	return SVGFEOffsetElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1705,15 +1790,19 @@ type SVGFEPointLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFEPointLightElementFromJS is casting a js.Wrapper into SVGFEPointLightElement.
-func SVGFEPointLightElementFromJS(value js.Wrapper) *SVGFEPointLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEPointLightElementFromJS is casting a js.Value into SVGFEPointLightElement.
+func SVGFEPointLightElementFromJS(value js.Value) *SVGFEPointLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEPointLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEPointLightElementFromJS is casting from something that holds a js.Value into SVGFEPointLightElement.
+func SVGFEPointLightElementFromWrapper(input core.Wrapper) *SVGFEPointLightElement {
+	return SVGFEPointLightElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1748,15 +1837,19 @@ type SVGFESpecularLightingElement struct {
 	svg.SVGElement
 }
 
-// SVGFESpecularLightingElementFromJS is casting a js.Wrapper into SVGFESpecularLightingElement.
-func SVGFESpecularLightingElementFromJS(value js.Wrapper) *SVGFESpecularLightingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFESpecularLightingElementFromJS is casting a js.Value into SVGFESpecularLightingElement.
+func SVGFESpecularLightingElementFromJS(value js.Value) *SVGFESpecularLightingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFESpecularLightingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFESpecularLightingElementFromJS is casting from something that holds a js.Value into SVGFESpecularLightingElement.
+func SVGFESpecularLightingElementFromWrapper(input core.Wrapper) *SVGFESpecularLightingElement {
+	return SVGFESpecularLightingElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1863,15 +1956,19 @@ type SVGFESpotLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFESpotLightElementFromJS is casting a js.Wrapper into SVGFESpotLightElement.
-func SVGFESpotLightElementFromJS(value js.Wrapper) *SVGFESpotLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFESpotLightElementFromJS is casting a js.Value into SVGFESpotLightElement.
+func SVGFESpotLightElementFromJS(value js.Value) *SVGFESpotLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFESpotLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFESpotLightElementFromJS is casting from something that holds a js.Value into SVGFESpotLightElement.
+func SVGFESpotLightElementFromWrapper(input core.Wrapper) *SVGFESpotLightElement {
+	return SVGFESpotLightElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1951,15 +2048,19 @@ type SVGFETileElement struct {
 	svg.SVGElement
 }
 
-// SVGFETileElementFromJS is casting a js.Wrapper into SVGFETileElement.
-func SVGFETileElementFromJS(value js.Wrapper) *SVGFETileElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFETileElementFromJS is casting a js.Value into SVGFETileElement.
+func SVGFETileElementFromJS(value js.Value) *SVGFETileElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFETileElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFETileElementFromJS is casting from something that holds a js.Value into SVGFETileElement.
+func SVGFETileElementFromWrapper(input core.Wrapper) *SVGFETileElement {
+	return SVGFETileElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -2021,15 +2122,19 @@ type SVGFETurbulenceElement struct {
 	svg.SVGElement
 }
 
-// SVGFETurbulenceElementFromJS is casting a js.Wrapper into SVGFETurbulenceElement.
-func SVGFETurbulenceElementFromJS(value js.Wrapper) *SVGFETurbulenceElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFETurbulenceElementFromJS is casting a js.Value into SVGFETurbulenceElement.
+func SVGFETurbulenceElementFromJS(value js.Value) *SVGFETurbulenceElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFETurbulenceElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFETurbulenceElementFromJS is casting from something that holds a js.Value into SVGFETurbulenceElement.
+func SVGFETurbulenceElementFromWrapper(input core.Wrapper) *SVGFETurbulenceElement {
+	return SVGFETurbulenceElementFromJS(input.JSValue())
 }
 
 const (
@@ -2145,15 +2250,19 @@ type SVGFilterElement struct {
 	svg.SVGElement
 }
 
-// SVGFilterElementFromJS is casting a js.Wrapper into SVGFilterElement.
-func SVGFilterElementFromJS(value js.Wrapper) *SVGFilterElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFilterElementFromJS is casting a js.Value into SVGFilterElement.
+func SVGFilterElementFromJS(value js.Value) *SVGFilterElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFilterElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFilterElementFromJS is casting from something that holds a js.Value into SVGFilterElement.
+func SVGFilterElementFromWrapper(input core.Wrapper) *SVGFilterElement {
+	return SVGFilterElementFromJS(input.JSValue())
 }
 
 // FilterUnits returning attribute 'filterUnits' with

--- a/graphics/filtereffects/filtereffects_js.go
+++ b/graphics/filtereffects/filtereffects_js.go
@@ -5,6 +5,7 @@ package filtereffects
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/svg"
 )
 
@@ -47,15 +48,19 @@ type SVGComponentTransferFunctionElement struct {
 	svg.SVGElement
 }
 
-// SVGComponentTransferFunctionElementFromJS is casting a js.Wrapper into SVGComponentTransferFunctionElement.
-func SVGComponentTransferFunctionElementFromJS(value js.Wrapper) *SVGComponentTransferFunctionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGComponentTransferFunctionElementFromJS is casting a js.Value into SVGComponentTransferFunctionElement.
+func SVGComponentTransferFunctionElementFromJS(value js.Value) *SVGComponentTransferFunctionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGComponentTransferFunctionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGComponentTransferFunctionElementFromJS is casting from something that holds a js.Value into SVGComponentTransferFunctionElement.
+func SVGComponentTransferFunctionElementFromWrapper(input core.Wrapper) *SVGComponentTransferFunctionElement {
+	return SVGComponentTransferFunctionElementFromJS(input.JSValue())
 }
 
 const (
@@ -135,15 +140,19 @@ type SVGFEBlendElement struct {
 	svg.SVGElement
 }
 
-// SVGFEBlendElementFromJS is casting a js.Wrapper into SVGFEBlendElement.
-func SVGFEBlendElementFromJS(value js.Wrapper) *SVGFEBlendElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEBlendElementFromJS is casting a js.Value into SVGFEBlendElement.
+func SVGFEBlendElementFromJS(value js.Value) *SVGFEBlendElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEBlendElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEBlendElementFromJS is casting from something that holds a js.Value into SVGFEBlendElement.
+func SVGFEBlendElementFromWrapper(input core.Wrapper) *SVGFEBlendElement {
+	return SVGFEBlendElementFromJS(input.JSValue())
 }
 
 const (
@@ -243,15 +252,19 @@ type SVGFEColorMatrixElement struct {
 	svg.SVGElement
 }
 
-// SVGFEColorMatrixElementFromJS is casting a js.Wrapper into SVGFEColorMatrixElement.
-func SVGFEColorMatrixElementFromJS(value js.Wrapper) *SVGFEColorMatrixElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEColorMatrixElementFromJS is casting a js.Value into SVGFEColorMatrixElement.
+func SVGFEColorMatrixElementFromJS(value js.Value) *SVGFEColorMatrixElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEColorMatrixElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEColorMatrixElementFromJS is casting from something that holds a js.Value into SVGFEColorMatrixElement.
+func SVGFEColorMatrixElementFromWrapper(input core.Wrapper) *SVGFEColorMatrixElement {
+	return SVGFEColorMatrixElementFromJS(input.JSValue())
 }
 
 const (
@@ -339,15 +352,19 @@ type SVGFEComponentTransferElement struct {
 	svg.SVGElement
 }
 
-// SVGFEComponentTransferElementFromJS is casting a js.Wrapper into SVGFEComponentTransferElement.
-func SVGFEComponentTransferElementFromJS(value js.Wrapper) *SVGFEComponentTransferElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEComponentTransferElementFromJS is casting a js.Value into SVGFEComponentTransferElement.
+func SVGFEComponentTransferElementFromJS(value js.Value) *SVGFEComponentTransferElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEComponentTransferElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEComponentTransferElementFromJS is casting from something that holds a js.Value into SVGFEComponentTransferElement.
+func SVGFEComponentTransferElementFromWrapper(input core.Wrapper) *SVGFEComponentTransferElement {
+	return SVGFEComponentTransferElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -409,15 +426,19 @@ type SVGFECompositeElement struct {
 	svg.SVGElement
 }
 
-// SVGFECompositeElementFromJS is casting a js.Wrapper into SVGFECompositeElement.
-func SVGFECompositeElementFromJS(value js.Wrapper) *SVGFECompositeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFECompositeElementFromJS is casting a js.Value into SVGFECompositeElement.
+func SVGFECompositeElementFromJS(value js.Value) *SVGFECompositeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFECompositeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFECompositeElementFromJS is casting from something that holds a js.Value into SVGFECompositeElement.
+func SVGFECompositeElementFromWrapper(input core.Wrapper) *SVGFECompositeElement {
+	return SVGFECompositeElementFromJS(input.JSValue())
 }
 
 const (
@@ -543,15 +564,19 @@ type SVGFEConvolveMatrixElement struct {
 	svg.SVGElement
 }
 
-// SVGFEConvolveMatrixElementFromJS is casting a js.Wrapper into SVGFEConvolveMatrixElement.
-func SVGFEConvolveMatrixElementFromJS(value js.Wrapper) *SVGFEConvolveMatrixElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEConvolveMatrixElementFromJS is casting a js.Value into SVGFEConvolveMatrixElement.
+func SVGFEConvolveMatrixElementFromJS(value js.Value) *SVGFEConvolveMatrixElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEConvolveMatrixElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEConvolveMatrixElementFromJS is casting from something that holds a js.Value into SVGFEConvolveMatrixElement.
+func SVGFEConvolveMatrixElementFromWrapper(input core.Wrapper) *SVGFEConvolveMatrixElement {
+	return SVGFEConvolveMatrixElementFromJS(input.JSValue())
 }
 
 const (
@@ -719,15 +744,19 @@ type SVGFEDiffuseLightingElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDiffuseLightingElementFromJS is casting a js.Wrapper into SVGFEDiffuseLightingElement.
-func SVGFEDiffuseLightingElementFromJS(value js.Wrapper) *SVGFEDiffuseLightingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDiffuseLightingElementFromJS is casting a js.Value into SVGFEDiffuseLightingElement.
+func SVGFEDiffuseLightingElementFromJS(value js.Value) *SVGFEDiffuseLightingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDiffuseLightingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDiffuseLightingElementFromJS is casting from something that holds a js.Value into SVGFEDiffuseLightingElement.
+func SVGFEDiffuseLightingElementFromWrapper(input core.Wrapper) *SVGFEDiffuseLightingElement {
+	return SVGFEDiffuseLightingElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -825,15 +854,19 @@ type SVGFEDisplacementMapElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDisplacementMapElementFromJS is casting a js.Wrapper into SVGFEDisplacementMapElement.
-func SVGFEDisplacementMapElementFromJS(value js.Wrapper) *SVGFEDisplacementMapElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDisplacementMapElementFromJS is casting a js.Value into SVGFEDisplacementMapElement.
+func SVGFEDisplacementMapElementFromJS(value js.Value) *SVGFEDisplacementMapElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDisplacementMapElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDisplacementMapElementFromJS is casting from something that holds a js.Value into SVGFEDisplacementMapElement.
+func SVGFEDisplacementMapElementFromWrapper(input core.Wrapper) *SVGFEDisplacementMapElement {
+	return SVGFEDisplacementMapElementFromJS(input.JSValue())
 }
 
 const (
@@ -939,15 +972,19 @@ type SVGFEDistantLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDistantLightElementFromJS is casting a js.Wrapper into SVGFEDistantLightElement.
-func SVGFEDistantLightElementFromJS(value js.Wrapper) *SVGFEDistantLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDistantLightElementFromJS is casting a js.Value into SVGFEDistantLightElement.
+func SVGFEDistantLightElementFromJS(value js.Value) *SVGFEDistantLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDistantLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDistantLightElementFromJS is casting from something that holds a js.Value into SVGFEDistantLightElement.
+func SVGFEDistantLightElementFromWrapper(input core.Wrapper) *SVGFEDistantLightElement {
+	return SVGFEDistantLightElementFromJS(input.JSValue())
 }
 
 // Azimuth returning attribute 'azimuth' with
@@ -973,15 +1010,19 @@ type SVGFEDropShadowElement struct {
 	svg.SVGElement
 }
 
-// SVGFEDropShadowElementFromJS is casting a js.Wrapper into SVGFEDropShadowElement.
-func SVGFEDropShadowElementFromJS(value js.Wrapper) *SVGFEDropShadowElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEDropShadowElementFromJS is casting a js.Value into SVGFEDropShadowElement.
+func SVGFEDropShadowElementFromJS(value js.Value) *SVGFEDropShadowElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEDropShadowElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEDropShadowElementFromJS is casting from something that holds a js.Value into SVGFEDropShadowElement.
+func SVGFEDropShadowElementFromWrapper(input core.Wrapper) *SVGFEDropShadowElement {
+	return SVGFEDropShadowElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1094,15 +1135,19 @@ type SVGFEFloodElement struct {
 	svg.SVGElement
 }
 
-// SVGFEFloodElementFromJS is casting a js.Wrapper into SVGFEFloodElement.
-func SVGFEFloodElementFromJS(value js.Wrapper) *SVGFEFloodElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFloodElementFromJS is casting a js.Value into SVGFEFloodElement.
+func SVGFEFloodElementFromJS(value js.Value) *SVGFEFloodElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFloodElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFloodElementFromJS is casting from something that holds a js.Value into SVGFEFloodElement.
+func SVGFEFloodElementFromWrapper(input core.Wrapper) *SVGFEFloodElement {
+	return SVGFEFloodElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1155,15 +1200,19 @@ type SVGFEFuncAElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncAElementFromJS is casting a js.Wrapper into SVGFEFuncAElement.
-func SVGFEFuncAElementFromJS(value js.Wrapper) *SVGFEFuncAElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncAElementFromJS is casting a js.Value into SVGFEFuncAElement.
+func SVGFEFuncAElementFromJS(value js.Value) *SVGFEFuncAElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncAElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncAElementFromJS is casting from something that holds a js.Value into SVGFEFuncAElement.
+func SVGFEFuncAElementFromWrapper(input core.Wrapper) *SVGFEFuncAElement {
+	return SVGFEFuncAElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncBElement
@@ -1171,15 +1220,19 @@ type SVGFEFuncBElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncBElementFromJS is casting a js.Wrapper into SVGFEFuncBElement.
-func SVGFEFuncBElementFromJS(value js.Wrapper) *SVGFEFuncBElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncBElementFromJS is casting a js.Value into SVGFEFuncBElement.
+func SVGFEFuncBElementFromJS(value js.Value) *SVGFEFuncBElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncBElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncBElementFromJS is casting from something that holds a js.Value into SVGFEFuncBElement.
+func SVGFEFuncBElementFromWrapper(input core.Wrapper) *SVGFEFuncBElement {
+	return SVGFEFuncBElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncGElement
@@ -1187,15 +1240,19 @@ type SVGFEFuncGElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncGElementFromJS is casting a js.Wrapper into SVGFEFuncGElement.
-func SVGFEFuncGElementFromJS(value js.Wrapper) *SVGFEFuncGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncGElementFromJS is casting a js.Value into SVGFEFuncGElement.
+func SVGFEFuncGElementFromJS(value js.Value) *SVGFEFuncGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncGElementFromJS is casting from something that holds a js.Value into SVGFEFuncGElement.
+func SVGFEFuncGElementFromWrapper(input core.Wrapper) *SVGFEFuncGElement {
+	return SVGFEFuncGElementFromJS(input.JSValue())
 }
 
 // class: SVGFEFuncRElement
@@ -1203,15 +1260,19 @@ type SVGFEFuncRElement struct {
 	SVGComponentTransferFunctionElement
 }
 
-// SVGFEFuncRElementFromJS is casting a js.Wrapper into SVGFEFuncRElement.
-func SVGFEFuncRElementFromJS(value js.Wrapper) *SVGFEFuncRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEFuncRElementFromJS is casting a js.Value into SVGFEFuncRElement.
+func SVGFEFuncRElementFromJS(value js.Value) *SVGFEFuncRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEFuncRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEFuncRElementFromJS is casting from something that holds a js.Value into SVGFEFuncRElement.
+func SVGFEFuncRElementFromWrapper(input core.Wrapper) *SVGFEFuncRElement {
+	return SVGFEFuncRElementFromJS(input.JSValue())
 }
 
 // class: SVGFEGaussianBlurElement
@@ -1219,15 +1280,19 @@ type SVGFEGaussianBlurElement struct {
 	svg.SVGElement
 }
 
-// SVGFEGaussianBlurElementFromJS is casting a js.Wrapper into SVGFEGaussianBlurElement.
-func SVGFEGaussianBlurElementFromJS(value js.Wrapper) *SVGFEGaussianBlurElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEGaussianBlurElementFromJS is casting a js.Value into SVGFEGaussianBlurElement.
+func SVGFEGaussianBlurElementFromJS(value js.Value) *SVGFEGaussianBlurElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEGaussianBlurElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEGaussianBlurElementFromJS is casting from something that holds a js.Value into SVGFEGaussianBlurElement.
+func SVGFEGaussianBlurElementFromWrapper(input core.Wrapper) *SVGFEGaussianBlurElement {
+	return SVGFEGaussianBlurElementFromJS(input.JSValue())
 }
 
 const (
@@ -1338,15 +1403,19 @@ type SVGFEImageElement struct {
 	svg.SVGElement
 }
 
-// SVGFEImageElementFromJS is casting a js.Wrapper into SVGFEImageElement.
-func SVGFEImageElementFromJS(value js.Wrapper) *SVGFEImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEImageElementFromJS is casting a js.Value into SVGFEImageElement.
+func SVGFEImageElementFromJS(value js.Value) *SVGFEImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEImageElementFromJS is casting from something that holds a js.Value into SVGFEImageElement.
+func SVGFEImageElementFromWrapper(input core.Wrapper) *SVGFEImageElement {
+	return SVGFEImageElementFromJS(input.JSValue())
 }
 
 // PreserveAspectRatio returning attribute 'preserveAspectRatio' with
@@ -1426,15 +1495,19 @@ type SVGFEMergeElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMergeElementFromJS is casting a js.Wrapper into SVGFEMergeElement.
-func SVGFEMergeElementFromJS(value js.Wrapper) *SVGFEMergeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMergeElementFromJS is casting a js.Value into SVGFEMergeElement.
+func SVGFEMergeElementFromJS(value js.Value) *SVGFEMergeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMergeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMergeElementFromJS is casting from something that holds a js.Value into SVGFEMergeElement.
+func SVGFEMergeElementFromWrapper(input core.Wrapper) *SVGFEMergeElement {
+	return SVGFEMergeElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1487,15 +1560,19 @@ type SVGFEMergeNodeElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMergeNodeElementFromJS is casting a js.Wrapper into SVGFEMergeNodeElement.
-func SVGFEMergeNodeElementFromJS(value js.Wrapper) *SVGFEMergeNodeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMergeNodeElementFromJS is casting a js.Value into SVGFEMergeNodeElement.
+func SVGFEMergeNodeElementFromJS(value js.Value) *SVGFEMergeNodeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMergeNodeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMergeNodeElementFromJS is casting from something that holds a js.Value into SVGFEMergeNodeElement.
+func SVGFEMergeNodeElementFromWrapper(input core.Wrapper) *SVGFEMergeNodeElement {
+	return SVGFEMergeNodeElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1512,15 +1589,19 @@ type SVGFEMorphologyElement struct {
 	svg.SVGElement
 }
 
-// SVGFEMorphologyElementFromJS is casting a js.Wrapper into SVGFEMorphologyElement.
-func SVGFEMorphologyElementFromJS(value js.Wrapper) *SVGFEMorphologyElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEMorphologyElementFromJS is casting a js.Value into SVGFEMorphologyElement.
+func SVGFEMorphologyElementFromJS(value js.Value) *SVGFEMorphologyElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEMorphologyElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEMorphologyElementFromJS is casting from something that holds a js.Value into SVGFEMorphologyElement.
+func SVGFEMorphologyElementFromWrapper(input core.Wrapper) *SVGFEMorphologyElement {
+	return SVGFEMorphologyElementFromJS(input.JSValue())
 }
 
 const (
@@ -1615,15 +1696,19 @@ type SVGFEOffsetElement struct {
 	svg.SVGElement
 }
 
-// SVGFEOffsetElementFromJS is casting a js.Wrapper into SVGFEOffsetElement.
-func SVGFEOffsetElementFromJS(value js.Wrapper) *SVGFEOffsetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEOffsetElementFromJS is casting a js.Value into SVGFEOffsetElement.
+func SVGFEOffsetElementFromJS(value js.Value) *SVGFEOffsetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEOffsetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEOffsetElementFromJS is casting from something that holds a js.Value into SVGFEOffsetElement.
+func SVGFEOffsetElementFromWrapper(input core.Wrapper) *SVGFEOffsetElement {
+	return SVGFEOffsetElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1703,15 +1788,19 @@ type SVGFEPointLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFEPointLightElementFromJS is casting a js.Wrapper into SVGFEPointLightElement.
-func SVGFEPointLightElementFromJS(value js.Wrapper) *SVGFEPointLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFEPointLightElementFromJS is casting a js.Value into SVGFEPointLightElement.
+func SVGFEPointLightElementFromJS(value js.Value) *SVGFEPointLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFEPointLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFEPointLightElementFromJS is casting from something that holds a js.Value into SVGFEPointLightElement.
+func SVGFEPointLightElementFromWrapper(input core.Wrapper) *SVGFEPointLightElement {
+	return SVGFEPointLightElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1746,15 +1835,19 @@ type SVGFESpecularLightingElement struct {
 	svg.SVGElement
 }
 
-// SVGFESpecularLightingElementFromJS is casting a js.Wrapper into SVGFESpecularLightingElement.
-func SVGFESpecularLightingElementFromJS(value js.Wrapper) *SVGFESpecularLightingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFESpecularLightingElementFromJS is casting a js.Value into SVGFESpecularLightingElement.
+func SVGFESpecularLightingElementFromJS(value js.Value) *SVGFESpecularLightingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFESpecularLightingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFESpecularLightingElementFromJS is casting from something that holds a js.Value into SVGFESpecularLightingElement.
+func SVGFESpecularLightingElementFromWrapper(input core.Wrapper) *SVGFESpecularLightingElement {
+	return SVGFESpecularLightingElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -1861,15 +1954,19 @@ type SVGFESpotLightElement struct {
 	svg.SVGElement
 }
 
-// SVGFESpotLightElementFromJS is casting a js.Wrapper into SVGFESpotLightElement.
-func SVGFESpotLightElementFromJS(value js.Wrapper) *SVGFESpotLightElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFESpotLightElementFromJS is casting a js.Value into SVGFESpotLightElement.
+func SVGFESpotLightElementFromJS(value js.Value) *SVGFESpotLightElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFESpotLightElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFESpotLightElementFromJS is casting from something that holds a js.Value into SVGFESpotLightElement.
+func SVGFESpotLightElementFromWrapper(input core.Wrapper) *SVGFESpotLightElement {
+	return SVGFESpotLightElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -1949,15 +2046,19 @@ type SVGFETileElement struct {
 	svg.SVGElement
 }
 
-// SVGFETileElementFromJS is casting a js.Wrapper into SVGFETileElement.
-func SVGFETileElementFromJS(value js.Wrapper) *SVGFETileElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFETileElementFromJS is casting a js.Value into SVGFETileElement.
+func SVGFETileElementFromJS(value js.Value) *SVGFETileElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFETileElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFETileElementFromJS is casting from something that holds a js.Value into SVGFETileElement.
+func SVGFETileElementFromWrapper(input core.Wrapper) *SVGFETileElement {
+	return SVGFETileElementFromJS(input.JSValue())
 }
 
 // In1 returning attribute 'in1' with
@@ -2019,15 +2120,19 @@ type SVGFETurbulenceElement struct {
 	svg.SVGElement
 }
 
-// SVGFETurbulenceElementFromJS is casting a js.Wrapper into SVGFETurbulenceElement.
-func SVGFETurbulenceElementFromJS(value js.Wrapper) *SVGFETurbulenceElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFETurbulenceElementFromJS is casting a js.Value into SVGFETurbulenceElement.
+func SVGFETurbulenceElementFromJS(value js.Value) *SVGFETurbulenceElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFETurbulenceElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFETurbulenceElementFromJS is casting from something that holds a js.Value into SVGFETurbulenceElement.
+func SVGFETurbulenceElementFromWrapper(input core.Wrapper) *SVGFETurbulenceElement {
+	return SVGFETurbulenceElementFromJS(input.JSValue())
 }
 
 const (
@@ -2143,15 +2248,19 @@ type SVGFilterElement struct {
 	svg.SVGElement
 }
 
-// SVGFilterElementFromJS is casting a js.Wrapper into SVGFilterElement.
-func SVGFilterElementFromJS(value js.Wrapper) *SVGFilterElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGFilterElementFromJS is casting a js.Value into SVGFilterElement.
+func SVGFilterElementFromJS(value js.Value) *SVGFilterElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGFilterElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGFilterElementFromJS is casting from something that holds a js.Value into SVGFilterElement.
+func SVGFilterElementFromWrapper(input core.Wrapper) *SVGFilterElement {
+	return SVGFilterElementFromJS(input.JSValue())
 }
 
 // FilterUnits returning attribute 'filterUnits' with

--- a/graphics/fontmetrics/fontmetrics.go
+++ b/graphics/fontmetrics/fontmetrics.go
@@ -7,6 +7,7 @@ package fontmetrics
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -46,15 +47,19 @@ func (_this *Baseline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BaselineFromJS is casting a js.Wrapper into Baseline.
-func BaselineFromJS(value js.Wrapper) *Baseline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BaselineFromJS is casting a js.Value into Baseline.
+func BaselineFromJS(value js.Value) *Baseline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Baseline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BaselineFromJS is casting from something that holds a js.Value into Baseline.
+func BaselineFromWrapper(input core.Wrapper) *Baseline {
+	return BaselineFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -85,15 +90,19 @@ func (_this *Font) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFromJS is casting a js.Wrapper into Font.
-func FontFromJS(value js.Wrapper) *Font {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFromJS is casting a js.Value into Font.
+func FontFromJS(value js.Value) *Font {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Font{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFromJS is casting from something that holds a js.Value into Font.
+func FontFromWrapper(input core.Wrapper) *Font {
+	return FontFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -124,15 +133,19 @@ func (_this *FontMetrics) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontMetricsFromJS is casting a js.Wrapper into FontMetrics.
-func FontMetricsFromJS(value js.Wrapper) *FontMetrics {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontMetricsFromJS is casting a js.Value into FontMetrics.
+func FontMetricsFromJS(value js.Value) *FontMetrics {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontMetrics{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontMetricsFromJS is casting from something that holds a js.Value into FontMetrics.
+func FontMetricsFromWrapper(input core.Wrapper) *FontMetrics {
+	return FontMetricsFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with

--- a/graphics/fontmetrics/fontmetrics_js.go
+++ b/graphics/fontmetrics/fontmetrics_js.go
@@ -5,6 +5,7 @@ package fontmetrics
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -44,15 +45,19 @@ func (_this *Baseline) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BaselineFromJS is casting a js.Wrapper into Baseline.
-func BaselineFromJS(value js.Wrapper) *Baseline {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BaselineFromJS is casting a js.Value into Baseline.
+func BaselineFromJS(value js.Value) *Baseline {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Baseline{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BaselineFromJS is casting from something that holds a js.Value into Baseline.
+func BaselineFromWrapper(input core.Wrapper) *Baseline {
+	return BaselineFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -83,15 +88,19 @@ func (_this *Font) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontFromJS is casting a js.Wrapper into Font.
-func FontFromJS(value js.Wrapper) *Font {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontFromJS is casting a js.Value into Font.
+func FontFromJS(value js.Value) *Font {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Font{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontFromJS is casting from something that holds a js.Value into Font.
+func FontFromWrapper(input core.Wrapper) *Font {
+	return FontFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -122,15 +131,19 @@ func (_this *FontMetrics) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FontMetricsFromJS is casting a js.Wrapper into FontMetrics.
-func FontMetricsFromJS(value js.Wrapper) *FontMetrics {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FontMetricsFromJS is casting a js.Value into FontMetrics.
+func FontMetricsFromJS(value js.Value) *FontMetrics {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FontMetrics{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FontMetricsFromJS is casting from something that holds a js.Value into FontMetrics.
+func FontMetricsFromWrapper(input core.Wrapper) *FontMetrics {
+	return FontMetricsFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with

--- a/graphics/presentation/presentation.go
+++ b/graphics/presentation/presentation.go
@@ -7,6 +7,7 @@ package presentation
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/channel"
@@ -305,7 +306,7 @@ type ConnectionAvailableEventInit struct {
 	Connection *Connection
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionAvailableEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -321,10 +322,8 @@ func (_this *ConnectionAvailableEventInit) JSValue() js.Value {
 }
 
 // ConnectionAvailableEventInitFromJS is allocating a new
-// ConnectionAvailableEventInit object and copy all values from
-// input javascript object
-func ConnectionAvailableEventInitFromJS(value js.Wrapper) *ConnectionAvailableEventInit {
-	input := value.JSValue()
+// ConnectionAvailableEventInit object and copy all values in the value javascript object.
+func ConnectionAvailableEventInitFromJS(value js.Value) *ConnectionAvailableEventInit {
 	var out ConnectionAvailableEventInit
 	var (
 		value0 bool        // javascript: boolean {bubbles Bubbles bubbles}
@@ -332,13 +331,13 @@ func ConnectionAvailableEventInitFromJS(value js.Wrapper) *ConnectionAvailableEv
 		value2 bool        // javascript: boolean {composed Composed composed}
 		value3 *Connection // javascript: PresentationConnection {connection Connection connection}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = ConnectionFromJS(input.Get("connection"))
+	value3 = ConnectionFromJS(value.Get("connection"))
 	out.Connection = value3
 	return &out
 }
@@ -352,7 +351,7 @@ type ConnectionCloseEventInit struct {
 	Message    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionCloseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -370,10 +369,8 @@ func (_this *ConnectionCloseEventInit) JSValue() js.Value {
 }
 
 // ConnectionCloseEventInitFromJS is allocating a new
-// ConnectionCloseEventInit object and copy all values from
-// input javascript object
-func ConnectionCloseEventInitFromJS(value js.Wrapper) *ConnectionCloseEventInit {
-	input := value.JSValue()
+// ConnectionCloseEventInit object and copy all values in the value javascript object.
+func ConnectionCloseEventInitFromJS(value js.Value) *ConnectionCloseEventInit {
 	var out ConnectionCloseEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -382,15 +379,15 @@ func ConnectionCloseEventInitFromJS(value js.Wrapper) *ConnectionCloseEventInit 
 		value3 ConnectionCloseReason // javascript: PresentationConnectionCloseReason {reason Reason reason}
 		value4 string                // javascript: DOMString {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = ConnectionCloseReasonFromJS(input.Get("reason"))
+	value3 = ConnectionCloseReasonFromJS(value.Get("reason"))
 	out.Reason = value3
-	value4 = (input.Get("message")).String()
+	value4 = (value.Get("message")).String()
 	out.Message = value4
 	return &out
 }
@@ -400,15 +397,19 @@ type Availability struct {
 	domcore.EventTarget
 }
 
-// AvailabilityFromJS is casting a js.Wrapper into Availability.
-func AvailabilityFromJS(value js.Wrapper) *Availability {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AvailabilityFromJS is casting a js.Value into Availability.
+func AvailabilityFromJS(value js.Value) *Availability {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Availability{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AvailabilityFromJS is casting from something that holds a js.Value into Availability.
+func AvailabilityFromWrapper(input core.Wrapper) *Availability {
+	return AvailabilityFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -466,15 +467,19 @@ type Connection struct {
 	domcore.EventTarget
 }
 
-// ConnectionFromJS is casting a js.Wrapper into Connection.
-func ConnectionFromJS(value js.Wrapper) *Connection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionFromJS is casting a js.Value into Connection.
+func ConnectionFromJS(value js.Value) *Connection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Connection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionFromJS is casting from something that holds a js.Value into Connection.
+func ConnectionFromWrapper(input core.Wrapper) *Connection {
+	return ConnectionFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -741,15 +746,19 @@ type ConnectionAvailableEvent struct {
 	domcore.Event
 }
 
-// ConnectionAvailableEventFromJS is casting a js.Wrapper into ConnectionAvailableEvent.
-func ConnectionAvailableEventFromJS(value js.Wrapper) *ConnectionAvailableEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionAvailableEventFromJS is casting a js.Value into ConnectionAvailableEvent.
+func ConnectionAvailableEventFromJS(value js.Value) *ConnectionAvailableEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionAvailableEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionAvailableEventFromJS is casting from something that holds a js.Value into ConnectionAvailableEvent.
+func ConnectionAvailableEventFromWrapper(input core.Wrapper) *ConnectionAvailableEvent {
+	return ConnectionAvailableEventFromJS(input.JSValue())
 }
 
 func NewPresentationConnectionAvailableEvent(_type string, eventInitDict *ConnectionAvailableEventInit) (_result *ConnectionAvailableEvent) {
@@ -787,15 +796,19 @@ type ConnectionCloseEvent struct {
 	domcore.Event
 }
 
-// ConnectionCloseEventFromJS is casting a js.Wrapper into ConnectionCloseEvent.
-func ConnectionCloseEventFromJS(value js.Wrapper) *ConnectionCloseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionCloseEventFromJS is casting a js.Value into ConnectionCloseEvent.
+func ConnectionCloseEventFromJS(value js.Value) *ConnectionCloseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionCloseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionCloseEventFromJS is casting from something that holds a js.Value into ConnectionCloseEvent.
+func ConnectionCloseEventFromWrapper(input core.Wrapper) *ConnectionCloseEvent {
+	return ConnectionCloseEventFromJS(input.JSValue())
 }
 
 func NewPresentationConnectionCloseEvent(_type string, eventInitDict *ConnectionCloseEventInit) (_result *ConnectionCloseEvent) {
@@ -842,15 +855,19 @@ type ConnectionList struct {
 	domcore.EventTarget
 }
 
-// ConnectionListFromJS is casting a js.Wrapper into ConnectionList.
-func ConnectionListFromJS(value js.Wrapper) *ConnectionList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionListFromJS is casting a js.Value into ConnectionList.
+func ConnectionListFromJS(value js.Value) *ConnectionList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionListFromJS is casting from something that holds a js.Value into ConnectionList.
+func ConnectionListFromWrapper(input core.Wrapper) *ConnectionList {
+	return ConnectionListFromJS(input.JSValue())
 }
 
 // Connections returning attribute 'connections' with
@@ -913,15 +930,19 @@ func (_this *Presentation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PresentationFromJS is casting a js.Wrapper into Presentation.
-func PresentationFromJS(value js.Wrapper) *Presentation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PresentationFromJS is casting a js.Value into Presentation.
+func PresentationFromJS(value js.Value) *Presentation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Presentation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PresentationFromJS is casting from something that holds a js.Value into Presentation.
+func PresentationFromWrapper(input core.Wrapper) *Presentation {
+	return PresentationFromJS(input.JSValue())
 }
 
 // DefaultRequest returning attribute 'defaultRequest' with
@@ -963,15 +984,19 @@ func (_this *PromiseAvailability) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAvailabilityFromJS is casting a js.Wrapper into PromiseAvailability.
-func PromiseAvailabilityFromJS(value js.Wrapper) *PromiseAvailability {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAvailabilityFromJS is casting a js.Value into PromiseAvailability.
+func PromiseAvailabilityFromJS(value js.Value) *PromiseAvailability {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAvailability{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAvailabilityFromJS is casting from something that holds a js.Value into PromiseAvailability.
+func PromiseAvailabilityFromWrapper(input core.Wrapper) *PromiseAvailability {
+	return PromiseAvailabilityFromJS(input.JSValue())
 }
 
 func (_this *PromiseAvailability) Then(onFulfilled *PromiseAvailabilityOnFulfilled, onRejected *PromiseAvailabilityOnRejected) (_result *PromiseAvailability) {
@@ -1068,15 +1093,19 @@ func (_this *PromiseConnection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseConnectionFromJS is casting a js.Wrapper into PromiseConnection.
-func PromiseConnectionFromJS(value js.Wrapper) *PromiseConnection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseConnectionFromJS is casting a js.Value into PromiseConnection.
+func PromiseConnectionFromJS(value js.Value) *PromiseConnection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseConnection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseConnectionFromJS is casting from something that holds a js.Value into PromiseConnection.
+func PromiseConnectionFromWrapper(input core.Wrapper) *PromiseConnection {
+	return PromiseConnectionFromJS(input.JSValue())
 }
 
 func (_this *PromiseConnection) Then(onFulfilled *PromiseConnectionOnFulfilled, onRejected *PromiseConnectionOnRejected) (_result *PromiseConnection) {
@@ -1173,15 +1202,19 @@ func (_this *Receiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReceiverFromJS is casting a js.Wrapper into Receiver.
-func ReceiverFromJS(value js.Wrapper) *Receiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReceiverFromJS is casting a js.Value into Receiver.
+func ReceiverFromJS(value js.Value) *Receiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Receiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReceiverFromJS is casting from something that holds a js.Value into Receiver.
+func ReceiverFromWrapper(input core.Wrapper) *Receiver {
+	return ReceiverFromJS(input.JSValue())
 }
 
 // ConnectionList returning attribute 'connectionList' with
@@ -1198,15 +1231,19 @@ type Request struct {
 	domcore.EventTarget
 }
 
-// RequestFromJS is casting a js.Wrapper into Request.
-func RequestFromJS(value js.Wrapper) *Request {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RequestFromJS is casting a js.Value into Request.
+func RequestFromJS(value js.Value) *Request {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Request{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RequestFromJS is casting from something that holds a js.Value into Request.
+func RequestFromWrapper(input core.Wrapper) *Request {
+	return RequestFromJS(input.JSValue())
 }
 
 func NewPresentationRequest(urls []string) (_result *Request) {

--- a/graphics/presentation/presentation_js.go
+++ b/graphics/presentation/presentation_js.go
@@ -5,6 +5,7 @@ package presentation
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/channel"
@@ -303,7 +304,7 @@ type ConnectionAvailableEventInit struct {
 	Connection *Connection
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionAvailableEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -319,10 +320,8 @@ func (_this *ConnectionAvailableEventInit) JSValue() js.Value {
 }
 
 // ConnectionAvailableEventInitFromJS is allocating a new
-// ConnectionAvailableEventInit object and copy all values from
-// input javascript object
-func ConnectionAvailableEventInitFromJS(value js.Wrapper) *ConnectionAvailableEventInit {
-	input := value.JSValue()
+// ConnectionAvailableEventInit object and copy all values in the value javascript object.
+func ConnectionAvailableEventInitFromJS(value js.Value) *ConnectionAvailableEventInit {
 	var out ConnectionAvailableEventInit
 	var (
 		value0 bool        // javascript: boolean {bubbles Bubbles bubbles}
@@ -330,13 +329,13 @@ func ConnectionAvailableEventInitFromJS(value js.Wrapper) *ConnectionAvailableEv
 		value2 bool        // javascript: boolean {composed Composed composed}
 		value3 *Connection // javascript: PresentationConnection {connection Connection connection}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = ConnectionFromJS(input.Get("connection"))
+	value3 = ConnectionFromJS(value.Get("connection"))
 	out.Connection = value3
 	return &out
 }
@@ -350,7 +349,7 @@ type ConnectionCloseEventInit struct {
 	Message    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionCloseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -368,10 +367,8 @@ func (_this *ConnectionCloseEventInit) JSValue() js.Value {
 }
 
 // ConnectionCloseEventInitFromJS is allocating a new
-// ConnectionCloseEventInit object and copy all values from
-// input javascript object
-func ConnectionCloseEventInitFromJS(value js.Wrapper) *ConnectionCloseEventInit {
-	input := value.JSValue()
+// ConnectionCloseEventInit object and copy all values in the value javascript object.
+func ConnectionCloseEventInitFromJS(value js.Value) *ConnectionCloseEventInit {
 	var out ConnectionCloseEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -380,15 +377,15 @@ func ConnectionCloseEventInitFromJS(value js.Wrapper) *ConnectionCloseEventInit 
 		value3 ConnectionCloseReason // javascript: PresentationConnectionCloseReason {reason Reason reason}
 		value4 string                // javascript: DOMString {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = ConnectionCloseReasonFromJS(input.Get("reason"))
+	value3 = ConnectionCloseReasonFromJS(value.Get("reason"))
 	out.Reason = value3
-	value4 = (input.Get("message")).String()
+	value4 = (value.Get("message")).String()
 	out.Message = value4
 	return &out
 }
@@ -398,15 +395,19 @@ type Availability struct {
 	domcore.EventTarget
 }
 
-// AvailabilityFromJS is casting a js.Wrapper into Availability.
-func AvailabilityFromJS(value js.Wrapper) *Availability {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AvailabilityFromJS is casting a js.Value into Availability.
+func AvailabilityFromJS(value js.Value) *Availability {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Availability{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AvailabilityFromJS is casting from something that holds a js.Value into Availability.
+func AvailabilityFromWrapper(input core.Wrapper) *Availability {
+	return AvailabilityFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -464,15 +465,19 @@ type Connection struct {
 	domcore.EventTarget
 }
 
-// ConnectionFromJS is casting a js.Wrapper into Connection.
-func ConnectionFromJS(value js.Wrapper) *Connection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionFromJS is casting a js.Value into Connection.
+func ConnectionFromJS(value js.Value) *Connection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Connection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionFromJS is casting from something that holds a js.Value into Connection.
+func ConnectionFromWrapper(input core.Wrapper) *Connection {
+	return ConnectionFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -739,15 +744,19 @@ type ConnectionAvailableEvent struct {
 	domcore.Event
 }
 
-// ConnectionAvailableEventFromJS is casting a js.Wrapper into ConnectionAvailableEvent.
-func ConnectionAvailableEventFromJS(value js.Wrapper) *ConnectionAvailableEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionAvailableEventFromJS is casting a js.Value into ConnectionAvailableEvent.
+func ConnectionAvailableEventFromJS(value js.Value) *ConnectionAvailableEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionAvailableEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionAvailableEventFromJS is casting from something that holds a js.Value into ConnectionAvailableEvent.
+func ConnectionAvailableEventFromWrapper(input core.Wrapper) *ConnectionAvailableEvent {
+	return ConnectionAvailableEventFromJS(input.JSValue())
 }
 
 func NewPresentationConnectionAvailableEvent(_type string, eventInitDict *ConnectionAvailableEventInit) (_result *ConnectionAvailableEvent) {
@@ -785,15 +794,19 @@ type ConnectionCloseEvent struct {
 	domcore.Event
 }
 
-// ConnectionCloseEventFromJS is casting a js.Wrapper into ConnectionCloseEvent.
-func ConnectionCloseEventFromJS(value js.Wrapper) *ConnectionCloseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionCloseEventFromJS is casting a js.Value into ConnectionCloseEvent.
+func ConnectionCloseEventFromJS(value js.Value) *ConnectionCloseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionCloseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionCloseEventFromJS is casting from something that holds a js.Value into ConnectionCloseEvent.
+func ConnectionCloseEventFromWrapper(input core.Wrapper) *ConnectionCloseEvent {
+	return ConnectionCloseEventFromJS(input.JSValue())
 }
 
 func NewPresentationConnectionCloseEvent(_type string, eventInitDict *ConnectionCloseEventInit) (_result *ConnectionCloseEvent) {
@@ -840,15 +853,19 @@ type ConnectionList struct {
 	domcore.EventTarget
 }
 
-// ConnectionListFromJS is casting a js.Wrapper into ConnectionList.
-func ConnectionListFromJS(value js.Wrapper) *ConnectionList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionListFromJS is casting a js.Value into ConnectionList.
+func ConnectionListFromJS(value js.Value) *ConnectionList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionListFromJS is casting from something that holds a js.Value into ConnectionList.
+func ConnectionListFromWrapper(input core.Wrapper) *ConnectionList {
+	return ConnectionListFromJS(input.JSValue())
 }
 
 // Connections returning attribute 'connections' with
@@ -911,15 +928,19 @@ func (_this *Presentation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PresentationFromJS is casting a js.Wrapper into Presentation.
-func PresentationFromJS(value js.Wrapper) *Presentation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PresentationFromJS is casting a js.Value into Presentation.
+func PresentationFromJS(value js.Value) *Presentation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Presentation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PresentationFromJS is casting from something that holds a js.Value into Presentation.
+func PresentationFromWrapper(input core.Wrapper) *Presentation {
+	return PresentationFromJS(input.JSValue())
 }
 
 // DefaultRequest returning attribute 'defaultRequest' with
@@ -961,15 +982,19 @@ func (_this *PromiseAvailability) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAvailabilityFromJS is casting a js.Wrapper into PromiseAvailability.
-func PromiseAvailabilityFromJS(value js.Wrapper) *PromiseAvailability {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAvailabilityFromJS is casting a js.Value into PromiseAvailability.
+func PromiseAvailabilityFromJS(value js.Value) *PromiseAvailability {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAvailability{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAvailabilityFromJS is casting from something that holds a js.Value into PromiseAvailability.
+func PromiseAvailabilityFromWrapper(input core.Wrapper) *PromiseAvailability {
+	return PromiseAvailabilityFromJS(input.JSValue())
 }
 
 func (_this *PromiseAvailability) Then(onFulfilled *PromiseAvailabilityOnFulfilled, onRejected *PromiseAvailabilityOnRejected) (_result *PromiseAvailability) {
@@ -1066,15 +1091,19 @@ func (_this *PromiseConnection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseConnectionFromJS is casting a js.Wrapper into PromiseConnection.
-func PromiseConnectionFromJS(value js.Wrapper) *PromiseConnection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseConnectionFromJS is casting a js.Value into PromiseConnection.
+func PromiseConnectionFromJS(value js.Value) *PromiseConnection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseConnection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseConnectionFromJS is casting from something that holds a js.Value into PromiseConnection.
+func PromiseConnectionFromWrapper(input core.Wrapper) *PromiseConnection {
+	return PromiseConnectionFromJS(input.JSValue())
 }
 
 func (_this *PromiseConnection) Then(onFulfilled *PromiseConnectionOnFulfilled, onRejected *PromiseConnectionOnRejected) (_result *PromiseConnection) {
@@ -1171,15 +1200,19 @@ func (_this *Receiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReceiverFromJS is casting a js.Wrapper into Receiver.
-func ReceiverFromJS(value js.Wrapper) *Receiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReceiverFromJS is casting a js.Value into Receiver.
+func ReceiverFromJS(value js.Value) *Receiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Receiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReceiverFromJS is casting from something that holds a js.Value into Receiver.
+func ReceiverFromWrapper(input core.Wrapper) *Receiver {
+	return ReceiverFromJS(input.JSValue())
 }
 
 // ConnectionList returning attribute 'connectionList' with
@@ -1196,15 +1229,19 @@ type Request struct {
 	domcore.EventTarget
 }
 
-// RequestFromJS is casting a js.Wrapper into Request.
-func RequestFromJS(value js.Wrapper) *Request {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RequestFromJS is casting a js.Value into Request.
+func RequestFromJS(value js.Value) *Request {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Request{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RequestFromJS is casting from something that holds a js.Value into Request.
+func RequestFromWrapper(input core.Wrapper) *Request {
+	return RequestFromJS(input.JSValue())
 }
 
 func NewPresentationRequest(urls []string) (_result *Request) {

--- a/graphics/shapedetection/shapedetection.go
+++ b/graphics/shapedetection/shapedetection.go
@@ -7,6 +7,7 @@ package shapedetection
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -419,7 +420,7 @@ type BarcodeDetectorOptions struct {
 	Formats []BarcodeFormat
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BarcodeDetectorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -433,19 +434,17 @@ func (_this *BarcodeDetectorOptions) JSValue() js.Value {
 }
 
 // BarcodeDetectorOptionsFromJS is allocating a new
-// BarcodeDetectorOptions object and copy all values from
-// input javascript object
-func BarcodeDetectorOptionsFromJS(value js.Wrapper) *BarcodeDetectorOptions {
-	input := value.JSValue()
+// BarcodeDetectorOptions object and copy all values in the value javascript object.
+func BarcodeDetectorOptionsFromJS(value js.Value) *BarcodeDetectorOptions {
 	var out BarcodeDetectorOptions
 	var (
 		value0 []BarcodeFormat // javascript: sequence<BarcodeFormat> {formats Formats formats}
 	)
-	__length0 := input.Get("formats").Length()
+	__length0 := value.Get("formats").Length()
 	__array0 := make([]BarcodeFormat, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 BarcodeFormat
-		__seq_in0 := input.Get("formats").Index(__idx0)
+		__seq_in0 := value.Get("formats").Index(__idx0)
 		__seq_out0 = BarcodeFormatFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -460,7 +459,7 @@ type FaceDetectorOptions struct {
 	FastMode         bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FaceDetectorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -472,18 +471,16 @@ func (_this *FaceDetectorOptions) JSValue() js.Value {
 }
 
 // FaceDetectorOptionsFromJS is allocating a new
-// FaceDetectorOptions object and copy all values from
-// input javascript object
-func FaceDetectorOptionsFromJS(value js.Wrapper) *FaceDetectorOptions {
-	input := value.JSValue()
+// FaceDetectorOptions object and copy all values in the value javascript object.
+func FaceDetectorOptionsFromJS(value js.Value) *FaceDetectorOptions {
 	var out FaceDetectorOptions
 	var (
 		value0 int  // javascript: unsigned short {maxDetectedFaces MaxDetectedFaces maxDetectedFaces}
 		value1 bool // javascript: boolean {fastMode FastMode fastMode}
 	)
-	value0 = (input.Get("maxDetectedFaces")).Int()
+	value0 = (value.Get("maxDetectedFaces")).Int()
 	out.MaxDetectedFaces = value0
-	value1 = (input.Get("fastMode")).Bool()
+	value1 = (value.Get("fastMode")).Bool()
 	out.FastMode = value1
 	return &out
 }
@@ -494,7 +491,7 @@ type Landmark struct {
 	Type      LandmarkType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Landmark) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -506,18 +503,16 @@ func (_this *Landmark) JSValue() js.Value {
 }
 
 // LandmarkFromJS is allocating a new
-// Landmark object and copy all values from
-// input javascript object
-func LandmarkFromJS(value js.Wrapper) *Landmark {
-	input := value.JSValue()
+// Landmark object and copy all values in the value javascript object.
+func LandmarkFromJS(value js.Value) *Landmark {
 	var out Landmark
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {locations Locations locations}
 		value1 LandmarkType            // javascript: LandmarkType {type Type _type}
 	)
-	value0 = javascript.FrozenArrayFromJS(input.Get("locations"))
+	value0 = javascript.FrozenArrayFromJS(value.Get("locations"))
 	out.Locations = value0
-	value1 = LandmarkTypeFromJS(input.Get("type"))
+	value1 = LandmarkTypeFromJS(value.Get("type"))
 	out.Type = value1
 	return &out
 }
@@ -532,15 +527,19 @@ func (_this *BarcodeDetector) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BarcodeDetectorFromJS is casting a js.Wrapper into BarcodeDetector.
-func BarcodeDetectorFromJS(value js.Wrapper) *BarcodeDetector {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BarcodeDetectorFromJS is casting a js.Value into BarcodeDetector.
+func BarcodeDetectorFromJS(value js.Value) *BarcodeDetector {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BarcodeDetector{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BarcodeDetectorFromJS is casting from something that holds a js.Value into BarcodeDetector.
+func BarcodeDetectorFromWrapper(input core.Wrapper) *BarcodeDetector {
+	return BarcodeDetectorFromJS(input.JSValue())
 }
 
 func GetSupportedFormats() (_result *PromiseSequenceBarcodeFormat) {
@@ -606,15 +605,19 @@ func (_this *DetectedBarcode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DetectedBarcodeFromJS is casting a js.Wrapper into DetectedBarcode.
-func DetectedBarcodeFromJS(value js.Wrapper) *DetectedBarcode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DetectedBarcodeFromJS is casting a js.Value into DetectedBarcode.
+func DetectedBarcodeFromJS(value js.Value) *DetectedBarcode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DetectedBarcode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DetectedBarcodeFromJS is casting from something that holds a js.Value into DetectedBarcode.
+func DetectedBarcodeFromWrapper(input core.Wrapper) *DetectedBarcode {
+	return DetectedBarcodeFromJS(input.JSValue())
 }
 
 // BoundingBox returning attribute 'boundingBox' with
@@ -663,15 +666,19 @@ func (_this *DetectedFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DetectedFaceFromJS is casting a js.Wrapper into DetectedFace.
-func DetectedFaceFromJS(value js.Wrapper) *DetectedFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DetectedFaceFromJS is casting a js.Value into DetectedFace.
+func DetectedFaceFromJS(value js.Value) *DetectedFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DetectedFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DetectedFaceFromJS is casting from something that holds a js.Value into DetectedFace.
+func DetectedFaceFromWrapper(input core.Wrapper) *DetectedFace {
+	return DetectedFaceFromJS(input.JSValue())
 }
 
 // BoundingBox returning attribute 'boundingBox' with
@@ -704,15 +711,19 @@ func (_this *FaceDetector) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FaceDetectorFromJS is casting a js.Wrapper into FaceDetector.
-func FaceDetectorFromJS(value js.Wrapper) *FaceDetector {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FaceDetectorFromJS is casting a js.Value into FaceDetector.
+func FaceDetectorFromJS(value js.Value) *FaceDetector {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FaceDetector{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FaceDetectorFromJS is casting from something that holds a js.Value into FaceDetector.
+func FaceDetectorFromWrapper(input core.Wrapper) *FaceDetector {
+	return FaceDetectorFromJS(input.JSValue())
 }
 
 func NewFaceDetector(faceDetectorOptions *FaceDetectorOptions) (_result *FaceDetector) {
@@ -762,15 +773,19 @@ func (_this *PromiseSequenceBarcodeFormat) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceBarcodeFormatFromJS is casting a js.Wrapper into PromiseSequenceBarcodeFormat.
-func PromiseSequenceBarcodeFormatFromJS(value js.Wrapper) *PromiseSequenceBarcodeFormat {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceBarcodeFormatFromJS is casting a js.Value into PromiseSequenceBarcodeFormat.
+func PromiseSequenceBarcodeFormatFromJS(value js.Value) *PromiseSequenceBarcodeFormat {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceBarcodeFormat{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceBarcodeFormatFromJS is casting from something that holds a js.Value into PromiseSequenceBarcodeFormat.
+func PromiseSequenceBarcodeFormatFromWrapper(input core.Wrapper) *PromiseSequenceBarcodeFormat {
+	return PromiseSequenceBarcodeFormatFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceBarcodeFormat) Then(onFulfilled *PromiseSequenceBarcodeFormatOnFulfilled, onRejected *PromiseSequenceBarcodeFormatOnRejected) (_result *PromiseSequenceBarcodeFormat) {
@@ -867,15 +882,19 @@ func (_this *PromiseSequenceDetectedBarcode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDetectedBarcodeFromJS is casting a js.Wrapper into PromiseSequenceDetectedBarcode.
-func PromiseSequenceDetectedBarcodeFromJS(value js.Wrapper) *PromiseSequenceDetectedBarcode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDetectedBarcodeFromJS is casting a js.Value into PromiseSequenceDetectedBarcode.
+func PromiseSequenceDetectedBarcodeFromJS(value js.Value) *PromiseSequenceDetectedBarcode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDetectedBarcode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDetectedBarcodeFromJS is casting from something that holds a js.Value into PromiseSequenceDetectedBarcode.
+func PromiseSequenceDetectedBarcodeFromWrapper(input core.Wrapper) *PromiseSequenceDetectedBarcode {
+	return PromiseSequenceDetectedBarcodeFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDetectedBarcode) Then(onFulfilled *PromiseSequenceDetectedBarcodeOnFulfilled, onRejected *PromiseSequenceDetectedBarcodeOnRejected) (_result *PromiseSequenceDetectedBarcode) {
@@ -972,15 +991,19 @@ func (_this *PromiseSequenceDetectedFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDetectedFaceFromJS is casting a js.Wrapper into PromiseSequenceDetectedFace.
-func PromiseSequenceDetectedFaceFromJS(value js.Wrapper) *PromiseSequenceDetectedFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDetectedFaceFromJS is casting a js.Value into PromiseSequenceDetectedFace.
+func PromiseSequenceDetectedFaceFromJS(value js.Value) *PromiseSequenceDetectedFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDetectedFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDetectedFaceFromJS is casting from something that holds a js.Value into PromiseSequenceDetectedFace.
+func PromiseSequenceDetectedFaceFromWrapper(input core.Wrapper) *PromiseSequenceDetectedFace {
+	return PromiseSequenceDetectedFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDetectedFace) Then(onFulfilled *PromiseSequenceDetectedFaceOnFulfilled, onRejected *PromiseSequenceDetectedFaceOnRejected) (_result *PromiseSequenceDetectedFace) {

--- a/graphics/shapedetection/shapedetection_js.go
+++ b/graphics/shapedetection/shapedetection_js.go
@@ -5,6 +5,7 @@ package shapedetection
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/geometry"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -417,7 +418,7 @@ type BarcodeDetectorOptions struct {
 	Formats []BarcodeFormat
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BarcodeDetectorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -431,19 +432,17 @@ func (_this *BarcodeDetectorOptions) JSValue() js.Value {
 }
 
 // BarcodeDetectorOptionsFromJS is allocating a new
-// BarcodeDetectorOptions object and copy all values from
-// input javascript object
-func BarcodeDetectorOptionsFromJS(value js.Wrapper) *BarcodeDetectorOptions {
-	input := value.JSValue()
+// BarcodeDetectorOptions object and copy all values in the value javascript object.
+func BarcodeDetectorOptionsFromJS(value js.Value) *BarcodeDetectorOptions {
 	var out BarcodeDetectorOptions
 	var (
 		value0 []BarcodeFormat // javascript: sequence<BarcodeFormat> {formats Formats formats}
 	)
-	__length0 := input.Get("formats").Length()
+	__length0 := value.Get("formats").Length()
 	__array0 := make([]BarcodeFormat, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 BarcodeFormat
-		__seq_in0 := input.Get("formats").Index(__idx0)
+		__seq_in0 := value.Get("formats").Index(__idx0)
 		__seq_out0 = BarcodeFormatFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -458,7 +457,7 @@ type FaceDetectorOptions struct {
 	FastMode         bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FaceDetectorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -470,18 +469,16 @@ func (_this *FaceDetectorOptions) JSValue() js.Value {
 }
 
 // FaceDetectorOptionsFromJS is allocating a new
-// FaceDetectorOptions object and copy all values from
-// input javascript object
-func FaceDetectorOptionsFromJS(value js.Wrapper) *FaceDetectorOptions {
-	input := value.JSValue()
+// FaceDetectorOptions object and copy all values in the value javascript object.
+func FaceDetectorOptionsFromJS(value js.Value) *FaceDetectorOptions {
 	var out FaceDetectorOptions
 	var (
 		value0 int  // javascript: unsigned short {maxDetectedFaces MaxDetectedFaces maxDetectedFaces}
 		value1 bool // javascript: boolean {fastMode FastMode fastMode}
 	)
-	value0 = (input.Get("maxDetectedFaces")).Int()
+	value0 = (value.Get("maxDetectedFaces")).Int()
 	out.MaxDetectedFaces = value0
-	value1 = (input.Get("fastMode")).Bool()
+	value1 = (value.Get("fastMode")).Bool()
 	out.FastMode = value1
 	return &out
 }
@@ -492,7 +489,7 @@ type Landmark struct {
 	Type      LandmarkType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Landmark) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -504,18 +501,16 @@ func (_this *Landmark) JSValue() js.Value {
 }
 
 // LandmarkFromJS is allocating a new
-// Landmark object and copy all values from
-// input javascript object
-func LandmarkFromJS(value js.Wrapper) *Landmark {
-	input := value.JSValue()
+// Landmark object and copy all values in the value javascript object.
+func LandmarkFromJS(value js.Value) *Landmark {
 	var out Landmark
 	var (
 		value0 *javascript.FrozenArray // javascript: FrozenArray {locations Locations locations}
 		value1 LandmarkType            // javascript: LandmarkType {type Type _type}
 	)
-	value0 = javascript.FrozenArrayFromJS(input.Get("locations"))
+	value0 = javascript.FrozenArrayFromJS(value.Get("locations"))
 	out.Locations = value0
-	value1 = LandmarkTypeFromJS(input.Get("type"))
+	value1 = LandmarkTypeFromJS(value.Get("type"))
 	out.Type = value1
 	return &out
 }
@@ -530,15 +525,19 @@ func (_this *BarcodeDetector) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BarcodeDetectorFromJS is casting a js.Wrapper into BarcodeDetector.
-func BarcodeDetectorFromJS(value js.Wrapper) *BarcodeDetector {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BarcodeDetectorFromJS is casting a js.Value into BarcodeDetector.
+func BarcodeDetectorFromJS(value js.Value) *BarcodeDetector {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BarcodeDetector{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BarcodeDetectorFromJS is casting from something that holds a js.Value into BarcodeDetector.
+func BarcodeDetectorFromWrapper(input core.Wrapper) *BarcodeDetector {
+	return BarcodeDetectorFromJS(input.JSValue())
 }
 
 func GetSupportedFormats() (_result *PromiseSequenceBarcodeFormat) {
@@ -604,15 +603,19 @@ func (_this *DetectedBarcode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DetectedBarcodeFromJS is casting a js.Wrapper into DetectedBarcode.
-func DetectedBarcodeFromJS(value js.Wrapper) *DetectedBarcode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DetectedBarcodeFromJS is casting a js.Value into DetectedBarcode.
+func DetectedBarcodeFromJS(value js.Value) *DetectedBarcode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DetectedBarcode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DetectedBarcodeFromJS is casting from something that holds a js.Value into DetectedBarcode.
+func DetectedBarcodeFromWrapper(input core.Wrapper) *DetectedBarcode {
+	return DetectedBarcodeFromJS(input.JSValue())
 }
 
 // BoundingBox returning attribute 'boundingBox' with
@@ -661,15 +664,19 @@ func (_this *DetectedFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DetectedFaceFromJS is casting a js.Wrapper into DetectedFace.
-func DetectedFaceFromJS(value js.Wrapper) *DetectedFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DetectedFaceFromJS is casting a js.Value into DetectedFace.
+func DetectedFaceFromJS(value js.Value) *DetectedFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DetectedFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DetectedFaceFromJS is casting from something that holds a js.Value into DetectedFace.
+func DetectedFaceFromWrapper(input core.Wrapper) *DetectedFace {
+	return DetectedFaceFromJS(input.JSValue())
 }
 
 // BoundingBox returning attribute 'boundingBox' with
@@ -702,15 +709,19 @@ func (_this *FaceDetector) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FaceDetectorFromJS is casting a js.Wrapper into FaceDetector.
-func FaceDetectorFromJS(value js.Wrapper) *FaceDetector {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FaceDetectorFromJS is casting a js.Value into FaceDetector.
+func FaceDetectorFromJS(value js.Value) *FaceDetector {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FaceDetector{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FaceDetectorFromJS is casting from something that holds a js.Value into FaceDetector.
+func FaceDetectorFromWrapper(input core.Wrapper) *FaceDetector {
+	return FaceDetectorFromJS(input.JSValue())
 }
 
 func NewFaceDetector(faceDetectorOptions *FaceDetectorOptions) (_result *FaceDetector) {
@@ -760,15 +771,19 @@ func (_this *PromiseSequenceBarcodeFormat) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceBarcodeFormatFromJS is casting a js.Wrapper into PromiseSequenceBarcodeFormat.
-func PromiseSequenceBarcodeFormatFromJS(value js.Wrapper) *PromiseSequenceBarcodeFormat {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceBarcodeFormatFromJS is casting a js.Value into PromiseSequenceBarcodeFormat.
+func PromiseSequenceBarcodeFormatFromJS(value js.Value) *PromiseSequenceBarcodeFormat {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceBarcodeFormat{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceBarcodeFormatFromJS is casting from something that holds a js.Value into PromiseSequenceBarcodeFormat.
+func PromiseSequenceBarcodeFormatFromWrapper(input core.Wrapper) *PromiseSequenceBarcodeFormat {
+	return PromiseSequenceBarcodeFormatFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceBarcodeFormat) Then(onFulfilled *PromiseSequenceBarcodeFormatOnFulfilled, onRejected *PromiseSequenceBarcodeFormatOnRejected) (_result *PromiseSequenceBarcodeFormat) {
@@ -865,15 +880,19 @@ func (_this *PromiseSequenceDetectedBarcode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDetectedBarcodeFromJS is casting a js.Wrapper into PromiseSequenceDetectedBarcode.
-func PromiseSequenceDetectedBarcodeFromJS(value js.Wrapper) *PromiseSequenceDetectedBarcode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDetectedBarcodeFromJS is casting a js.Value into PromiseSequenceDetectedBarcode.
+func PromiseSequenceDetectedBarcodeFromJS(value js.Value) *PromiseSequenceDetectedBarcode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDetectedBarcode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDetectedBarcodeFromJS is casting from something that holds a js.Value into PromiseSequenceDetectedBarcode.
+func PromiseSequenceDetectedBarcodeFromWrapper(input core.Wrapper) *PromiseSequenceDetectedBarcode {
+	return PromiseSequenceDetectedBarcodeFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDetectedBarcode) Then(onFulfilled *PromiseSequenceDetectedBarcodeOnFulfilled, onRejected *PromiseSequenceDetectedBarcodeOnRejected) (_result *PromiseSequenceDetectedBarcode) {
@@ -970,15 +989,19 @@ func (_this *PromiseSequenceDetectedFace) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceDetectedFaceFromJS is casting a js.Wrapper into PromiseSequenceDetectedFace.
-func PromiseSequenceDetectedFaceFromJS(value js.Wrapper) *PromiseSequenceDetectedFace {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceDetectedFaceFromJS is casting a js.Value into PromiseSequenceDetectedFace.
+func PromiseSequenceDetectedFaceFromJS(value js.Value) *PromiseSequenceDetectedFace {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceDetectedFace{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceDetectedFaceFromJS is casting from something that holds a js.Value into PromiseSequenceDetectedFace.
+func PromiseSequenceDetectedFaceFromWrapper(input core.Wrapper) *PromiseSequenceDetectedFace {
+	return PromiseSequenceDetectedFaceFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceDetectedFace) Then(onFulfilled *PromiseSequenceDetectedFaceOnFulfilled, onRejected *PromiseSequenceDetectedFaceOnRejected) (_result *PromiseSequenceDetectedFace) {

--- a/graphics/svg/svg.go
+++ b/graphics/svg/svg.go
@@ -9,6 +9,7 @@ import js "github.com/gowebapi/webapi/core/js"
 import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
 	"github.com/gowebapi/webapi/css/animations/webani"
@@ -101,7 +102,7 @@ type SVGBoundingBoxOptions struct {
 	Clipped bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SVGBoundingBoxOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -117,10 +118,8 @@ func (_this *SVGBoundingBoxOptions) JSValue() js.Value {
 }
 
 // SVGBoundingBoxOptionsFromJS is allocating a new
-// SVGBoundingBoxOptions object and copy all values from
-// input javascript object
-func SVGBoundingBoxOptionsFromJS(value js.Wrapper) *SVGBoundingBoxOptions {
-	input := value.JSValue()
+// SVGBoundingBoxOptions object and copy all values in the value javascript object.
+func SVGBoundingBoxOptionsFromJS(value js.Value) *SVGBoundingBoxOptions {
 	var out SVGBoundingBoxOptions
 	var (
 		value0 bool // javascript: boolean {fill Fill fill}
@@ -128,13 +127,13 @@ func SVGBoundingBoxOptionsFromJS(value js.Wrapper) *SVGBoundingBoxOptions {
 		value2 bool // javascript: boolean {markers Markers markers}
 		value3 bool // javascript: boolean {clipped Clipped clipped}
 	)
-	value0 = (input.Get("fill")).Bool()
+	value0 = (value.Get("fill")).Bool()
 	out.Fill = value0
-	value1 = (input.Get("stroke")).Bool()
+	value1 = (value.Get("stroke")).Bool()
 	out.Stroke = value1
-	value2 = (input.Get("markers")).Bool()
+	value2 = (value.Get("markers")).Bool()
 	out.Markers = value2
-	value3 = (input.Get("clipped")).Bool()
+	value3 = (value.Get("clipped")).Bool()
 	out.Clipped = value3
 	return &out
 }
@@ -144,15 +143,19 @@ type SVGAElement struct {
 	SVGGraphicsElement
 }
 
-// SVGAElementFromJS is casting a js.Wrapper into SVGAElement.
-func SVGAElementFromJS(value js.Wrapper) *SVGAElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAElementFromJS is casting a js.Value into SVGAElement.
+func SVGAElementFromJS(value js.Value) *SVGAElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAElementFromJS is casting from something that holds a js.Value into SVGAElement.
+func SVGAElementFromWrapper(input core.Wrapper) *SVGAElement {
+	return SVGAElementFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -469,15 +472,19 @@ func (_this *SVGAngle) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAngleFromJS is casting a js.Wrapper into SVGAngle.
-func SVGAngleFromJS(value js.Wrapper) *SVGAngle {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAngleFromJS is casting a js.Value into SVGAngle.
+func SVGAngleFromJS(value js.Value) *SVGAngle {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAngle{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAngleFromJS is casting from something that holds a js.Value into SVGAngle.
+func SVGAngleFromWrapper(input core.Wrapper) *SVGAngle {
+	return SVGAngleFromJS(input.JSValue())
 }
 
 const (
@@ -582,15 +589,19 @@ func (_this *SVGAnimatedAngle) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedAngleFromJS is casting a js.Wrapper into SVGAnimatedAngle.
-func SVGAnimatedAngleFromJS(value js.Wrapper) *SVGAnimatedAngle {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedAngleFromJS is casting a js.Value into SVGAnimatedAngle.
+func SVGAnimatedAngleFromJS(value js.Value) *SVGAnimatedAngle {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedAngle{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedAngleFromJS is casting from something that holds a js.Value into SVGAnimatedAngle.
+func SVGAnimatedAngleFromWrapper(input core.Wrapper) *SVGAnimatedAngle {
+	return SVGAnimatedAngleFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -621,15 +632,19 @@ func (_this *SVGAnimatedBoolean) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedBooleanFromJS is casting a js.Wrapper into SVGAnimatedBoolean.
-func SVGAnimatedBooleanFromJS(value js.Wrapper) *SVGAnimatedBoolean {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedBooleanFromJS is casting a js.Value into SVGAnimatedBoolean.
+func SVGAnimatedBooleanFromJS(value js.Value) *SVGAnimatedBoolean {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedBoolean{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedBooleanFromJS is casting from something that holds a js.Value into SVGAnimatedBoolean.
+func SVGAnimatedBooleanFromWrapper(input core.Wrapper) *SVGAnimatedBoolean {
+	return SVGAnimatedBooleanFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -667,15 +682,19 @@ func (_this *SVGAnimatedEnumeration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedEnumerationFromJS is casting a js.Wrapper into SVGAnimatedEnumeration.
-func SVGAnimatedEnumerationFromJS(value js.Wrapper) *SVGAnimatedEnumeration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedEnumerationFromJS is casting a js.Value into SVGAnimatedEnumeration.
+func SVGAnimatedEnumerationFromJS(value js.Value) *SVGAnimatedEnumeration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedEnumeration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedEnumerationFromJS is casting from something that holds a js.Value into SVGAnimatedEnumeration.
+func SVGAnimatedEnumerationFromWrapper(input core.Wrapper) *SVGAnimatedEnumeration {
+	return SVGAnimatedEnumerationFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -713,15 +732,19 @@ func (_this *SVGAnimatedInteger) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedIntegerFromJS is casting a js.Wrapper into SVGAnimatedInteger.
-func SVGAnimatedIntegerFromJS(value js.Wrapper) *SVGAnimatedInteger {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedIntegerFromJS is casting a js.Value into SVGAnimatedInteger.
+func SVGAnimatedIntegerFromJS(value js.Value) *SVGAnimatedInteger {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedInteger{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedIntegerFromJS is casting from something that holds a js.Value into SVGAnimatedInteger.
+func SVGAnimatedIntegerFromWrapper(input core.Wrapper) *SVGAnimatedInteger {
+	return SVGAnimatedIntegerFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -759,15 +782,19 @@ func (_this *SVGAnimatedLength) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedLengthFromJS is casting a js.Wrapper into SVGAnimatedLength.
-func SVGAnimatedLengthFromJS(value js.Wrapper) *SVGAnimatedLength {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedLengthFromJS is casting a js.Value into SVGAnimatedLength.
+func SVGAnimatedLengthFromJS(value js.Value) *SVGAnimatedLength {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedLength{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedLengthFromJS is casting from something that holds a js.Value into SVGAnimatedLength.
+func SVGAnimatedLengthFromWrapper(input core.Wrapper) *SVGAnimatedLength {
+	return SVGAnimatedLengthFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -798,15 +825,19 @@ func (_this *SVGAnimatedLengthList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedLengthListFromJS is casting a js.Wrapper into SVGAnimatedLengthList.
-func SVGAnimatedLengthListFromJS(value js.Wrapper) *SVGAnimatedLengthList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedLengthListFromJS is casting a js.Value into SVGAnimatedLengthList.
+func SVGAnimatedLengthListFromJS(value js.Value) *SVGAnimatedLengthList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedLengthList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedLengthListFromJS is casting from something that holds a js.Value into SVGAnimatedLengthList.
+func SVGAnimatedLengthListFromWrapper(input core.Wrapper) *SVGAnimatedLengthList {
+	return SVGAnimatedLengthListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -837,15 +868,19 @@ func (_this *SVGAnimatedNumber) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedNumberFromJS is casting a js.Wrapper into SVGAnimatedNumber.
-func SVGAnimatedNumberFromJS(value js.Wrapper) *SVGAnimatedNumber {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedNumberFromJS is casting a js.Value into SVGAnimatedNumber.
+func SVGAnimatedNumberFromJS(value js.Value) *SVGAnimatedNumber {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedNumber{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedNumberFromJS is casting from something that holds a js.Value into SVGAnimatedNumber.
+func SVGAnimatedNumberFromWrapper(input core.Wrapper) *SVGAnimatedNumber {
+	return SVGAnimatedNumberFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -883,15 +918,19 @@ func (_this *SVGAnimatedNumberList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedNumberListFromJS is casting a js.Wrapper into SVGAnimatedNumberList.
-func SVGAnimatedNumberListFromJS(value js.Wrapper) *SVGAnimatedNumberList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedNumberListFromJS is casting a js.Value into SVGAnimatedNumberList.
+func SVGAnimatedNumberListFromJS(value js.Value) *SVGAnimatedNumberList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedNumberList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedNumberListFromJS is casting from something that holds a js.Value into SVGAnimatedNumberList.
+func SVGAnimatedNumberListFromWrapper(input core.Wrapper) *SVGAnimatedNumberList {
+	return SVGAnimatedNumberListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -922,15 +961,19 @@ func (_this *SVGAnimatedPreserveAspectRatio) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedPreserveAspectRatioFromJS is casting a js.Wrapper into SVGAnimatedPreserveAspectRatio.
-func SVGAnimatedPreserveAspectRatioFromJS(value js.Wrapper) *SVGAnimatedPreserveAspectRatio {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedPreserveAspectRatioFromJS is casting a js.Value into SVGAnimatedPreserveAspectRatio.
+func SVGAnimatedPreserveAspectRatioFromJS(value js.Value) *SVGAnimatedPreserveAspectRatio {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedPreserveAspectRatio{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedPreserveAspectRatioFromJS is casting from something that holds a js.Value into SVGAnimatedPreserveAspectRatio.
+func SVGAnimatedPreserveAspectRatioFromWrapper(input core.Wrapper) *SVGAnimatedPreserveAspectRatio {
+	return SVGAnimatedPreserveAspectRatioFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -961,15 +1004,19 @@ func (_this *SVGAnimatedRect) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedRectFromJS is casting a js.Wrapper into SVGAnimatedRect.
-func SVGAnimatedRectFromJS(value js.Wrapper) *SVGAnimatedRect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedRectFromJS is casting a js.Value into SVGAnimatedRect.
+func SVGAnimatedRectFromJS(value js.Value) *SVGAnimatedRect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedRect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedRectFromJS is casting from something that holds a js.Value into SVGAnimatedRect.
+func SVGAnimatedRectFromWrapper(input core.Wrapper) *SVGAnimatedRect {
+	return SVGAnimatedRectFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -1000,15 +1047,19 @@ func (_this *SVGAnimatedString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedStringFromJS is casting a js.Wrapper into SVGAnimatedString.
-func SVGAnimatedStringFromJS(value js.Wrapper) *SVGAnimatedString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedStringFromJS is casting a js.Value into SVGAnimatedString.
+func SVGAnimatedStringFromJS(value js.Value) *SVGAnimatedString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedStringFromJS is casting from something that holds a js.Value into SVGAnimatedString.
+func SVGAnimatedStringFromWrapper(input core.Wrapper) *SVGAnimatedString {
+	return SVGAnimatedStringFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -1046,15 +1097,19 @@ func (_this *SVGAnimatedTransformList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedTransformListFromJS is casting a js.Wrapper into SVGAnimatedTransformList.
-func SVGAnimatedTransformListFromJS(value js.Wrapper) *SVGAnimatedTransformList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedTransformListFromJS is casting a js.Value into SVGAnimatedTransformList.
+func SVGAnimatedTransformListFromJS(value js.Value) *SVGAnimatedTransformList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedTransformList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedTransformListFromJS is casting from something that holds a js.Value into SVGAnimatedTransformList.
+func SVGAnimatedTransformListFromWrapper(input core.Wrapper) *SVGAnimatedTransformList {
+	return SVGAnimatedTransformListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -1080,15 +1135,19 @@ type SVGCircleElement struct {
 	SVGGeometryElement
 }
 
-// SVGCircleElementFromJS is casting a js.Wrapper into SVGCircleElement.
-func SVGCircleElementFromJS(value js.Wrapper) *SVGCircleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGCircleElementFromJS is casting a js.Value into SVGCircleElement.
+func SVGCircleElementFromJS(value js.Value) *SVGCircleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGCircleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGCircleElementFromJS is casting from something that holds a js.Value into SVGCircleElement.
+func SVGCircleElementFromWrapper(input core.Wrapper) *SVGCircleElement {
+	return SVGCircleElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -1123,15 +1182,19 @@ type SVGDefsElement struct {
 	SVGGraphicsElement
 }
 
-// SVGDefsElementFromJS is casting a js.Wrapper into SVGDefsElement.
-func SVGDefsElementFromJS(value js.Wrapper) *SVGDefsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGDefsElementFromJS is casting a js.Value into SVGDefsElement.
+func SVGDefsElementFromJS(value js.Value) *SVGDefsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGDefsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGDefsElementFromJS is casting from something that holds a js.Value into SVGDefsElement.
+func SVGDefsElementFromWrapper(input core.Wrapper) *SVGDefsElement {
+	return SVGDefsElementFromJS(input.JSValue())
 }
 
 // class: SVGDescElement
@@ -1139,15 +1202,19 @@ type SVGDescElement struct {
 	SVGElement
 }
 
-// SVGDescElementFromJS is casting a js.Wrapper into SVGDescElement.
-func SVGDescElementFromJS(value js.Wrapper) *SVGDescElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGDescElementFromJS is casting a js.Value into SVGDescElement.
+func SVGDescElementFromJS(value js.Value) *SVGDescElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGDescElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGDescElementFromJS is casting from something that holds a js.Value into SVGDescElement.
+func SVGDescElementFromWrapper(input core.Wrapper) *SVGDescElement {
+	return SVGDescElementFromJS(input.JSValue())
 }
 
 // class: SVGElement
@@ -1155,15 +1222,19 @@ type SVGElement struct {
 	dom.Element
 }
 
-// SVGElementFromJS is casting a js.Wrapper into SVGElement.
-func SVGElementFromJS(value js.Wrapper) *SVGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGElementFromJS is casting a js.Value into SVGElement.
+func SVGElementFromJS(value js.Value) *SVGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGElementFromJS is casting from something that holds a js.Value into SVGElement.
+func SVGElementFromWrapper(input core.Wrapper) *SVGElement {
+	return SVGElementFromJS(input.JSValue())
 }
 
 // ClassName returning attribute 'className' with
@@ -3960,15 +4031,19 @@ type SVGEllipseElement struct {
 	SVGGeometryElement
 }
 
-// SVGEllipseElementFromJS is casting a js.Wrapper into SVGEllipseElement.
-func SVGEllipseElementFromJS(value js.Wrapper) *SVGEllipseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGEllipseElementFromJS is casting a js.Value into SVGEllipseElement.
+func SVGEllipseElementFromJS(value js.Value) *SVGEllipseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGEllipseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGEllipseElementFromJS is casting from something that holds a js.Value into SVGEllipseElement.
+func SVGEllipseElementFromWrapper(input core.Wrapper) *SVGEllipseElement {
+	return SVGEllipseElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -4012,15 +4087,19 @@ type SVGForeignObjectElement struct {
 	SVGGraphicsElement
 }
 
-// SVGForeignObjectElementFromJS is casting a js.Wrapper into SVGForeignObjectElement.
-func SVGForeignObjectElementFromJS(value js.Wrapper) *SVGForeignObjectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGForeignObjectElementFromJS is casting a js.Value into SVGForeignObjectElement.
+func SVGForeignObjectElementFromJS(value js.Value) *SVGForeignObjectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGForeignObjectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGForeignObjectElementFromJS is casting from something that holds a js.Value into SVGForeignObjectElement.
+func SVGForeignObjectElementFromWrapper(input core.Wrapper) *SVGForeignObjectElement {
+	return SVGForeignObjectElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -4064,15 +4143,19 @@ type SVGGElement struct {
 	SVGGraphicsElement
 }
 
-// SVGGElementFromJS is casting a js.Wrapper into SVGGElement.
-func SVGGElementFromJS(value js.Wrapper) *SVGGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGElementFromJS is casting a js.Value into SVGGElement.
+func SVGGElementFromJS(value js.Value) *SVGGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGElementFromJS is casting from something that holds a js.Value into SVGGElement.
+func SVGGElementFromWrapper(input core.Wrapper) *SVGGElement {
+	return SVGGElementFromJS(input.JSValue())
 }
 
 // class: SVGGeometryElement
@@ -4080,15 +4163,19 @@ type SVGGeometryElement struct {
 	SVGGraphicsElement
 }
 
-// SVGGeometryElementFromJS is casting a js.Wrapper into SVGGeometryElement.
-func SVGGeometryElementFromJS(value js.Wrapper) *SVGGeometryElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGeometryElementFromJS is casting a js.Value into SVGGeometryElement.
+func SVGGeometryElementFromJS(value js.Value) *SVGGeometryElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGeometryElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGeometryElementFromJS is casting from something that holds a js.Value into SVGGeometryElement.
+func SVGGeometryElementFromWrapper(input core.Wrapper) *SVGGeometryElement {
+	return SVGGeometryElementFromJS(input.JSValue())
 }
 
 // PathLength returning attribute 'pathLength' with
@@ -4174,15 +4261,19 @@ type SVGGradientElement struct {
 	SVGElement
 }
 
-// SVGGradientElementFromJS is casting a js.Wrapper into SVGGradientElement.
-func SVGGradientElementFromJS(value js.Wrapper) *SVGGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGradientElementFromJS is casting a js.Value into SVGGradientElement.
+func SVGGradientElementFromJS(value js.Value) *SVGGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGradientElementFromJS is casting from something that holds a js.Value into SVGGradientElement.
+func SVGGradientElementFromWrapper(input core.Wrapper) *SVGGradientElement {
+	return SVGGradientElementFromJS(input.JSValue())
 }
 
 const (
@@ -4233,15 +4324,19 @@ type SVGGraphicsElement struct {
 	SVGElement
 }
 
-// SVGGraphicsElementFromJS is casting a js.Wrapper into SVGGraphicsElement.
-func SVGGraphicsElementFromJS(value js.Wrapper) *SVGGraphicsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGraphicsElementFromJS is casting a js.Value into SVGGraphicsElement.
+func SVGGraphicsElementFromJS(value js.Value) *SVGGraphicsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGraphicsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGraphicsElementFromJS is casting from something that holds a js.Value into SVGGraphicsElement.
+func SVGGraphicsElementFromWrapper(input core.Wrapper) *SVGGraphicsElement {
+	return SVGGraphicsElementFromJS(input.JSValue())
 }
 
 // Transform returning attribute 'transform' with
@@ -4327,15 +4422,19 @@ type SVGImageElement struct {
 	SVGGraphicsElement
 }
 
-// SVGImageElementFromJS is casting a js.Wrapper into SVGImageElement.
-func SVGImageElementFromJS(value js.Wrapper) *SVGImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGImageElementFromJS is casting a js.Value into SVGImageElement.
+func SVGImageElementFromJS(value js.Value) *SVGImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGImageElementFromJS is casting from something that holds a js.Value into SVGImageElement.
+func SVGImageElementFromWrapper(input core.Wrapper) *SVGImageElement {
+	return SVGImageElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -4426,15 +4525,19 @@ func (_this *SVGLength) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGLengthFromJS is casting a js.Wrapper into SVGLength.
-func SVGLengthFromJS(value js.Wrapper) *SVGLength {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLengthFromJS is casting a js.Value into SVGLength.
+func SVGLengthFromJS(value js.Value) *SVGLength {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLength{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLengthFromJS is casting from something that holds a js.Value into SVGLength.
+func SVGLengthFromWrapper(input core.Wrapper) *SVGLength {
+	return SVGLengthFromJS(input.JSValue())
 }
 
 const (
@@ -4545,15 +4648,19 @@ func (_this *SVGLengthList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGLengthListFromJS is casting a js.Wrapper into SVGLengthList.
-func SVGLengthListFromJS(value js.Wrapper) *SVGLengthList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLengthListFromJS is casting a js.Value into SVGLengthList.
+func SVGLengthListFromJS(value js.Value) *SVGLengthList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLengthList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLengthListFromJS is casting from something that holds a js.Value into SVGLengthList.
+func SVGLengthListFromWrapper(input core.Wrapper) *SVGLengthList {
+	return SVGLengthListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -4728,15 +4835,19 @@ type SVGLineElement struct {
 	SVGGeometryElement
 }
 
-// SVGLineElementFromJS is casting a js.Wrapper into SVGLineElement.
-func SVGLineElementFromJS(value js.Wrapper) *SVGLineElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLineElementFromJS is casting a js.Value into SVGLineElement.
+func SVGLineElementFromJS(value js.Value) *SVGLineElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLineElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLineElementFromJS is casting from something that holds a js.Value into SVGLineElement.
+func SVGLineElementFromWrapper(input core.Wrapper) *SVGLineElement {
+	return SVGLineElementFromJS(input.JSValue())
 }
 
 // X1 returning attribute 'x1' with
@@ -4780,15 +4891,19 @@ type SVGLinearGradientElement struct {
 	SVGGradientElement
 }
 
-// SVGLinearGradientElementFromJS is casting a js.Wrapper into SVGLinearGradientElement.
-func SVGLinearGradientElementFromJS(value js.Wrapper) *SVGLinearGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLinearGradientElementFromJS is casting a js.Value into SVGLinearGradientElement.
+func SVGLinearGradientElementFromJS(value js.Value) *SVGLinearGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLinearGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLinearGradientElementFromJS is casting from something that holds a js.Value into SVGLinearGradientElement.
+func SVGLinearGradientElementFromWrapper(input core.Wrapper) *SVGLinearGradientElement {
+	return SVGLinearGradientElementFromJS(input.JSValue())
 }
 
 // X1 returning attribute 'x1' with
@@ -4832,15 +4947,19 @@ type SVGMarkerElement struct {
 	SVGElement
 }
 
-// SVGMarkerElementFromJS is casting a js.Wrapper into SVGMarkerElement.
-func SVGMarkerElementFromJS(value js.Wrapper) *SVGMarkerElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMarkerElementFromJS is casting a js.Value into SVGMarkerElement.
+func SVGMarkerElementFromJS(value js.Value) *SVGMarkerElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMarkerElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMarkerElementFromJS is casting from something that holds a js.Value into SVGMarkerElement.
+func SVGMarkerElementFromWrapper(input core.Wrapper) *SVGMarkerElement {
+	return SVGMarkerElementFromJS(input.JSValue())
 }
 
 const (
@@ -4975,15 +5094,19 @@ type SVGMetadataElement struct {
 	SVGElement
 }
 
-// SVGMetadataElementFromJS is casting a js.Wrapper into SVGMetadataElement.
-func SVGMetadataElementFromJS(value js.Wrapper) *SVGMetadataElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMetadataElementFromJS is casting a js.Value into SVGMetadataElement.
+func SVGMetadataElementFromJS(value js.Value) *SVGMetadataElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMetadataElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMetadataElementFromJS is casting from something that holds a js.Value into SVGMetadataElement.
+func SVGMetadataElementFromWrapper(input core.Wrapper) *SVGMetadataElement {
+	return SVGMetadataElementFromJS(input.JSValue())
 }
 
 // class: SVGNumber
@@ -4996,15 +5119,19 @@ func (_this *SVGNumber) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGNumberFromJS is casting a js.Wrapper into SVGNumber.
-func SVGNumberFromJS(value js.Wrapper) *SVGNumber {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGNumberFromJS is casting a js.Value into SVGNumber.
+func SVGNumberFromJS(value js.Value) *SVGNumber {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGNumber{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGNumberFromJS is casting from something that holds a js.Value into SVGNumber.
+func SVGNumberFromWrapper(input core.Wrapper) *SVGNumber {
+	return SVGNumberFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -5033,15 +5160,19 @@ func (_this *SVGNumberList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGNumberListFromJS is casting a js.Wrapper into SVGNumberList.
-func SVGNumberListFromJS(value js.Wrapper) *SVGNumberList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGNumberListFromJS is casting a js.Value into SVGNumberList.
+func SVGNumberListFromJS(value js.Value) *SVGNumberList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGNumberList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGNumberListFromJS is casting from something that holds a js.Value into SVGNumberList.
+func SVGNumberListFromWrapper(input core.Wrapper) *SVGNumberList {
+	return SVGNumberListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5216,15 +5347,19 @@ type SVGPathElement struct {
 	SVGGeometryElement
 }
 
-// SVGPathElementFromJS is casting a js.Wrapper into SVGPathElement.
-func SVGPathElementFromJS(value js.Wrapper) *SVGPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPathElementFromJS is casting a js.Value into SVGPathElement.
+func SVGPathElementFromJS(value js.Value) *SVGPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPathElementFromJS is casting from something that holds a js.Value into SVGPathElement.
+func SVGPathElementFromWrapper(input core.Wrapper) *SVGPathElement {
+	return SVGPathElementFromJS(input.JSValue())
 }
 
 // class: SVGPatternElement
@@ -5232,15 +5367,19 @@ type SVGPatternElement struct {
 	SVGElement
 }
 
-// SVGPatternElementFromJS is casting a js.Wrapper into SVGPatternElement.
-func SVGPatternElementFromJS(value js.Wrapper) *SVGPatternElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPatternElementFromJS is casting a js.Value into SVGPatternElement.
+func SVGPatternElementFromJS(value js.Value) *SVGPatternElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPatternElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPatternElementFromJS is casting from something that holds a js.Value into SVGPatternElement.
+func SVGPatternElementFromWrapper(input core.Wrapper) *SVGPatternElement {
+	return SVGPatternElementFromJS(input.JSValue())
 }
 
 // PatternUnits returning attribute 'patternUnits' with
@@ -5343,15 +5482,19 @@ func (_this *SVGPointList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGPointListFromJS is casting a js.Wrapper into SVGPointList.
-func SVGPointListFromJS(value js.Wrapper) *SVGPointList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPointListFromJS is casting a js.Value into SVGPointList.
+func SVGPointListFromJS(value js.Value) *SVGPointList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPointList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPointListFromJS is casting from something that holds a js.Value into SVGPointList.
+func SVGPointListFromWrapper(input core.Wrapper) *SVGPointList {
+	return SVGPointListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5526,15 +5669,19 @@ type SVGPolygonElement struct {
 	SVGGeometryElement
 }
 
-// SVGPolygonElementFromJS is casting a js.Wrapper into SVGPolygonElement.
-func SVGPolygonElementFromJS(value js.Wrapper) *SVGPolygonElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPolygonElementFromJS is casting a js.Value into SVGPolygonElement.
+func SVGPolygonElementFromJS(value js.Value) *SVGPolygonElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPolygonElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPolygonElementFromJS is casting from something that holds a js.Value into SVGPolygonElement.
+func SVGPolygonElementFromWrapper(input core.Wrapper) *SVGPolygonElement {
+	return SVGPolygonElementFromJS(input.JSValue())
 }
 
 // Points returning attribute 'points' with
@@ -5560,15 +5707,19 @@ type SVGPolylineElement struct {
 	SVGGeometryElement
 }
 
-// SVGPolylineElementFromJS is casting a js.Wrapper into SVGPolylineElement.
-func SVGPolylineElementFromJS(value js.Wrapper) *SVGPolylineElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPolylineElementFromJS is casting a js.Value into SVGPolylineElement.
+func SVGPolylineElementFromJS(value js.Value) *SVGPolylineElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPolylineElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPolylineElementFromJS is casting from something that holds a js.Value into SVGPolylineElement.
+func SVGPolylineElementFromWrapper(input core.Wrapper) *SVGPolylineElement {
+	return SVGPolylineElementFromJS(input.JSValue())
 }
 
 // Points returning attribute 'points' with
@@ -5599,15 +5750,19 @@ func (_this *SVGPreserveAspectRatio) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGPreserveAspectRatioFromJS is casting a js.Wrapper into SVGPreserveAspectRatio.
-func SVGPreserveAspectRatioFromJS(value js.Wrapper) *SVGPreserveAspectRatio {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPreserveAspectRatioFromJS is casting a js.Value into SVGPreserveAspectRatio.
+func SVGPreserveAspectRatioFromJS(value js.Value) *SVGPreserveAspectRatio {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPreserveAspectRatio{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPreserveAspectRatioFromJS is casting from something that holds a js.Value into SVGPreserveAspectRatio.
+func SVGPreserveAspectRatioFromWrapper(input core.Wrapper) *SVGPreserveAspectRatio {
+	return SVGPreserveAspectRatioFromJS(input.JSValue())
 }
 
 const (
@@ -5664,15 +5819,19 @@ type SVGRadialGradientElement struct {
 	SVGGradientElement
 }
 
-// SVGRadialGradientElementFromJS is casting a js.Wrapper into SVGRadialGradientElement.
-func SVGRadialGradientElementFromJS(value js.Wrapper) *SVGRadialGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGRadialGradientElementFromJS is casting a js.Value into SVGRadialGradientElement.
+func SVGRadialGradientElementFromJS(value js.Value) *SVGRadialGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGRadialGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGRadialGradientElementFromJS is casting from something that holds a js.Value into SVGRadialGradientElement.
+func SVGRadialGradientElementFromWrapper(input core.Wrapper) *SVGRadialGradientElement {
+	return SVGRadialGradientElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -5734,15 +5893,19 @@ type SVGRectElement struct {
 	SVGGeometryElement
 }
 
-// SVGRectElementFromJS is casting a js.Wrapper into SVGRectElement.
-func SVGRectElementFromJS(value js.Wrapper) *SVGRectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGRectElementFromJS is casting a js.Value into SVGRectElement.
+func SVGRectElementFromJS(value js.Value) *SVGRectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGRectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGRectElementFromJS is casting from something that holds a js.Value into SVGRectElement.
+func SVGRectElementFromWrapper(input core.Wrapper) *SVGRectElement {
+	return SVGRectElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -5804,15 +5967,19 @@ type SVGSVGElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSVGElementFromJS is casting a js.Wrapper into SVGSVGElement.
-func SVGSVGElementFromJS(value js.Wrapper) *SVGSVGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSVGElementFromJS is casting a js.Value into SVGSVGElement.
+func SVGSVGElementFromJS(value js.Value) *SVGSVGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSVGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSVGElementFromJS is casting from something that holds a js.Value into SVGSVGElement.
+func SVGSVGElementFromWrapper(input core.Wrapper) *SVGSVGElement {
+	return SVGSVGElementFromJS(input.JSValue())
 }
 
 const (
@@ -6735,15 +6902,19 @@ type SVGScriptElement struct {
 	SVGElement
 }
 
-// SVGScriptElementFromJS is casting a js.Wrapper into SVGScriptElement.
-func SVGScriptElementFromJS(value js.Wrapper) *SVGScriptElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGScriptElementFromJS is casting a js.Value into SVGScriptElement.
+func SVGScriptElementFromJS(value js.Value) *SVGScriptElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGScriptElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGScriptElementFromJS is casting from something that holds a js.Value into SVGScriptElement.
+func SVGScriptElementFromWrapper(input core.Wrapper) *SVGScriptElement {
+	return SVGScriptElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -6800,15 +6971,19 @@ type SVGStopElement struct {
 	SVGElement
 }
 
-// SVGStopElementFromJS is casting a js.Wrapper into SVGStopElement.
-func SVGStopElementFromJS(value js.Wrapper) *SVGStopElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStopElementFromJS is casting a js.Value into SVGStopElement.
+func SVGStopElementFromJS(value js.Value) *SVGStopElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStopElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStopElementFromJS is casting from something that holds a js.Value into SVGStopElement.
+func SVGStopElementFromWrapper(input core.Wrapper) *SVGStopElement {
+	return SVGStopElementFromJS(input.JSValue())
 }
 
 // Offset returning attribute 'offset' with
@@ -6830,15 +7005,19 @@ func (_this *SVGStringList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGStringListFromJS is casting a js.Wrapper into SVGStringList.
-func SVGStringListFromJS(value js.Wrapper) *SVGStringList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStringListFromJS is casting a js.Value into SVGStringList.
+func SVGStringListFromJS(value js.Value) *SVGStringList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStringList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStringListFromJS is casting from something that holds a js.Value into SVGStringList.
+func SVGStringListFromWrapper(input core.Wrapper) *SVGStringList {
+	return SVGStringListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -7013,15 +7192,19 @@ type SVGStyleElement struct {
 	SVGElement
 }
 
-// SVGStyleElementFromJS is casting a js.Wrapper into SVGStyleElement.
-func SVGStyleElementFromJS(value js.Wrapper) *SVGStyleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStyleElementFromJS is casting a js.Value into SVGStyleElement.
+func SVGStyleElementFromJS(value js.Value) *SVGStyleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStyleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStyleElementFromJS is casting from something that holds a js.Value into SVGStyleElement.
+func SVGStyleElementFromWrapper(input core.Wrapper) *SVGStyleElement {
+	return SVGStyleElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -7088,15 +7271,19 @@ type SVGSwitchElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSwitchElementFromJS is casting a js.Wrapper into SVGSwitchElement.
-func SVGSwitchElementFromJS(value js.Wrapper) *SVGSwitchElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSwitchElementFromJS is casting a js.Value into SVGSwitchElement.
+func SVGSwitchElementFromJS(value js.Value) *SVGSwitchElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSwitchElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSwitchElementFromJS is casting from something that holds a js.Value into SVGSwitchElement.
+func SVGSwitchElementFromWrapper(input core.Wrapper) *SVGSwitchElement {
+	return SVGSwitchElementFromJS(input.JSValue())
 }
 
 // class: SVGSymbolElement
@@ -7104,15 +7291,19 @@ type SVGSymbolElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSymbolElementFromJS is casting a js.Wrapper into SVGSymbolElement.
-func SVGSymbolElementFromJS(value js.Wrapper) *SVGSymbolElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSymbolElementFromJS is casting a js.Value into SVGSymbolElement.
+func SVGSymbolElementFromJS(value js.Value) *SVGSymbolElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSymbolElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSymbolElementFromJS is casting from something that holds a js.Value into SVGSymbolElement.
+func SVGSymbolElementFromWrapper(input core.Wrapper) *SVGSymbolElement {
+	return SVGSymbolElementFromJS(input.JSValue())
 }
 
 // ViewBox returning attribute 'viewBox' with
@@ -7138,15 +7329,19 @@ type SVGTSpanElement struct {
 	SVGTextPositioningElement
 }
 
-// SVGTSpanElementFromJS is casting a js.Wrapper into SVGTSpanElement.
-func SVGTSpanElementFromJS(value js.Wrapper) *SVGTSpanElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTSpanElementFromJS is casting a js.Value into SVGTSpanElement.
+func SVGTSpanElementFromJS(value js.Value) *SVGTSpanElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTSpanElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTSpanElementFromJS is casting from something that holds a js.Value into SVGTSpanElement.
+func SVGTSpanElementFromWrapper(input core.Wrapper) *SVGTSpanElement {
+	return SVGTSpanElementFromJS(input.JSValue())
 }
 
 // class: SVGTextContentElement
@@ -7154,15 +7349,19 @@ type SVGTextContentElement struct {
 	SVGGraphicsElement
 }
 
-// SVGTextContentElementFromJS is casting a js.Wrapper into SVGTextContentElement.
-func SVGTextContentElementFromJS(value js.Wrapper) *SVGTextContentElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextContentElementFromJS is casting a js.Value into SVGTextContentElement.
+func SVGTextContentElementFromJS(value js.Value) *SVGTextContentElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextContentElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextContentElementFromJS is casting from something that holds a js.Value into SVGTextContentElement.
+func SVGTextContentElementFromWrapper(input core.Wrapper) *SVGTextContentElement {
+	return SVGTextContentElementFromJS(input.JSValue())
 }
 
 const (
@@ -7344,15 +7543,19 @@ type SVGTextElement struct {
 	SVGTextPositioningElement
 }
 
-// SVGTextElementFromJS is casting a js.Wrapper into SVGTextElement.
-func SVGTextElementFromJS(value js.Wrapper) *SVGTextElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextElementFromJS is casting a js.Value into SVGTextElement.
+func SVGTextElementFromJS(value js.Value) *SVGTextElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextElementFromJS is casting from something that holds a js.Value into SVGTextElement.
+func SVGTextElementFromWrapper(input core.Wrapper) *SVGTextElement {
+	return SVGTextElementFromJS(input.JSValue())
 }
 
 // class: SVGTextPathElement
@@ -7360,15 +7563,19 @@ type SVGTextPathElement struct {
 	SVGTextContentElement
 }
 
-// SVGTextPathElementFromJS is casting a js.Wrapper into SVGTextPathElement.
-func SVGTextPathElementFromJS(value js.Wrapper) *SVGTextPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextPathElementFromJS is casting a js.Value into SVGTextPathElement.
+func SVGTextPathElementFromJS(value js.Value) *SVGTextPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextPathElementFromJS is casting from something that holds a js.Value into SVGTextPathElement.
+func SVGTextPathElementFromWrapper(input core.Wrapper) *SVGTextPathElement {
+	return SVGTextPathElementFromJS(input.JSValue())
 }
 
 const (
@@ -7421,15 +7628,19 @@ type SVGTextPositioningElement struct {
 	SVGTextContentElement
 }
 
-// SVGTextPositioningElementFromJS is casting a js.Wrapper into SVGTextPositioningElement.
-func SVGTextPositioningElementFromJS(value js.Wrapper) *SVGTextPositioningElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextPositioningElementFromJS is casting a js.Value into SVGTextPositioningElement.
+func SVGTextPositioningElementFromJS(value js.Value) *SVGTextPositioningElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextPositioningElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextPositioningElementFromJS is casting from something that holds a js.Value into SVGTextPositioningElement.
+func SVGTextPositioningElementFromWrapper(input core.Wrapper) *SVGTextPositioningElement {
+	return SVGTextPositioningElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -7482,15 +7693,19 @@ type SVGTitleElement struct {
 	SVGElement
 }
 
-// SVGTitleElementFromJS is casting a js.Wrapper into SVGTitleElement.
-func SVGTitleElementFromJS(value js.Wrapper) *SVGTitleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTitleElementFromJS is casting a js.Value into SVGTitleElement.
+func SVGTitleElementFromJS(value js.Value) *SVGTitleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTitleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTitleElementFromJS is casting from something that holds a js.Value into SVGTitleElement.
+func SVGTitleElementFromWrapper(input core.Wrapper) *SVGTitleElement {
+	return SVGTitleElementFromJS(input.JSValue())
 }
 
 // class: SVGTransform
@@ -7503,15 +7718,19 @@ func (_this *SVGTransform) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGTransformFromJS is casting a js.Wrapper into SVGTransform.
-func SVGTransformFromJS(value js.Wrapper) *SVGTransform {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTransformFromJS is casting a js.Value into SVGTransform.
+func SVGTransformFromJS(value js.Value) *SVGTransform {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTransform{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTransformFromJS is casting from something that holds a js.Value into SVGTransform.
+func SVGTransformFromWrapper(input core.Wrapper) *SVGTransform {
+	return SVGTransformFromJS(input.JSValue())
 }
 
 const (
@@ -7647,15 +7866,19 @@ func (_this *SVGTransformList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGTransformListFromJS is casting a js.Wrapper into SVGTransformList.
-func SVGTransformListFromJS(value js.Wrapper) *SVGTransformList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTransformListFromJS is casting a js.Value into SVGTransformList.
+func SVGTransformListFromJS(value js.Value) *SVGTransformList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTransformList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTransformListFromJS is casting from something that holds a js.Value into SVGTransformList.
+func SVGTransformListFromWrapper(input core.Wrapper) *SVGTransformList {
+	return SVGTransformListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -7870,15 +8093,19 @@ func (_this *SVGUnitTypes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGUnitTypesFromJS is casting a js.Wrapper into SVGUnitTypes.
-func SVGUnitTypesFromJS(value js.Wrapper) *SVGUnitTypes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUnitTypesFromJS is casting a js.Value into SVGUnitTypes.
+func SVGUnitTypesFromJS(value js.Value) *SVGUnitTypes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUnitTypes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUnitTypesFromJS is casting from something that holds a js.Value into SVGUnitTypes.
+func SVGUnitTypesFromWrapper(input core.Wrapper) *SVGUnitTypes {
+	return SVGUnitTypesFromJS(input.JSValue())
 }
 
 const (
@@ -7892,15 +8119,19 @@ type SVGUnknownElement struct {
 	SVGGraphicsElement
 }
 
-// SVGUnknownElementFromJS is casting a js.Wrapper into SVGUnknownElement.
-func SVGUnknownElementFromJS(value js.Wrapper) *SVGUnknownElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUnknownElementFromJS is casting a js.Value into SVGUnknownElement.
+func SVGUnknownElementFromJS(value js.Value) *SVGUnknownElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUnknownElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUnknownElementFromJS is casting from something that holds a js.Value into SVGUnknownElement.
+func SVGUnknownElementFromWrapper(input core.Wrapper) *SVGUnknownElement {
+	return SVGUnknownElementFromJS(input.JSValue())
 }
 
 // class: SVGUseElement
@@ -7908,15 +8139,19 @@ type SVGUseElement struct {
 	SVGGraphicsElement
 }
 
-// SVGUseElementFromJS is casting a js.Wrapper into SVGUseElement.
-func SVGUseElementFromJS(value js.Wrapper) *SVGUseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUseElementFromJS is casting a js.Value into SVGUseElement.
+func SVGUseElementFromJS(value js.Value) *SVGUseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUseElementFromJS is casting from something that holds a js.Value into SVGUseElement.
+func SVGUseElementFromWrapper(input core.Wrapper) *SVGUseElement {
+	return SVGUseElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -7991,15 +8226,19 @@ type SVGUseElementShadowRoot struct {
 	dom.ShadowRoot
 }
 
-// SVGUseElementShadowRootFromJS is casting a js.Wrapper into SVGUseElementShadowRoot.
-func SVGUseElementShadowRootFromJS(value js.Wrapper) *SVGUseElementShadowRoot {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUseElementShadowRootFromJS is casting a js.Value into SVGUseElementShadowRoot.
+func SVGUseElementShadowRootFromJS(value js.Value) *SVGUseElementShadowRoot {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUseElementShadowRoot{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUseElementShadowRootFromJS is casting from something that holds a js.Value into SVGUseElementShadowRoot.
+func SVGUseElementShadowRootFromWrapper(input core.Wrapper) *SVGUseElementShadowRoot {
+	return SVGUseElementShadowRootFromJS(input.JSValue())
 }
 
 // class: SVGViewElement
@@ -8007,15 +8246,19 @@ type SVGViewElement struct {
 	SVGElement
 }
 
-// SVGViewElementFromJS is casting a js.Wrapper into SVGViewElement.
-func SVGViewElementFromJS(value js.Wrapper) *SVGViewElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGViewElementFromJS is casting a js.Value into SVGViewElement.
+func SVGViewElementFromJS(value js.Value) *SVGViewElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGViewElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGViewElementFromJS is casting from something that holds a js.Value into SVGViewElement.
+func SVGViewElementFromWrapper(input core.Wrapper) *SVGViewElement {
+	return SVGViewElementFromJS(input.JSValue())
 }
 
 const (
@@ -8063,15 +8306,19 @@ type ShadowAnimation struct {
 	webani.Animation
 }
 
-// ShadowAnimationFromJS is casting a js.Wrapper into ShadowAnimation.
-func ShadowAnimationFromJS(value js.Wrapper) *ShadowAnimation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShadowAnimationFromJS is casting a js.Value into ShadowAnimation.
+func ShadowAnimationFromJS(value js.Value) *ShadowAnimation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShadowAnimation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShadowAnimationFromJS is casting from something that holds a js.Value into ShadowAnimation.
+func ShadowAnimationFromWrapper(input core.Wrapper) *ShadowAnimation {
+	return ShadowAnimationFromJS(input.JSValue())
 }
 
 // SourceAnimation returning attribute 'sourceAnimation' with

--- a/graphics/svg/svg_js.go
+++ b/graphics/svg/svg_js.go
@@ -7,6 +7,7 @@ import "syscall/js"
 import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
 	"github.com/gowebapi/webapi/css/animations/webani"
@@ -99,7 +100,7 @@ type SVGBoundingBoxOptions struct {
 	Clipped bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SVGBoundingBoxOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -115,10 +116,8 @@ func (_this *SVGBoundingBoxOptions) JSValue() js.Value {
 }
 
 // SVGBoundingBoxOptionsFromJS is allocating a new
-// SVGBoundingBoxOptions object and copy all values from
-// input javascript object
-func SVGBoundingBoxOptionsFromJS(value js.Wrapper) *SVGBoundingBoxOptions {
-	input := value.JSValue()
+// SVGBoundingBoxOptions object and copy all values in the value javascript object.
+func SVGBoundingBoxOptionsFromJS(value js.Value) *SVGBoundingBoxOptions {
 	var out SVGBoundingBoxOptions
 	var (
 		value0 bool // javascript: boolean {fill Fill fill}
@@ -126,13 +125,13 @@ func SVGBoundingBoxOptionsFromJS(value js.Wrapper) *SVGBoundingBoxOptions {
 		value2 bool // javascript: boolean {markers Markers markers}
 		value3 bool // javascript: boolean {clipped Clipped clipped}
 	)
-	value0 = (input.Get("fill")).Bool()
+	value0 = (value.Get("fill")).Bool()
 	out.Fill = value0
-	value1 = (input.Get("stroke")).Bool()
+	value1 = (value.Get("stroke")).Bool()
 	out.Stroke = value1
-	value2 = (input.Get("markers")).Bool()
+	value2 = (value.Get("markers")).Bool()
 	out.Markers = value2
-	value3 = (input.Get("clipped")).Bool()
+	value3 = (value.Get("clipped")).Bool()
 	out.Clipped = value3
 	return &out
 }
@@ -142,15 +141,19 @@ type SVGAElement struct {
 	SVGGraphicsElement
 }
 
-// SVGAElementFromJS is casting a js.Wrapper into SVGAElement.
-func SVGAElementFromJS(value js.Wrapper) *SVGAElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAElementFromJS is casting a js.Value into SVGAElement.
+func SVGAElementFromJS(value js.Value) *SVGAElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAElementFromJS is casting from something that holds a js.Value into SVGAElement.
+func SVGAElementFromWrapper(input core.Wrapper) *SVGAElement {
+	return SVGAElementFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -467,15 +470,19 @@ func (_this *SVGAngle) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAngleFromJS is casting a js.Wrapper into SVGAngle.
-func SVGAngleFromJS(value js.Wrapper) *SVGAngle {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAngleFromJS is casting a js.Value into SVGAngle.
+func SVGAngleFromJS(value js.Value) *SVGAngle {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAngle{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAngleFromJS is casting from something that holds a js.Value into SVGAngle.
+func SVGAngleFromWrapper(input core.Wrapper) *SVGAngle {
+	return SVGAngleFromJS(input.JSValue())
 }
 
 const (
@@ -580,15 +587,19 @@ func (_this *SVGAnimatedAngle) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedAngleFromJS is casting a js.Wrapper into SVGAnimatedAngle.
-func SVGAnimatedAngleFromJS(value js.Wrapper) *SVGAnimatedAngle {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedAngleFromJS is casting a js.Value into SVGAnimatedAngle.
+func SVGAnimatedAngleFromJS(value js.Value) *SVGAnimatedAngle {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedAngle{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedAngleFromJS is casting from something that holds a js.Value into SVGAnimatedAngle.
+func SVGAnimatedAngleFromWrapper(input core.Wrapper) *SVGAnimatedAngle {
+	return SVGAnimatedAngleFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -619,15 +630,19 @@ func (_this *SVGAnimatedBoolean) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedBooleanFromJS is casting a js.Wrapper into SVGAnimatedBoolean.
-func SVGAnimatedBooleanFromJS(value js.Wrapper) *SVGAnimatedBoolean {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedBooleanFromJS is casting a js.Value into SVGAnimatedBoolean.
+func SVGAnimatedBooleanFromJS(value js.Value) *SVGAnimatedBoolean {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedBoolean{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedBooleanFromJS is casting from something that holds a js.Value into SVGAnimatedBoolean.
+func SVGAnimatedBooleanFromWrapper(input core.Wrapper) *SVGAnimatedBoolean {
+	return SVGAnimatedBooleanFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -665,15 +680,19 @@ func (_this *SVGAnimatedEnumeration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedEnumerationFromJS is casting a js.Wrapper into SVGAnimatedEnumeration.
-func SVGAnimatedEnumerationFromJS(value js.Wrapper) *SVGAnimatedEnumeration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedEnumerationFromJS is casting a js.Value into SVGAnimatedEnumeration.
+func SVGAnimatedEnumerationFromJS(value js.Value) *SVGAnimatedEnumeration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedEnumeration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedEnumerationFromJS is casting from something that holds a js.Value into SVGAnimatedEnumeration.
+func SVGAnimatedEnumerationFromWrapper(input core.Wrapper) *SVGAnimatedEnumeration {
+	return SVGAnimatedEnumerationFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -711,15 +730,19 @@ func (_this *SVGAnimatedInteger) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedIntegerFromJS is casting a js.Wrapper into SVGAnimatedInteger.
-func SVGAnimatedIntegerFromJS(value js.Wrapper) *SVGAnimatedInteger {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedIntegerFromJS is casting a js.Value into SVGAnimatedInteger.
+func SVGAnimatedIntegerFromJS(value js.Value) *SVGAnimatedInteger {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedInteger{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedIntegerFromJS is casting from something that holds a js.Value into SVGAnimatedInteger.
+func SVGAnimatedIntegerFromWrapper(input core.Wrapper) *SVGAnimatedInteger {
+	return SVGAnimatedIntegerFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -757,15 +780,19 @@ func (_this *SVGAnimatedLength) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedLengthFromJS is casting a js.Wrapper into SVGAnimatedLength.
-func SVGAnimatedLengthFromJS(value js.Wrapper) *SVGAnimatedLength {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedLengthFromJS is casting a js.Value into SVGAnimatedLength.
+func SVGAnimatedLengthFromJS(value js.Value) *SVGAnimatedLength {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedLength{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedLengthFromJS is casting from something that holds a js.Value into SVGAnimatedLength.
+func SVGAnimatedLengthFromWrapper(input core.Wrapper) *SVGAnimatedLength {
+	return SVGAnimatedLengthFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -796,15 +823,19 @@ func (_this *SVGAnimatedLengthList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedLengthListFromJS is casting a js.Wrapper into SVGAnimatedLengthList.
-func SVGAnimatedLengthListFromJS(value js.Wrapper) *SVGAnimatedLengthList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedLengthListFromJS is casting a js.Value into SVGAnimatedLengthList.
+func SVGAnimatedLengthListFromJS(value js.Value) *SVGAnimatedLengthList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedLengthList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedLengthListFromJS is casting from something that holds a js.Value into SVGAnimatedLengthList.
+func SVGAnimatedLengthListFromWrapper(input core.Wrapper) *SVGAnimatedLengthList {
+	return SVGAnimatedLengthListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -835,15 +866,19 @@ func (_this *SVGAnimatedNumber) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedNumberFromJS is casting a js.Wrapper into SVGAnimatedNumber.
-func SVGAnimatedNumberFromJS(value js.Wrapper) *SVGAnimatedNumber {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedNumberFromJS is casting a js.Value into SVGAnimatedNumber.
+func SVGAnimatedNumberFromJS(value js.Value) *SVGAnimatedNumber {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedNumber{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedNumberFromJS is casting from something that holds a js.Value into SVGAnimatedNumber.
+func SVGAnimatedNumberFromWrapper(input core.Wrapper) *SVGAnimatedNumber {
+	return SVGAnimatedNumberFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -881,15 +916,19 @@ func (_this *SVGAnimatedNumberList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedNumberListFromJS is casting a js.Wrapper into SVGAnimatedNumberList.
-func SVGAnimatedNumberListFromJS(value js.Wrapper) *SVGAnimatedNumberList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedNumberListFromJS is casting a js.Value into SVGAnimatedNumberList.
+func SVGAnimatedNumberListFromJS(value js.Value) *SVGAnimatedNumberList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedNumberList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedNumberListFromJS is casting from something that holds a js.Value into SVGAnimatedNumberList.
+func SVGAnimatedNumberListFromWrapper(input core.Wrapper) *SVGAnimatedNumberList {
+	return SVGAnimatedNumberListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -920,15 +959,19 @@ func (_this *SVGAnimatedPreserveAspectRatio) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedPreserveAspectRatioFromJS is casting a js.Wrapper into SVGAnimatedPreserveAspectRatio.
-func SVGAnimatedPreserveAspectRatioFromJS(value js.Wrapper) *SVGAnimatedPreserveAspectRatio {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedPreserveAspectRatioFromJS is casting a js.Value into SVGAnimatedPreserveAspectRatio.
+func SVGAnimatedPreserveAspectRatioFromJS(value js.Value) *SVGAnimatedPreserveAspectRatio {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedPreserveAspectRatio{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedPreserveAspectRatioFromJS is casting from something that holds a js.Value into SVGAnimatedPreserveAspectRatio.
+func SVGAnimatedPreserveAspectRatioFromWrapper(input core.Wrapper) *SVGAnimatedPreserveAspectRatio {
+	return SVGAnimatedPreserveAspectRatioFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -959,15 +1002,19 @@ func (_this *SVGAnimatedRect) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedRectFromJS is casting a js.Wrapper into SVGAnimatedRect.
-func SVGAnimatedRectFromJS(value js.Wrapper) *SVGAnimatedRect {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedRectFromJS is casting a js.Value into SVGAnimatedRect.
+func SVGAnimatedRectFromJS(value js.Value) *SVGAnimatedRect {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedRect{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedRectFromJS is casting from something that holds a js.Value into SVGAnimatedRect.
+func SVGAnimatedRectFromWrapper(input core.Wrapper) *SVGAnimatedRect {
+	return SVGAnimatedRectFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -998,15 +1045,19 @@ func (_this *SVGAnimatedString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedStringFromJS is casting a js.Wrapper into SVGAnimatedString.
-func SVGAnimatedStringFromJS(value js.Wrapper) *SVGAnimatedString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedStringFromJS is casting a js.Value into SVGAnimatedString.
+func SVGAnimatedStringFromJS(value js.Value) *SVGAnimatedString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedStringFromJS is casting from something that holds a js.Value into SVGAnimatedString.
+func SVGAnimatedStringFromWrapper(input core.Wrapper) *SVGAnimatedString {
+	return SVGAnimatedStringFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -1044,15 +1095,19 @@ func (_this *SVGAnimatedTransformList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGAnimatedTransformListFromJS is casting a js.Wrapper into SVGAnimatedTransformList.
-func SVGAnimatedTransformListFromJS(value js.Wrapper) *SVGAnimatedTransformList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGAnimatedTransformListFromJS is casting a js.Value into SVGAnimatedTransformList.
+func SVGAnimatedTransformListFromJS(value js.Value) *SVGAnimatedTransformList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGAnimatedTransformList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGAnimatedTransformListFromJS is casting from something that holds a js.Value into SVGAnimatedTransformList.
+func SVGAnimatedTransformListFromWrapper(input core.Wrapper) *SVGAnimatedTransformList {
+	return SVGAnimatedTransformListFromJS(input.JSValue())
 }
 
 // BaseVal returning attribute 'baseVal' with
@@ -1078,15 +1133,19 @@ type SVGCircleElement struct {
 	SVGGeometryElement
 }
 
-// SVGCircleElementFromJS is casting a js.Wrapper into SVGCircleElement.
-func SVGCircleElementFromJS(value js.Wrapper) *SVGCircleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGCircleElementFromJS is casting a js.Value into SVGCircleElement.
+func SVGCircleElementFromJS(value js.Value) *SVGCircleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGCircleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGCircleElementFromJS is casting from something that holds a js.Value into SVGCircleElement.
+func SVGCircleElementFromWrapper(input core.Wrapper) *SVGCircleElement {
+	return SVGCircleElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -1121,15 +1180,19 @@ type SVGDefsElement struct {
 	SVGGraphicsElement
 }
 
-// SVGDefsElementFromJS is casting a js.Wrapper into SVGDefsElement.
-func SVGDefsElementFromJS(value js.Wrapper) *SVGDefsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGDefsElementFromJS is casting a js.Value into SVGDefsElement.
+func SVGDefsElementFromJS(value js.Value) *SVGDefsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGDefsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGDefsElementFromJS is casting from something that holds a js.Value into SVGDefsElement.
+func SVGDefsElementFromWrapper(input core.Wrapper) *SVGDefsElement {
+	return SVGDefsElementFromJS(input.JSValue())
 }
 
 // class: SVGDescElement
@@ -1137,15 +1200,19 @@ type SVGDescElement struct {
 	SVGElement
 }
 
-// SVGDescElementFromJS is casting a js.Wrapper into SVGDescElement.
-func SVGDescElementFromJS(value js.Wrapper) *SVGDescElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGDescElementFromJS is casting a js.Value into SVGDescElement.
+func SVGDescElementFromJS(value js.Value) *SVGDescElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGDescElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGDescElementFromJS is casting from something that holds a js.Value into SVGDescElement.
+func SVGDescElementFromWrapper(input core.Wrapper) *SVGDescElement {
+	return SVGDescElementFromJS(input.JSValue())
 }
 
 // class: SVGElement
@@ -1153,15 +1220,19 @@ type SVGElement struct {
 	dom.Element
 }
 
-// SVGElementFromJS is casting a js.Wrapper into SVGElement.
-func SVGElementFromJS(value js.Wrapper) *SVGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGElementFromJS is casting a js.Value into SVGElement.
+func SVGElementFromJS(value js.Value) *SVGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGElementFromJS is casting from something that holds a js.Value into SVGElement.
+func SVGElementFromWrapper(input core.Wrapper) *SVGElement {
+	return SVGElementFromJS(input.JSValue())
 }
 
 // ClassName returning attribute 'className' with
@@ -3958,15 +4029,19 @@ type SVGEllipseElement struct {
 	SVGGeometryElement
 }
 
-// SVGEllipseElementFromJS is casting a js.Wrapper into SVGEllipseElement.
-func SVGEllipseElementFromJS(value js.Wrapper) *SVGEllipseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGEllipseElementFromJS is casting a js.Value into SVGEllipseElement.
+func SVGEllipseElementFromJS(value js.Value) *SVGEllipseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGEllipseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGEllipseElementFromJS is casting from something that holds a js.Value into SVGEllipseElement.
+func SVGEllipseElementFromWrapper(input core.Wrapper) *SVGEllipseElement {
+	return SVGEllipseElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -4010,15 +4085,19 @@ type SVGForeignObjectElement struct {
 	SVGGraphicsElement
 }
 
-// SVGForeignObjectElementFromJS is casting a js.Wrapper into SVGForeignObjectElement.
-func SVGForeignObjectElementFromJS(value js.Wrapper) *SVGForeignObjectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGForeignObjectElementFromJS is casting a js.Value into SVGForeignObjectElement.
+func SVGForeignObjectElementFromJS(value js.Value) *SVGForeignObjectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGForeignObjectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGForeignObjectElementFromJS is casting from something that holds a js.Value into SVGForeignObjectElement.
+func SVGForeignObjectElementFromWrapper(input core.Wrapper) *SVGForeignObjectElement {
+	return SVGForeignObjectElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -4062,15 +4141,19 @@ type SVGGElement struct {
 	SVGGraphicsElement
 }
 
-// SVGGElementFromJS is casting a js.Wrapper into SVGGElement.
-func SVGGElementFromJS(value js.Wrapper) *SVGGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGElementFromJS is casting a js.Value into SVGGElement.
+func SVGGElementFromJS(value js.Value) *SVGGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGElementFromJS is casting from something that holds a js.Value into SVGGElement.
+func SVGGElementFromWrapper(input core.Wrapper) *SVGGElement {
+	return SVGGElementFromJS(input.JSValue())
 }
 
 // class: SVGGeometryElement
@@ -4078,15 +4161,19 @@ type SVGGeometryElement struct {
 	SVGGraphicsElement
 }
 
-// SVGGeometryElementFromJS is casting a js.Wrapper into SVGGeometryElement.
-func SVGGeometryElementFromJS(value js.Wrapper) *SVGGeometryElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGeometryElementFromJS is casting a js.Value into SVGGeometryElement.
+func SVGGeometryElementFromJS(value js.Value) *SVGGeometryElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGeometryElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGeometryElementFromJS is casting from something that holds a js.Value into SVGGeometryElement.
+func SVGGeometryElementFromWrapper(input core.Wrapper) *SVGGeometryElement {
+	return SVGGeometryElementFromJS(input.JSValue())
 }
 
 // PathLength returning attribute 'pathLength' with
@@ -4172,15 +4259,19 @@ type SVGGradientElement struct {
 	SVGElement
 }
 
-// SVGGradientElementFromJS is casting a js.Wrapper into SVGGradientElement.
-func SVGGradientElementFromJS(value js.Wrapper) *SVGGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGradientElementFromJS is casting a js.Value into SVGGradientElement.
+func SVGGradientElementFromJS(value js.Value) *SVGGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGradientElementFromJS is casting from something that holds a js.Value into SVGGradientElement.
+func SVGGradientElementFromWrapper(input core.Wrapper) *SVGGradientElement {
+	return SVGGradientElementFromJS(input.JSValue())
 }
 
 const (
@@ -4231,15 +4322,19 @@ type SVGGraphicsElement struct {
 	SVGElement
 }
 
-// SVGGraphicsElementFromJS is casting a js.Wrapper into SVGGraphicsElement.
-func SVGGraphicsElementFromJS(value js.Wrapper) *SVGGraphicsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGGraphicsElementFromJS is casting a js.Value into SVGGraphicsElement.
+func SVGGraphicsElementFromJS(value js.Value) *SVGGraphicsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGGraphicsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGGraphicsElementFromJS is casting from something that holds a js.Value into SVGGraphicsElement.
+func SVGGraphicsElementFromWrapper(input core.Wrapper) *SVGGraphicsElement {
+	return SVGGraphicsElementFromJS(input.JSValue())
 }
 
 // Transform returning attribute 'transform' with
@@ -4325,15 +4420,19 @@ type SVGImageElement struct {
 	SVGGraphicsElement
 }
 
-// SVGImageElementFromJS is casting a js.Wrapper into SVGImageElement.
-func SVGImageElementFromJS(value js.Wrapper) *SVGImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGImageElementFromJS is casting a js.Value into SVGImageElement.
+func SVGImageElementFromJS(value js.Value) *SVGImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGImageElementFromJS is casting from something that holds a js.Value into SVGImageElement.
+func SVGImageElementFromWrapper(input core.Wrapper) *SVGImageElement {
+	return SVGImageElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -4424,15 +4523,19 @@ func (_this *SVGLength) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGLengthFromJS is casting a js.Wrapper into SVGLength.
-func SVGLengthFromJS(value js.Wrapper) *SVGLength {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLengthFromJS is casting a js.Value into SVGLength.
+func SVGLengthFromJS(value js.Value) *SVGLength {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLength{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLengthFromJS is casting from something that holds a js.Value into SVGLength.
+func SVGLengthFromWrapper(input core.Wrapper) *SVGLength {
+	return SVGLengthFromJS(input.JSValue())
 }
 
 const (
@@ -4543,15 +4646,19 @@ func (_this *SVGLengthList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGLengthListFromJS is casting a js.Wrapper into SVGLengthList.
-func SVGLengthListFromJS(value js.Wrapper) *SVGLengthList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLengthListFromJS is casting a js.Value into SVGLengthList.
+func SVGLengthListFromJS(value js.Value) *SVGLengthList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLengthList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLengthListFromJS is casting from something that holds a js.Value into SVGLengthList.
+func SVGLengthListFromWrapper(input core.Wrapper) *SVGLengthList {
+	return SVGLengthListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -4726,15 +4833,19 @@ type SVGLineElement struct {
 	SVGGeometryElement
 }
 
-// SVGLineElementFromJS is casting a js.Wrapper into SVGLineElement.
-func SVGLineElementFromJS(value js.Wrapper) *SVGLineElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLineElementFromJS is casting a js.Value into SVGLineElement.
+func SVGLineElementFromJS(value js.Value) *SVGLineElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLineElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLineElementFromJS is casting from something that holds a js.Value into SVGLineElement.
+func SVGLineElementFromWrapper(input core.Wrapper) *SVGLineElement {
+	return SVGLineElementFromJS(input.JSValue())
 }
 
 // X1 returning attribute 'x1' with
@@ -4778,15 +4889,19 @@ type SVGLinearGradientElement struct {
 	SVGGradientElement
 }
 
-// SVGLinearGradientElementFromJS is casting a js.Wrapper into SVGLinearGradientElement.
-func SVGLinearGradientElementFromJS(value js.Wrapper) *SVGLinearGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGLinearGradientElementFromJS is casting a js.Value into SVGLinearGradientElement.
+func SVGLinearGradientElementFromJS(value js.Value) *SVGLinearGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGLinearGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGLinearGradientElementFromJS is casting from something that holds a js.Value into SVGLinearGradientElement.
+func SVGLinearGradientElementFromWrapper(input core.Wrapper) *SVGLinearGradientElement {
+	return SVGLinearGradientElementFromJS(input.JSValue())
 }
 
 // X1 returning attribute 'x1' with
@@ -4830,15 +4945,19 @@ type SVGMarkerElement struct {
 	SVGElement
 }
 
-// SVGMarkerElementFromJS is casting a js.Wrapper into SVGMarkerElement.
-func SVGMarkerElementFromJS(value js.Wrapper) *SVGMarkerElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMarkerElementFromJS is casting a js.Value into SVGMarkerElement.
+func SVGMarkerElementFromJS(value js.Value) *SVGMarkerElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMarkerElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMarkerElementFromJS is casting from something that holds a js.Value into SVGMarkerElement.
+func SVGMarkerElementFromWrapper(input core.Wrapper) *SVGMarkerElement {
+	return SVGMarkerElementFromJS(input.JSValue())
 }
 
 const (
@@ -4973,15 +5092,19 @@ type SVGMetadataElement struct {
 	SVGElement
 }
 
-// SVGMetadataElementFromJS is casting a js.Wrapper into SVGMetadataElement.
-func SVGMetadataElementFromJS(value js.Wrapper) *SVGMetadataElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGMetadataElementFromJS is casting a js.Value into SVGMetadataElement.
+func SVGMetadataElementFromJS(value js.Value) *SVGMetadataElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGMetadataElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGMetadataElementFromJS is casting from something that holds a js.Value into SVGMetadataElement.
+func SVGMetadataElementFromWrapper(input core.Wrapper) *SVGMetadataElement {
+	return SVGMetadataElementFromJS(input.JSValue())
 }
 
 // class: SVGNumber
@@ -4994,15 +5117,19 @@ func (_this *SVGNumber) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGNumberFromJS is casting a js.Wrapper into SVGNumber.
-func SVGNumberFromJS(value js.Wrapper) *SVGNumber {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGNumberFromJS is casting a js.Value into SVGNumber.
+func SVGNumberFromJS(value js.Value) *SVGNumber {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGNumber{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGNumberFromJS is casting from something that holds a js.Value into SVGNumber.
+func SVGNumberFromWrapper(input core.Wrapper) *SVGNumber {
+	return SVGNumberFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -5031,15 +5158,19 @@ func (_this *SVGNumberList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGNumberListFromJS is casting a js.Wrapper into SVGNumberList.
-func SVGNumberListFromJS(value js.Wrapper) *SVGNumberList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGNumberListFromJS is casting a js.Value into SVGNumberList.
+func SVGNumberListFromJS(value js.Value) *SVGNumberList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGNumberList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGNumberListFromJS is casting from something that holds a js.Value into SVGNumberList.
+func SVGNumberListFromWrapper(input core.Wrapper) *SVGNumberList {
+	return SVGNumberListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5214,15 +5345,19 @@ type SVGPathElement struct {
 	SVGGeometryElement
 }
 
-// SVGPathElementFromJS is casting a js.Wrapper into SVGPathElement.
-func SVGPathElementFromJS(value js.Wrapper) *SVGPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPathElementFromJS is casting a js.Value into SVGPathElement.
+func SVGPathElementFromJS(value js.Value) *SVGPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPathElementFromJS is casting from something that holds a js.Value into SVGPathElement.
+func SVGPathElementFromWrapper(input core.Wrapper) *SVGPathElement {
+	return SVGPathElementFromJS(input.JSValue())
 }
 
 // class: SVGPatternElement
@@ -5230,15 +5365,19 @@ type SVGPatternElement struct {
 	SVGElement
 }
 
-// SVGPatternElementFromJS is casting a js.Wrapper into SVGPatternElement.
-func SVGPatternElementFromJS(value js.Wrapper) *SVGPatternElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPatternElementFromJS is casting a js.Value into SVGPatternElement.
+func SVGPatternElementFromJS(value js.Value) *SVGPatternElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPatternElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPatternElementFromJS is casting from something that holds a js.Value into SVGPatternElement.
+func SVGPatternElementFromWrapper(input core.Wrapper) *SVGPatternElement {
+	return SVGPatternElementFromJS(input.JSValue())
 }
 
 // PatternUnits returning attribute 'patternUnits' with
@@ -5341,15 +5480,19 @@ func (_this *SVGPointList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGPointListFromJS is casting a js.Wrapper into SVGPointList.
-func SVGPointListFromJS(value js.Wrapper) *SVGPointList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPointListFromJS is casting a js.Value into SVGPointList.
+func SVGPointListFromJS(value js.Value) *SVGPointList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPointList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPointListFromJS is casting from something that holds a js.Value into SVGPointList.
+func SVGPointListFromWrapper(input core.Wrapper) *SVGPointList {
+	return SVGPointListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -5524,15 +5667,19 @@ type SVGPolygonElement struct {
 	SVGGeometryElement
 }
 
-// SVGPolygonElementFromJS is casting a js.Wrapper into SVGPolygonElement.
-func SVGPolygonElementFromJS(value js.Wrapper) *SVGPolygonElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPolygonElementFromJS is casting a js.Value into SVGPolygonElement.
+func SVGPolygonElementFromJS(value js.Value) *SVGPolygonElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPolygonElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPolygonElementFromJS is casting from something that holds a js.Value into SVGPolygonElement.
+func SVGPolygonElementFromWrapper(input core.Wrapper) *SVGPolygonElement {
+	return SVGPolygonElementFromJS(input.JSValue())
 }
 
 // Points returning attribute 'points' with
@@ -5558,15 +5705,19 @@ type SVGPolylineElement struct {
 	SVGGeometryElement
 }
 
-// SVGPolylineElementFromJS is casting a js.Wrapper into SVGPolylineElement.
-func SVGPolylineElementFromJS(value js.Wrapper) *SVGPolylineElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPolylineElementFromJS is casting a js.Value into SVGPolylineElement.
+func SVGPolylineElementFromJS(value js.Value) *SVGPolylineElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPolylineElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPolylineElementFromJS is casting from something that holds a js.Value into SVGPolylineElement.
+func SVGPolylineElementFromWrapper(input core.Wrapper) *SVGPolylineElement {
+	return SVGPolylineElementFromJS(input.JSValue())
 }
 
 // Points returning attribute 'points' with
@@ -5597,15 +5748,19 @@ func (_this *SVGPreserveAspectRatio) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGPreserveAspectRatioFromJS is casting a js.Wrapper into SVGPreserveAspectRatio.
-func SVGPreserveAspectRatioFromJS(value js.Wrapper) *SVGPreserveAspectRatio {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGPreserveAspectRatioFromJS is casting a js.Value into SVGPreserveAspectRatio.
+func SVGPreserveAspectRatioFromJS(value js.Value) *SVGPreserveAspectRatio {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGPreserveAspectRatio{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGPreserveAspectRatioFromJS is casting from something that holds a js.Value into SVGPreserveAspectRatio.
+func SVGPreserveAspectRatioFromWrapper(input core.Wrapper) *SVGPreserveAspectRatio {
+	return SVGPreserveAspectRatioFromJS(input.JSValue())
 }
 
 const (
@@ -5662,15 +5817,19 @@ type SVGRadialGradientElement struct {
 	SVGGradientElement
 }
 
-// SVGRadialGradientElementFromJS is casting a js.Wrapper into SVGRadialGradientElement.
-func SVGRadialGradientElementFromJS(value js.Wrapper) *SVGRadialGradientElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGRadialGradientElementFromJS is casting a js.Value into SVGRadialGradientElement.
+func SVGRadialGradientElementFromJS(value js.Value) *SVGRadialGradientElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGRadialGradientElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGRadialGradientElementFromJS is casting from something that holds a js.Value into SVGRadialGradientElement.
+func SVGRadialGradientElementFromWrapper(input core.Wrapper) *SVGRadialGradientElement {
+	return SVGRadialGradientElementFromJS(input.JSValue())
 }
 
 // Cx returning attribute 'cx' with
@@ -5732,15 +5891,19 @@ type SVGRectElement struct {
 	SVGGeometryElement
 }
 
-// SVGRectElementFromJS is casting a js.Wrapper into SVGRectElement.
-func SVGRectElementFromJS(value js.Wrapper) *SVGRectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGRectElementFromJS is casting a js.Value into SVGRectElement.
+func SVGRectElementFromJS(value js.Value) *SVGRectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGRectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGRectElementFromJS is casting from something that holds a js.Value into SVGRectElement.
+func SVGRectElementFromWrapper(input core.Wrapper) *SVGRectElement {
+	return SVGRectElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -5802,15 +5965,19 @@ type SVGSVGElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSVGElementFromJS is casting a js.Wrapper into SVGSVGElement.
-func SVGSVGElementFromJS(value js.Wrapper) *SVGSVGElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSVGElementFromJS is casting a js.Value into SVGSVGElement.
+func SVGSVGElementFromJS(value js.Value) *SVGSVGElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSVGElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSVGElementFromJS is casting from something that holds a js.Value into SVGSVGElement.
+func SVGSVGElementFromWrapper(input core.Wrapper) *SVGSVGElement {
+	return SVGSVGElementFromJS(input.JSValue())
 }
 
 const (
@@ -6733,15 +6900,19 @@ type SVGScriptElement struct {
 	SVGElement
 }
 
-// SVGScriptElementFromJS is casting a js.Wrapper into SVGScriptElement.
-func SVGScriptElementFromJS(value js.Wrapper) *SVGScriptElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGScriptElementFromJS is casting a js.Value into SVGScriptElement.
+func SVGScriptElementFromJS(value js.Value) *SVGScriptElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGScriptElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGScriptElementFromJS is casting from something that holds a js.Value into SVGScriptElement.
+func SVGScriptElementFromWrapper(input core.Wrapper) *SVGScriptElement {
+	return SVGScriptElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -6798,15 +6969,19 @@ type SVGStopElement struct {
 	SVGElement
 }
 
-// SVGStopElementFromJS is casting a js.Wrapper into SVGStopElement.
-func SVGStopElementFromJS(value js.Wrapper) *SVGStopElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStopElementFromJS is casting a js.Value into SVGStopElement.
+func SVGStopElementFromJS(value js.Value) *SVGStopElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStopElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStopElementFromJS is casting from something that holds a js.Value into SVGStopElement.
+func SVGStopElementFromWrapper(input core.Wrapper) *SVGStopElement {
+	return SVGStopElementFromJS(input.JSValue())
 }
 
 // Offset returning attribute 'offset' with
@@ -6828,15 +7003,19 @@ func (_this *SVGStringList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGStringListFromJS is casting a js.Wrapper into SVGStringList.
-func SVGStringListFromJS(value js.Wrapper) *SVGStringList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStringListFromJS is casting a js.Value into SVGStringList.
+func SVGStringListFromJS(value js.Value) *SVGStringList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStringList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStringListFromJS is casting from something that holds a js.Value into SVGStringList.
+func SVGStringListFromWrapper(input core.Wrapper) *SVGStringList {
+	return SVGStringListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -7011,15 +7190,19 @@ type SVGStyleElement struct {
 	SVGElement
 }
 
-// SVGStyleElementFromJS is casting a js.Wrapper into SVGStyleElement.
-func SVGStyleElementFromJS(value js.Wrapper) *SVGStyleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGStyleElementFromJS is casting a js.Value into SVGStyleElement.
+func SVGStyleElementFromJS(value js.Value) *SVGStyleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGStyleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGStyleElementFromJS is casting from something that holds a js.Value into SVGStyleElement.
+func SVGStyleElementFromWrapper(input core.Wrapper) *SVGStyleElement {
+	return SVGStyleElementFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -7086,15 +7269,19 @@ type SVGSwitchElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSwitchElementFromJS is casting a js.Wrapper into SVGSwitchElement.
-func SVGSwitchElementFromJS(value js.Wrapper) *SVGSwitchElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSwitchElementFromJS is casting a js.Value into SVGSwitchElement.
+func SVGSwitchElementFromJS(value js.Value) *SVGSwitchElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSwitchElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSwitchElementFromJS is casting from something that holds a js.Value into SVGSwitchElement.
+func SVGSwitchElementFromWrapper(input core.Wrapper) *SVGSwitchElement {
+	return SVGSwitchElementFromJS(input.JSValue())
 }
 
 // class: SVGSymbolElement
@@ -7102,15 +7289,19 @@ type SVGSymbolElement struct {
 	SVGGraphicsElement
 }
 
-// SVGSymbolElementFromJS is casting a js.Wrapper into SVGSymbolElement.
-func SVGSymbolElementFromJS(value js.Wrapper) *SVGSymbolElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGSymbolElementFromJS is casting a js.Value into SVGSymbolElement.
+func SVGSymbolElementFromJS(value js.Value) *SVGSymbolElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGSymbolElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGSymbolElementFromJS is casting from something that holds a js.Value into SVGSymbolElement.
+func SVGSymbolElementFromWrapper(input core.Wrapper) *SVGSymbolElement {
+	return SVGSymbolElementFromJS(input.JSValue())
 }
 
 // ViewBox returning attribute 'viewBox' with
@@ -7136,15 +7327,19 @@ type SVGTSpanElement struct {
 	SVGTextPositioningElement
 }
 
-// SVGTSpanElementFromJS is casting a js.Wrapper into SVGTSpanElement.
-func SVGTSpanElementFromJS(value js.Wrapper) *SVGTSpanElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTSpanElementFromJS is casting a js.Value into SVGTSpanElement.
+func SVGTSpanElementFromJS(value js.Value) *SVGTSpanElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTSpanElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTSpanElementFromJS is casting from something that holds a js.Value into SVGTSpanElement.
+func SVGTSpanElementFromWrapper(input core.Wrapper) *SVGTSpanElement {
+	return SVGTSpanElementFromJS(input.JSValue())
 }
 
 // class: SVGTextContentElement
@@ -7152,15 +7347,19 @@ type SVGTextContentElement struct {
 	SVGGraphicsElement
 }
 
-// SVGTextContentElementFromJS is casting a js.Wrapper into SVGTextContentElement.
-func SVGTextContentElementFromJS(value js.Wrapper) *SVGTextContentElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextContentElementFromJS is casting a js.Value into SVGTextContentElement.
+func SVGTextContentElementFromJS(value js.Value) *SVGTextContentElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextContentElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextContentElementFromJS is casting from something that holds a js.Value into SVGTextContentElement.
+func SVGTextContentElementFromWrapper(input core.Wrapper) *SVGTextContentElement {
+	return SVGTextContentElementFromJS(input.JSValue())
 }
 
 const (
@@ -7342,15 +7541,19 @@ type SVGTextElement struct {
 	SVGTextPositioningElement
 }
 
-// SVGTextElementFromJS is casting a js.Wrapper into SVGTextElement.
-func SVGTextElementFromJS(value js.Wrapper) *SVGTextElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextElementFromJS is casting a js.Value into SVGTextElement.
+func SVGTextElementFromJS(value js.Value) *SVGTextElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextElementFromJS is casting from something that holds a js.Value into SVGTextElement.
+func SVGTextElementFromWrapper(input core.Wrapper) *SVGTextElement {
+	return SVGTextElementFromJS(input.JSValue())
 }
 
 // class: SVGTextPathElement
@@ -7358,15 +7561,19 @@ type SVGTextPathElement struct {
 	SVGTextContentElement
 }
 
-// SVGTextPathElementFromJS is casting a js.Wrapper into SVGTextPathElement.
-func SVGTextPathElementFromJS(value js.Wrapper) *SVGTextPathElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextPathElementFromJS is casting a js.Value into SVGTextPathElement.
+func SVGTextPathElementFromJS(value js.Value) *SVGTextPathElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextPathElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextPathElementFromJS is casting from something that holds a js.Value into SVGTextPathElement.
+func SVGTextPathElementFromWrapper(input core.Wrapper) *SVGTextPathElement {
+	return SVGTextPathElementFromJS(input.JSValue())
 }
 
 const (
@@ -7419,15 +7626,19 @@ type SVGTextPositioningElement struct {
 	SVGTextContentElement
 }
 
-// SVGTextPositioningElementFromJS is casting a js.Wrapper into SVGTextPositioningElement.
-func SVGTextPositioningElementFromJS(value js.Wrapper) *SVGTextPositioningElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTextPositioningElementFromJS is casting a js.Value into SVGTextPositioningElement.
+func SVGTextPositioningElementFromJS(value js.Value) *SVGTextPositioningElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTextPositioningElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTextPositioningElementFromJS is casting from something that holds a js.Value into SVGTextPositioningElement.
+func SVGTextPositioningElementFromWrapper(input core.Wrapper) *SVGTextPositioningElement {
+	return SVGTextPositioningElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -7480,15 +7691,19 @@ type SVGTitleElement struct {
 	SVGElement
 }
 
-// SVGTitleElementFromJS is casting a js.Wrapper into SVGTitleElement.
-func SVGTitleElementFromJS(value js.Wrapper) *SVGTitleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTitleElementFromJS is casting a js.Value into SVGTitleElement.
+func SVGTitleElementFromJS(value js.Value) *SVGTitleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTitleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTitleElementFromJS is casting from something that holds a js.Value into SVGTitleElement.
+func SVGTitleElementFromWrapper(input core.Wrapper) *SVGTitleElement {
+	return SVGTitleElementFromJS(input.JSValue())
 }
 
 // class: SVGTransform
@@ -7501,15 +7716,19 @@ func (_this *SVGTransform) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGTransformFromJS is casting a js.Wrapper into SVGTransform.
-func SVGTransformFromJS(value js.Wrapper) *SVGTransform {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTransformFromJS is casting a js.Value into SVGTransform.
+func SVGTransformFromJS(value js.Value) *SVGTransform {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTransform{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTransformFromJS is casting from something that holds a js.Value into SVGTransform.
+func SVGTransformFromWrapper(input core.Wrapper) *SVGTransform {
+	return SVGTransformFromJS(input.JSValue())
 }
 
 const (
@@ -7645,15 +7864,19 @@ func (_this *SVGTransformList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGTransformListFromJS is casting a js.Wrapper into SVGTransformList.
-func SVGTransformListFromJS(value js.Wrapper) *SVGTransformList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGTransformListFromJS is casting a js.Value into SVGTransformList.
+func SVGTransformListFromJS(value js.Value) *SVGTransformList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGTransformList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGTransformListFromJS is casting from something that holds a js.Value into SVGTransformList.
+func SVGTransformListFromWrapper(input core.Wrapper) *SVGTransformList {
+	return SVGTransformListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -7868,15 +8091,19 @@ func (_this *SVGUnitTypes) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SVGUnitTypesFromJS is casting a js.Wrapper into SVGUnitTypes.
-func SVGUnitTypesFromJS(value js.Wrapper) *SVGUnitTypes {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUnitTypesFromJS is casting a js.Value into SVGUnitTypes.
+func SVGUnitTypesFromJS(value js.Value) *SVGUnitTypes {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUnitTypes{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUnitTypesFromJS is casting from something that holds a js.Value into SVGUnitTypes.
+func SVGUnitTypesFromWrapper(input core.Wrapper) *SVGUnitTypes {
+	return SVGUnitTypesFromJS(input.JSValue())
 }
 
 const (
@@ -7890,15 +8117,19 @@ type SVGUnknownElement struct {
 	SVGGraphicsElement
 }
 
-// SVGUnknownElementFromJS is casting a js.Wrapper into SVGUnknownElement.
-func SVGUnknownElementFromJS(value js.Wrapper) *SVGUnknownElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUnknownElementFromJS is casting a js.Value into SVGUnknownElement.
+func SVGUnknownElementFromJS(value js.Value) *SVGUnknownElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUnknownElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUnknownElementFromJS is casting from something that holds a js.Value into SVGUnknownElement.
+func SVGUnknownElementFromWrapper(input core.Wrapper) *SVGUnknownElement {
+	return SVGUnknownElementFromJS(input.JSValue())
 }
 
 // class: SVGUseElement
@@ -7906,15 +8137,19 @@ type SVGUseElement struct {
 	SVGGraphicsElement
 }
 
-// SVGUseElementFromJS is casting a js.Wrapper into SVGUseElement.
-func SVGUseElementFromJS(value js.Wrapper) *SVGUseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUseElementFromJS is casting a js.Value into SVGUseElement.
+func SVGUseElementFromJS(value js.Value) *SVGUseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUseElementFromJS is casting from something that holds a js.Value into SVGUseElement.
+func SVGUseElementFromWrapper(input core.Wrapper) *SVGUseElement {
+	return SVGUseElementFromJS(input.JSValue())
 }
 
 // X returning attribute 'x' with
@@ -7989,15 +8224,19 @@ type SVGUseElementShadowRoot struct {
 	dom.ShadowRoot
 }
 
-// SVGUseElementShadowRootFromJS is casting a js.Wrapper into SVGUseElementShadowRoot.
-func SVGUseElementShadowRootFromJS(value js.Wrapper) *SVGUseElementShadowRoot {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGUseElementShadowRootFromJS is casting a js.Value into SVGUseElementShadowRoot.
+func SVGUseElementShadowRootFromJS(value js.Value) *SVGUseElementShadowRoot {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGUseElementShadowRoot{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGUseElementShadowRootFromJS is casting from something that holds a js.Value into SVGUseElementShadowRoot.
+func SVGUseElementShadowRootFromWrapper(input core.Wrapper) *SVGUseElementShadowRoot {
+	return SVGUseElementShadowRootFromJS(input.JSValue())
 }
 
 // class: SVGViewElement
@@ -8005,15 +8244,19 @@ type SVGViewElement struct {
 	SVGElement
 }
 
-// SVGViewElementFromJS is casting a js.Wrapper into SVGViewElement.
-func SVGViewElementFromJS(value js.Wrapper) *SVGViewElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SVGViewElementFromJS is casting a js.Value into SVGViewElement.
+func SVGViewElementFromJS(value js.Value) *SVGViewElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SVGViewElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SVGViewElementFromJS is casting from something that holds a js.Value into SVGViewElement.
+func SVGViewElementFromWrapper(input core.Wrapper) *SVGViewElement {
+	return SVGViewElementFromJS(input.JSValue())
 }
 
 const (
@@ -8061,15 +8304,19 @@ type ShadowAnimation struct {
 	webani.Animation
 }
 
-// ShadowAnimationFromJS is casting a js.Wrapper into ShadowAnimation.
-func ShadowAnimationFromJS(value js.Wrapper) *ShadowAnimation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShadowAnimationFromJS is casting a js.Value into ShadowAnimation.
+func ShadowAnimationFromJS(value js.Value) *ShadowAnimation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShadowAnimation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShadowAnimationFromJS is casting from something that holds a js.Value into ShadowAnimation.
+func ShadowAnimationFromWrapper(input core.Wrapper) *ShadowAnimation {
+	return ShadowAnimationFromJS(input.JSValue())
 }
 
 // SourceAnimation returning attribute 'sourceAnimation' with

--- a/graphics/webgl/example_cube_test.go
+++ b/graphics/webgl/example_cube_test.go
@@ -32,13 +32,13 @@ func addCanvas() {
 	canvasE := webapi.GetWindow().Document().CreateElement("canvas", &webapi.Union{js.ValueOf("dom.Node")}) //TODO this seems wrong since we have to use js. for node
 	canvasE.SetId("canvas42")
 	app.AppendChild(&canvasE.Node)
-	canvasHTML := canvas.HTMLCanvasElementFromJS(canvasE)
+	canvasHTML := canvas.HTMLCanvasElementFromWrapper(canvasE)
 	canvasHTML.SetWidth(uint(width))
 	canvasHTML.SetHeight(uint(height))
 	//canvasHTML.RequestFullscreen(&dom.FullscreenOptions{})	//TODO find a way to do fullscreen request
 
 	contextU := canvasHTML.GetContext("webgl", nil)
-	gl := webgl.RenderingContextFromJS(contextU)
+	gl := webgl.RenderingContextFromWrapper(contextU)
 
 	vBuffer, iBuffer, icount := createBuffers(gl)
 

--- a/graphics/webgl/webgl.go
+++ b/graphics/webgl/webgl.go
@@ -7,6 +7,7 @@ package webgl
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -95,7 +96,7 @@ type ContextAttributes struct {
 	XrCompatible                 bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ContextAttributes) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -121,10 +122,8 @@ func (_this *ContextAttributes) JSValue() js.Value {
 }
 
 // ContextAttributesFromJS is allocating a new
-// ContextAttributes object and copy all values from
-// input javascript object
-func ContextAttributesFromJS(value js.Wrapper) *ContextAttributes {
-	input := value.JSValue()
+// ContextAttributes object and copy all values in the value javascript object.
+func ContextAttributesFromJS(value js.Value) *ContextAttributes {
 	var out ContextAttributes
 	var (
 		value0 bool            // javascript: boolean {alpha Alpha alpha}
@@ -137,23 +136,23 @@ func ContextAttributesFromJS(value js.Wrapper) *ContextAttributes {
 		value7 bool            // javascript: boolean {failIfMajorPerformanceCaveat FailIfMajorPerformanceCaveat failIfMajorPerformanceCaveat}
 		value8 bool            // javascript: boolean {xrCompatible XrCompatible xrCompatible}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
-	value1 = (input.Get("depth")).Bool()
+	value1 = (value.Get("depth")).Bool()
 	out.Depth = value1
-	value2 = (input.Get("stencil")).Bool()
+	value2 = (value.Get("stencil")).Bool()
 	out.Stencil = value2
-	value3 = (input.Get("antialias")).Bool()
+	value3 = (value.Get("antialias")).Bool()
 	out.Antialias = value3
-	value4 = (input.Get("premultipliedAlpha")).Bool()
+	value4 = (value.Get("premultipliedAlpha")).Bool()
 	out.PremultipliedAlpha = value4
-	value5 = (input.Get("preserveDrawingBuffer")).Bool()
+	value5 = (value.Get("preserveDrawingBuffer")).Bool()
 	out.PreserveDrawingBuffer = value5
-	value6 = PowerPreferenceFromJS(input.Get("powerPreference"))
+	value6 = PowerPreferenceFromJS(value.Get("powerPreference"))
 	out.PowerPreference = value6
-	value7 = (input.Get("failIfMajorPerformanceCaveat")).Bool()
+	value7 = (value.Get("failIfMajorPerformanceCaveat")).Bool()
 	out.FailIfMajorPerformanceCaveat = value7
-	value8 = (input.Get("xrCompatible")).Bool()
+	value8 = (value.Get("xrCompatible")).Bool()
 	out.XrCompatible = value8
 	return &out
 }
@@ -166,7 +165,7 @@ type ContextEventInit struct {
 	StatusMessage string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ContextEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -182,10 +181,8 @@ func (_this *ContextEventInit) JSValue() js.Value {
 }
 
 // ContextEventInitFromJS is allocating a new
-// ContextEventInit object and copy all values from
-// input javascript object
-func ContextEventInitFromJS(value js.Wrapper) *ContextEventInit {
-	input := value.JSValue()
+// ContextEventInit object and copy all values in the value javascript object.
+func ContextEventInitFromJS(value js.Value) *ContextEventInit {
 	var out ContextEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -193,13 +190,13 @@ func ContextEventInitFromJS(value js.Wrapper) *ContextEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 string // javascript: DOMString {statusMessage StatusMessage statusMessage}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("statusMessage")).String()
+	value3 = (value.Get("statusMessage")).String()
 	out.StatusMessage = value3
 	return &out
 }
@@ -214,15 +211,19 @@ func (_this *ActiveInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ActiveInfoFromJS is casting a js.Wrapper into ActiveInfo.
-func ActiveInfoFromJS(value js.Wrapper) *ActiveInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ActiveInfoFromJS is casting a js.Value into ActiveInfo.
+func ActiveInfoFromJS(value js.Value) *ActiveInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ActiveInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ActiveInfoFromJS is casting from something that holds a js.Value into ActiveInfo.
+func ActiveInfoFromWrapper(input core.Wrapper) *ActiveInfo {
+	return ActiveInfoFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -257,15 +258,19 @@ type Buffer struct {
 	Object
 }
 
-// BufferFromJS is casting a js.Wrapper into Buffer.
-func BufferFromJS(value js.Wrapper) *Buffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BufferFromJS is casting a js.Value into Buffer.
+func BufferFromJS(value js.Value) *Buffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Buffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BufferFromJS is casting from something that holds a js.Value into Buffer.
+func BufferFromWrapper(input core.Wrapper) *Buffer {
+	return BufferFromJS(input.JSValue())
 }
 
 // class: WebGLContextEvent
@@ -273,15 +278,19 @@ type ContextEvent struct {
 	domcore.Event
 }
 
-// ContextEventFromJS is casting a js.Wrapper into ContextEvent.
-func ContextEventFromJS(value js.Wrapper) *ContextEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ContextEventFromJS is casting a js.Value into ContextEvent.
+func ContextEventFromJS(value js.Value) *ContextEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ContextEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ContextEventFromJS is casting from something that holds a js.Value into ContextEvent.
+func ContextEventFromWrapper(input core.Wrapper) *ContextEvent {
+	return ContextEventFromJS(input.JSValue())
 }
 
 func NewWebGLContextEvent(_type string, eventInit *ContextEventInit) (_result *ContextEvent) {
@@ -321,15 +330,19 @@ type Framebuffer struct {
 	Object
 }
 
-// FramebufferFromJS is casting a js.Wrapper into Framebuffer.
-func FramebufferFromJS(value js.Wrapper) *Framebuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FramebufferFromJS is casting a js.Value into Framebuffer.
+func FramebufferFromJS(value js.Value) *Framebuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Framebuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FramebufferFromJS is casting from something that holds a js.Value into Framebuffer.
+func FramebufferFromWrapper(input core.Wrapper) *Framebuffer {
+	return FramebufferFromJS(input.JSValue())
 }
 
 // class: WebGLObject
@@ -342,15 +355,19 @@ func (_this *Object) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObjectFromJS is casting a js.Wrapper into Object.
-func ObjectFromJS(value js.Wrapper) *Object {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObjectFromJS is casting a js.Value into Object.
+func ObjectFromJS(value js.Value) *Object {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Object{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObjectFromJS is casting from something that holds a js.Value into Object.
+func ObjectFromWrapper(input core.Wrapper) *Object {
+	return ObjectFromJS(input.JSValue())
 }
 
 // class: WebGLProgram
@@ -358,15 +375,19 @@ type Program struct {
 	Object
 }
 
-// ProgramFromJS is casting a js.Wrapper into Program.
-func ProgramFromJS(value js.Wrapper) *Program {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProgramFromJS is casting a js.Value into Program.
+func ProgramFromJS(value js.Value) *Program {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Program{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProgramFromJS is casting from something that holds a js.Value into Program.
+func ProgramFromWrapper(input core.Wrapper) *Program {
+	return ProgramFromJS(input.JSValue())
 }
 
 // class: WebGLRenderbuffer
@@ -374,15 +395,19 @@ type Renderbuffer struct {
 	Object
 }
 
-// RenderbufferFromJS is casting a js.Wrapper into Renderbuffer.
-func RenderbufferFromJS(value js.Wrapper) *Renderbuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderbufferFromJS is casting a js.Value into Renderbuffer.
+func RenderbufferFromJS(value js.Value) *Renderbuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Renderbuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderbufferFromJS is casting from something that holds a js.Value into Renderbuffer.
+func RenderbufferFromWrapper(input core.Wrapper) *Renderbuffer {
+	return RenderbufferFromJS(input.JSValue())
 }
 
 // class: WebGLRenderingContext
@@ -395,15 +420,19 @@ func (_this *RenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RenderingContextFromJS is casting a js.Wrapper into RenderingContext.
-func RenderingContextFromJS(value js.Wrapper) *RenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderingContextFromJS is casting a js.Value into RenderingContext.
+func RenderingContextFromJS(value js.Value) *RenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderingContextFromJS is casting from something that holds a js.Value into RenderingContext.
+func RenderingContextFromWrapper(input core.Wrapper) *RenderingContext {
+	return RenderingContextFromJS(input.JSValue())
 }
 
 const (
@@ -3223,15 +3252,19 @@ type Shader struct {
 	Object
 }
 
-// ShaderFromJS is casting a js.Wrapper into Shader.
-func ShaderFromJS(value js.Wrapper) *Shader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShaderFromJS is casting a js.Value into Shader.
+func ShaderFromJS(value js.Value) *Shader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Shader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShaderFromJS is casting from something that holds a js.Value into Shader.
+func ShaderFromWrapper(input core.Wrapper) *Shader {
+	return ShaderFromJS(input.JSValue())
 }
 
 // class: WebGLShaderPrecisionFormat
@@ -3244,15 +3277,19 @@ func (_this *ShaderPrecisionFormat) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ShaderPrecisionFormatFromJS is casting a js.Wrapper into ShaderPrecisionFormat.
-func ShaderPrecisionFormatFromJS(value js.Wrapper) *ShaderPrecisionFormat {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShaderPrecisionFormatFromJS is casting a js.Value into ShaderPrecisionFormat.
+func ShaderPrecisionFormatFromJS(value js.Value) *ShaderPrecisionFormat {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShaderPrecisionFormat{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShaderPrecisionFormatFromJS is casting from something that holds a js.Value into ShaderPrecisionFormat.
+func ShaderPrecisionFormatFromWrapper(input core.Wrapper) *ShaderPrecisionFormat {
+	return ShaderPrecisionFormatFromJS(input.JSValue())
 }
 
 // RangeMin returning attribute 'rangeMin' with
@@ -3287,15 +3324,19 @@ type Texture struct {
 	Object
 }
 
-// TextureFromJS is casting a js.Wrapper into Texture.
-func TextureFromJS(value js.Wrapper) *Texture {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextureFromJS is casting a js.Value into Texture.
+func TextureFromJS(value js.Value) *Texture {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Texture{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextureFromJS is casting from something that holds a js.Value into Texture.
+func TextureFromWrapper(input core.Wrapper) *Texture {
+	return TextureFromJS(input.JSValue())
 }
 
 // class: WebGLUniformLocation
@@ -3308,13 +3349,17 @@ func (_this *UniformLocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// UniformLocationFromJS is casting a js.Wrapper into UniformLocation.
-func UniformLocationFromJS(value js.Wrapper) *UniformLocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UniformLocationFromJS is casting a js.Value into UniformLocation.
+func UniformLocationFromJS(value js.Value) *UniformLocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UniformLocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UniformLocationFromJS is casting from something that holds a js.Value into UniformLocation.
+func UniformLocationFromWrapper(input core.Wrapper) *UniformLocation {
+	return UniformLocationFromJS(input.JSValue())
 }

--- a/graphics/webgl/webgl_js.go
+++ b/graphics/webgl/webgl_js.go
@@ -5,6 +5,7 @@ package webgl
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -93,7 +94,7 @@ type ContextAttributes struct {
 	XrCompatible                 bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ContextAttributes) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -119,10 +120,8 @@ func (_this *ContextAttributes) JSValue() js.Value {
 }
 
 // ContextAttributesFromJS is allocating a new
-// ContextAttributes object and copy all values from
-// input javascript object
-func ContextAttributesFromJS(value js.Wrapper) *ContextAttributes {
-	input := value.JSValue()
+// ContextAttributes object and copy all values in the value javascript object.
+func ContextAttributesFromJS(value js.Value) *ContextAttributes {
 	var out ContextAttributes
 	var (
 		value0 bool            // javascript: boolean {alpha Alpha alpha}
@@ -135,23 +134,23 @@ func ContextAttributesFromJS(value js.Wrapper) *ContextAttributes {
 		value7 bool            // javascript: boolean {failIfMajorPerformanceCaveat FailIfMajorPerformanceCaveat failIfMajorPerformanceCaveat}
 		value8 bool            // javascript: boolean {xrCompatible XrCompatible xrCompatible}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
-	value1 = (input.Get("depth")).Bool()
+	value1 = (value.Get("depth")).Bool()
 	out.Depth = value1
-	value2 = (input.Get("stencil")).Bool()
+	value2 = (value.Get("stencil")).Bool()
 	out.Stencil = value2
-	value3 = (input.Get("antialias")).Bool()
+	value3 = (value.Get("antialias")).Bool()
 	out.Antialias = value3
-	value4 = (input.Get("premultipliedAlpha")).Bool()
+	value4 = (value.Get("premultipliedAlpha")).Bool()
 	out.PremultipliedAlpha = value4
-	value5 = (input.Get("preserveDrawingBuffer")).Bool()
+	value5 = (value.Get("preserveDrawingBuffer")).Bool()
 	out.PreserveDrawingBuffer = value5
-	value6 = PowerPreferenceFromJS(input.Get("powerPreference"))
+	value6 = PowerPreferenceFromJS(value.Get("powerPreference"))
 	out.PowerPreference = value6
-	value7 = (input.Get("failIfMajorPerformanceCaveat")).Bool()
+	value7 = (value.Get("failIfMajorPerformanceCaveat")).Bool()
 	out.FailIfMajorPerformanceCaveat = value7
-	value8 = (input.Get("xrCompatible")).Bool()
+	value8 = (value.Get("xrCompatible")).Bool()
 	out.XrCompatible = value8
 	return &out
 }
@@ -164,7 +163,7 @@ type ContextEventInit struct {
 	StatusMessage string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ContextEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -180,10 +179,8 @@ func (_this *ContextEventInit) JSValue() js.Value {
 }
 
 // ContextEventInitFromJS is allocating a new
-// ContextEventInit object and copy all values from
-// input javascript object
-func ContextEventInitFromJS(value js.Wrapper) *ContextEventInit {
-	input := value.JSValue()
+// ContextEventInit object and copy all values in the value javascript object.
+func ContextEventInitFromJS(value js.Value) *ContextEventInit {
 	var out ContextEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -191,13 +188,13 @@ func ContextEventInitFromJS(value js.Wrapper) *ContextEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 string // javascript: DOMString {statusMessage StatusMessage statusMessage}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("statusMessage")).String()
+	value3 = (value.Get("statusMessage")).String()
 	out.StatusMessage = value3
 	return &out
 }
@@ -212,15 +209,19 @@ func (_this *ActiveInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ActiveInfoFromJS is casting a js.Wrapper into ActiveInfo.
-func ActiveInfoFromJS(value js.Wrapper) *ActiveInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ActiveInfoFromJS is casting a js.Value into ActiveInfo.
+func ActiveInfoFromJS(value js.Value) *ActiveInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ActiveInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ActiveInfoFromJS is casting from something that holds a js.Value into ActiveInfo.
+func ActiveInfoFromWrapper(input core.Wrapper) *ActiveInfo {
+	return ActiveInfoFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -255,15 +256,19 @@ type Buffer struct {
 	Object
 }
 
-// BufferFromJS is casting a js.Wrapper into Buffer.
-func BufferFromJS(value js.Wrapper) *Buffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BufferFromJS is casting a js.Value into Buffer.
+func BufferFromJS(value js.Value) *Buffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Buffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BufferFromJS is casting from something that holds a js.Value into Buffer.
+func BufferFromWrapper(input core.Wrapper) *Buffer {
+	return BufferFromJS(input.JSValue())
 }
 
 // class: WebGLContextEvent
@@ -271,15 +276,19 @@ type ContextEvent struct {
 	domcore.Event
 }
 
-// ContextEventFromJS is casting a js.Wrapper into ContextEvent.
-func ContextEventFromJS(value js.Wrapper) *ContextEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ContextEventFromJS is casting a js.Value into ContextEvent.
+func ContextEventFromJS(value js.Value) *ContextEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ContextEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ContextEventFromJS is casting from something that holds a js.Value into ContextEvent.
+func ContextEventFromWrapper(input core.Wrapper) *ContextEvent {
+	return ContextEventFromJS(input.JSValue())
 }
 
 func NewWebGLContextEvent(_type string, eventInit *ContextEventInit) (_result *ContextEvent) {
@@ -319,15 +328,19 @@ type Framebuffer struct {
 	Object
 }
 
-// FramebufferFromJS is casting a js.Wrapper into Framebuffer.
-func FramebufferFromJS(value js.Wrapper) *Framebuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FramebufferFromJS is casting a js.Value into Framebuffer.
+func FramebufferFromJS(value js.Value) *Framebuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Framebuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FramebufferFromJS is casting from something that holds a js.Value into Framebuffer.
+func FramebufferFromWrapper(input core.Wrapper) *Framebuffer {
+	return FramebufferFromJS(input.JSValue())
 }
 
 // class: WebGLObject
@@ -340,15 +353,19 @@ func (_this *Object) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObjectFromJS is casting a js.Wrapper into Object.
-func ObjectFromJS(value js.Wrapper) *Object {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObjectFromJS is casting a js.Value into Object.
+func ObjectFromJS(value js.Value) *Object {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Object{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObjectFromJS is casting from something that holds a js.Value into Object.
+func ObjectFromWrapper(input core.Wrapper) *Object {
+	return ObjectFromJS(input.JSValue())
 }
 
 // class: WebGLProgram
@@ -356,15 +373,19 @@ type Program struct {
 	Object
 }
 
-// ProgramFromJS is casting a js.Wrapper into Program.
-func ProgramFromJS(value js.Wrapper) *Program {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ProgramFromJS is casting a js.Value into Program.
+func ProgramFromJS(value js.Value) *Program {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Program{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ProgramFromJS is casting from something that holds a js.Value into Program.
+func ProgramFromWrapper(input core.Wrapper) *Program {
+	return ProgramFromJS(input.JSValue())
 }
 
 // class: WebGLRenderbuffer
@@ -372,15 +393,19 @@ type Renderbuffer struct {
 	Object
 }
 
-// RenderbufferFromJS is casting a js.Wrapper into Renderbuffer.
-func RenderbufferFromJS(value js.Wrapper) *Renderbuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderbufferFromJS is casting a js.Value into Renderbuffer.
+func RenderbufferFromJS(value js.Value) *Renderbuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Renderbuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderbufferFromJS is casting from something that holds a js.Value into Renderbuffer.
+func RenderbufferFromWrapper(input core.Wrapper) *Renderbuffer {
+	return RenderbufferFromJS(input.JSValue())
 }
 
 // class: WebGLRenderingContext
@@ -393,15 +418,19 @@ func (_this *RenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RenderingContextFromJS is casting a js.Wrapper into RenderingContext.
-func RenderingContextFromJS(value js.Wrapper) *RenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderingContextFromJS is casting a js.Value into RenderingContext.
+func RenderingContextFromJS(value js.Value) *RenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderingContextFromJS is casting from something that holds a js.Value into RenderingContext.
+func RenderingContextFromWrapper(input core.Wrapper) *RenderingContext {
+	return RenderingContextFromJS(input.JSValue())
 }
 
 const (
@@ -3221,15 +3250,19 @@ type Shader struct {
 	Object
 }
 
-// ShaderFromJS is casting a js.Wrapper into Shader.
-func ShaderFromJS(value js.Wrapper) *Shader {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShaderFromJS is casting a js.Value into Shader.
+func ShaderFromJS(value js.Value) *Shader {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Shader{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShaderFromJS is casting from something that holds a js.Value into Shader.
+func ShaderFromWrapper(input core.Wrapper) *Shader {
+	return ShaderFromJS(input.JSValue())
 }
 
 // class: WebGLShaderPrecisionFormat
@@ -3242,15 +3275,19 @@ func (_this *ShaderPrecisionFormat) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ShaderPrecisionFormatFromJS is casting a js.Wrapper into ShaderPrecisionFormat.
-func ShaderPrecisionFormatFromJS(value js.Wrapper) *ShaderPrecisionFormat {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ShaderPrecisionFormatFromJS is casting a js.Value into ShaderPrecisionFormat.
+func ShaderPrecisionFormatFromJS(value js.Value) *ShaderPrecisionFormat {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ShaderPrecisionFormat{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ShaderPrecisionFormatFromJS is casting from something that holds a js.Value into ShaderPrecisionFormat.
+func ShaderPrecisionFormatFromWrapper(input core.Wrapper) *ShaderPrecisionFormat {
+	return ShaderPrecisionFormatFromJS(input.JSValue())
 }
 
 // RangeMin returning attribute 'rangeMin' with
@@ -3285,15 +3322,19 @@ type Texture struct {
 	Object
 }
 
-// TextureFromJS is casting a js.Wrapper into Texture.
-func TextureFromJS(value js.Wrapper) *Texture {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextureFromJS is casting a js.Value into Texture.
+func TextureFromJS(value js.Value) *Texture {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Texture{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextureFromJS is casting from something that holds a js.Value into Texture.
+func TextureFromWrapper(input core.Wrapper) *Texture {
+	return TextureFromJS(input.JSValue())
 }
 
 // class: WebGLUniformLocation
@@ -3306,13 +3347,17 @@ func (_this *UniformLocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// UniformLocationFromJS is casting a js.Wrapper into UniformLocation.
-func UniformLocationFromJS(value js.Wrapper) *UniformLocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UniformLocationFromJS is casting a js.Value into UniformLocation.
+func UniformLocationFromJS(value js.Value) *UniformLocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UniformLocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UniformLocationFromJS is casting from something that holds a js.Value into UniformLocation.
+func UniformLocationFromWrapper(input core.Wrapper) *UniformLocation {
+	return UniformLocationFromJS(input.JSValue())
 }

--- a/graphics/webgl2/webgl2.go
+++ b/graphics/webgl2/webgl2.go
@@ -7,6 +7,7 @@ package webgl2
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/webgl"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -54,15 +55,19 @@ type Query struct {
 	webgl.Object
 }
 
-// QueryFromJS is casting a js.Wrapper into Query.
-func QueryFromJS(value js.Wrapper) *Query {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// QueryFromJS is casting a js.Value into Query.
+func QueryFromJS(value js.Value) *Query {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Query{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// QueryFromJS is casting from something that holds a js.Value into Query.
+func QueryFromWrapper(input core.Wrapper) *Query {
+	return QueryFromJS(input.JSValue())
 }
 
 // class: WebGL2RenderingContext
@@ -75,15 +80,19 @@ func (_this *RenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RenderingContextFromJS is casting a js.Wrapper into RenderingContext.
-func RenderingContextFromJS(value js.Wrapper) *RenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderingContextFromJS is casting a js.Value into RenderingContext.
+func RenderingContextFromJS(value js.Value) *RenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderingContextFromJS is casting from something that holds a js.Value into RenderingContext.
+func RenderingContextFromWrapper(input core.Wrapper) *RenderingContext {
+	return RenderingContextFromJS(input.JSValue())
 }
 
 const (
@@ -6681,15 +6690,19 @@ type Sampler struct {
 	webgl.Object
 }
 
-// SamplerFromJS is casting a js.Wrapper into Sampler.
-func SamplerFromJS(value js.Wrapper) *Sampler {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SamplerFromJS is casting a js.Value into Sampler.
+func SamplerFromJS(value js.Value) *Sampler {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sampler{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SamplerFromJS is casting from something that holds a js.Value into Sampler.
+func SamplerFromWrapper(input core.Wrapper) *Sampler {
+	return SamplerFromJS(input.JSValue())
 }
 
 // class: WebGLSync
@@ -6697,15 +6710,19 @@ type Sync struct {
 	webgl.Object
 }
 
-// SyncFromJS is casting a js.Wrapper into Sync.
-func SyncFromJS(value js.Wrapper) *Sync {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncFromJS is casting a js.Value into Sync.
+func SyncFromJS(value js.Value) *Sync {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sync{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncFromJS is casting from something that holds a js.Value into Sync.
+func SyncFromWrapper(input core.Wrapper) *Sync {
+	return SyncFromJS(input.JSValue())
 }
 
 // class: WebGLTransformFeedback
@@ -6713,15 +6730,19 @@ type TransformFeedback struct {
 	webgl.Object
 }
 
-// TransformFeedbackFromJS is casting a js.Wrapper into TransformFeedback.
-func TransformFeedbackFromJS(value js.Wrapper) *TransformFeedback {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TransformFeedbackFromJS is casting a js.Value into TransformFeedback.
+func TransformFeedbackFromJS(value js.Value) *TransformFeedback {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TransformFeedback{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TransformFeedbackFromJS is casting from something that holds a js.Value into TransformFeedback.
+func TransformFeedbackFromWrapper(input core.Wrapper) *TransformFeedback {
+	return TransformFeedbackFromJS(input.JSValue())
 }
 
 // class: WebGLVertexArrayObject
@@ -6729,13 +6750,17 @@ type VertexArrayObject struct {
 	webgl.Object
 }
 
-// VertexArrayObjectFromJS is casting a js.Wrapper into VertexArrayObject.
-func VertexArrayObjectFromJS(value js.Wrapper) *VertexArrayObject {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VertexArrayObjectFromJS is casting a js.Value into VertexArrayObject.
+func VertexArrayObjectFromJS(value js.Value) *VertexArrayObject {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VertexArrayObject{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VertexArrayObjectFromJS is casting from something that holds a js.Value into VertexArrayObject.
+func VertexArrayObjectFromWrapper(input core.Wrapper) *VertexArrayObject {
+	return VertexArrayObjectFromJS(input.JSValue())
 }

--- a/graphics/webgl2/webgl2_js.go
+++ b/graphics/webgl2/webgl2_js.go
@@ -5,6 +5,7 @@ package webgl2
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/graphics/webgl"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -52,15 +53,19 @@ type Query struct {
 	webgl.Object
 }
 
-// QueryFromJS is casting a js.Wrapper into Query.
-func QueryFromJS(value js.Wrapper) *Query {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// QueryFromJS is casting a js.Value into Query.
+func QueryFromJS(value js.Value) *Query {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Query{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// QueryFromJS is casting from something that holds a js.Value into Query.
+func QueryFromWrapper(input core.Wrapper) *Query {
+	return QueryFromJS(input.JSValue())
 }
 
 // class: WebGL2RenderingContext
@@ -73,15 +78,19 @@ func (_this *RenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RenderingContextFromJS is casting a js.Wrapper into RenderingContext.
-func RenderingContextFromJS(value js.Wrapper) *RenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RenderingContextFromJS is casting a js.Value into RenderingContext.
+func RenderingContextFromJS(value js.Value) *RenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RenderingContextFromJS is casting from something that holds a js.Value into RenderingContext.
+func RenderingContextFromWrapper(input core.Wrapper) *RenderingContext {
+	return RenderingContextFromJS(input.JSValue())
 }
 
 const (
@@ -6679,15 +6688,19 @@ type Sampler struct {
 	webgl.Object
 }
 
-// SamplerFromJS is casting a js.Wrapper into Sampler.
-func SamplerFromJS(value js.Wrapper) *Sampler {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SamplerFromJS is casting a js.Value into Sampler.
+func SamplerFromJS(value js.Value) *Sampler {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sampler{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SamplerFromJS is casting from something that holds a js.Value into Sampler.
+func SamplerFromWrapper(input core.Wrapper) *Sampler {
+	return SamplerFromJS(input.JSValue())
 }
 
 // class: WebGLSync
@@ -6695,15 +6708,19 @@ type Sync struct {
 	webgl.Object
 }
 
-// SyncFromJS is casting a js.Wrapper into Sync.
-func SyncFromJS(value js.Wrapper) *Sync {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncFromJS is casting a js.Value into Sync.
+func SyncFromJS(value js.Value) *Sync {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Sync{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncFromJS is casting from something that holds a js.Value into Sync.
+func SyncFromWrapper(input core.Wrapper) *Sync {
+	return SyncFromJS(input.JSValue())
 }
 
 // class: WebGLTransformFeedback
@@ -6711,15 +6728,19 @@ type TransformFeedback struct {
 	webgl.Object
 }
 
-// TransformFeedbackFromJS is casting a js.Wrapper into TransformFeedback.
-func TransformFeedbackFromJS(value js.Wrapper) *TransformFeedback {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TransformFeedbackFromJS is casting a js.Value into TransformFeedback.
+func TransformFeedbackFromJS(value js.Value) *TransformFeedback {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TransformFeedback{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TransformFeedbackFromJS is casting from something that holds a js.Value into TransformFeedback.
+func TransformFeedbackFromWrapper(input core.Wrapper) *TransformFeedback {
+	return TransformFeedbackFromJS(input.JSValue())
 }
 
 // class: WebGLVertexArrayObject
@@ -6727,13 +6748,17 @@ type VertexArrayObject struct {
 	webgl.Object
 }
 
-// VertexArrayObjectFromJS is casting a js.Wrapper into VertexArrayObject.
-func VertexArrayObjectFromJS(value js.Wrapper) *VertexArrayObject {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VertexArrayObjectFromJS is casting a js.Value into VertexArrayObject.
+func VertexArrayObjectFromJS(value js.Value) *VertexArrayObject {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VertexArrayObject{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VertexArrayObjectFromJS is casting from something that holds a js.Value into VertexArrayObject.
+func VertexArrayObjectFromWrapper(input core.Wrapper) *VertexArrayObject {
+	return VertexArrayObjectFromJS(input.JSValue())
 }

--- a/html/canvas/canvas.go
+++ b/html/canvas/canvas.go
@@ -7,6 +7,7 @@ package canvas
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -618,7 +619,7 @@ type CanvasRenderingContext2DSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CanvasRenderingContext2DSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -628,15 +629,13 @@ func (_this *CanvasRenderingContext2DSettings) JSValue() js.Value {
 }
 
 // CanvasRenderingContext2DSettingsFromJS is allocating a new
-// CanvasRenderingContext2DSettings object and copy all values from
-// input javascript object
-func CanvasRenderingContext2DSettingsFromJS(value js.Wrapper) *CanvasRenderingContext2DSettings {
-	input := value.JSValue()
+// CanvasRenderingContext2DSettings object and copy all values in the value javascript object.
+func CanvasRenderingContext2DSettingsFromJS(value js.Value) *CanvasRenderingContext2DSettings {
 	var out CanvasRenderingContext2DSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -651,7 +650,7 @@ type ImageBitmapOptions struct {
 	ResizeQuality        ResizeQuality
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageBitmapOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -671,10 +670,8 @@ func (_this *ImageBitmapOptions) JSValue() js.Value {
 }
 
 // ImageBitmapOptionsFromJS is allocating a new
-// ImageBitmapOptions object and copy all values from
-// input javascript object
-func ImageBitmapOptionsFromJS(value js.Wrapper) *ImageBitmapOptions {
-	input := value.JSValue()
+// ImageBitmapOptions object and copy all values in the value javascript object.
+func ImageBitmapOptionsFromJS(value js.Value) *ImageBitmapOptions {
 	var out ImageBitmapOptions
 	var (
 		value0 ImageOrientation     // javascript: ImageOrientation {imageOrientation ImageOrientation imageOrientation}
@@ -684,17 +681,17 @@ func ImageBitmapOptionsFromJS(value js.Wrapper) *ImageBitmapOptions {
 		value4 uint                 // javascript: unsigned long {resizeHeight ResizeHeight resizeHeight}
 		value5 ResizeQuality        // javascript: ResizeQuality {resizeQuality ResizeQuality resizeQuality}
 	)
-	value0 = ImageOrientationFromJS(input.Get("imageOrientation"))
+	value0 = ImageOrientationFromJS(value.Get("imageOrientation"))
 	out.ImageOrientation = value0
-	value1 = PremultiplyAlphaFromJS(input.Get("premultiplyAlpha"))
+	value1 = PremultiplyAlphaFromJS(value.Get("premultiplyAlpha"))
 	out.PremultiplyAlpha = value1
-	value2 = ColorSpaceConversionFromJS(input.Get("colorSpaceConversion"))
+	value2 = ColorSpaceConversionFromJS(value.Get("colorSpaceConversion"))
 	out.ColorSpaceConversion = value2
-	value3 = (uint)((input.Get("resizeWidth")).Int())
+	value3 = (uint)((value.Get("resizeWidth")).Int())
 	out.ResizeWidth = value3
-	value4 = (uint)((input.Get("resizeHeight")).Int())
+	value4 = (uint)((value.Get("resizeHeight")).Int())
 	out.ResizeHeight = value4
-	value5 = ResizeQualityFromJS(input.Get("resizeQuality"))
+	value5 = ResizeQualityFromJS(value.Get("resizeQuality"))
 	out.ResizeQuality = value5
 	return &out
 }
@@ -709,15 +706,19 @@ func (_this *CanvasGradient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasGradientFromJS is casting a js.Wrapper into CanvasGradient.
-func CanvasGradientFromJS(value js.Wrapper) *CanvasGradient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasGradientFromJS is casting a js.Value into CanvasGradient.
+func CanvasGradientFromJS(value js.Value) *CanvasGradient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasGradient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasGradientFromJS is casting from something that holds a js.Value into CanvasGradient.
+func CanvasGradientFromWrapper(input core.Wrapper) *CanvasGradient {
+	return CanvasGradientFromJS(input.JSValue())
 }
 
 func (_this *CanvasGradient) AddColorStop(offset float64, color string) {
@@ -745,15 +746,19 @@ func (_this *CanvasPattern) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasPatternFromJS is casting a js.Wrapper into CanvasPattern.
-func CanvasPatternFromJS(value js.Wrapper) *CanvasPattern {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasPatternFromJS is casting a js.Value into CanvasPattern.
+func CanvasPatternFromJS(value js.Value) *CanvasPattern {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasPattern{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasPatternFromJS is casting from something that holds a js.Value into CanvasPattern.
+func CanvasPatternFromWrapper(input core.Wrapper) *CanvasPattern {
+	return CanvasPatternFromJS(input.JSValue())
 }
 
 func (_this *CanvasPattern) SetTransform(transform *geometry.DOMMatrix2DInit) {
@@ -780,15 +785,19 @@ func (_this *CanvasRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasRenderingContext2DFromJS is casting a js.Wrapper into CanvasRenderingContext2D.
-func CanvasRenderingContext2DFromJS(value js.Wrapper) *CanvasRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasRenderingContext2DFromJS is casting a js.Value into CanvasRenderingContext2D.
+func CanvasRenderingContext2DFromJS(value js.Value) *CanvasRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasRenderingContext2DFromJS is casting from something that holds a js.Value into CanvasRenderingContext2D.
+func CanvasRenderingContext2DFromWrapper(input core.Wrapper) *CanvasRenderingContext2D {
+	return CanvasRenderingContext2DFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -2167,15 +2176,19 @@ type HTMLCanvasElement struct {
 	html.HTMLElement
 }
 
-// HTMLCanvasElementFromJS is casting a js.Wrapper into HTMLCanvasElement.
-func HTMLCanvasElementFromJS(value js.Wrapper) *HTMLCanvasElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLCanvasElementFromJS is casting a js.Value into HTMLCanvasElement.
+func HTMLCanvasElementFromJS(value js.Value) *HTMLCanvasElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLCanvasElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLCanvasElementFromJS is casting from something that holds a js.Value into HTMLCanvasElement.
+func HTMLCanvasElementFromWrapper(input core.Wrapper) *HTMLCanvasElement {
+	return HTMLCanvasElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -2348,15 +2361,19 @@ func (_this *ImageBitmap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageBitmapFromJS is casting a js.Wrapper into ImageBitmap.
-func ImageBitmapFromJS(value js.Wrapper) *ImageBitmap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageBitmapFromJS is casting a js.Value into ImageBitmap.
+func ImageBitmapFromJS(value js.Value) *ImageBitmap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageBitmap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageBitmapFromJS is casting from something that holds a js.Value into ImageBitmap.
+func ImageBitmapFromWrapper(input core.Wrapper) *ImageBitmap {
+	return ImageBitmapFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -2396,15 +2413,19 @@ func (_this *ImageBitmapRenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageBitmapRenderingContextFromJS is casting a js.Wrapper into ImageBitmapRenderingContext.
-func ImageBitmapRenderingContextFromJS(value js.Wrapper) *ImageBitmapRenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageBitmapRenderingContextFromJS is casting a js.Value into ImageBitmapRenderingContext.
+func ImageBitmapRenderingContextFromJS(value js.Value) *ImageBitmapRenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageBitmapRenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageBitmapRenderingContextFromJS is casting from something that holds a js.Value into ImageBitmapRenderingContext.
+func ImageBitmapRenderingContextFromWrapper(input core.Wrapper) *ImageBitmapRenderingContext {
+	return ImageBitmapRenderingContextFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -2438,15 +2459,19 @@ func (_this *ImageData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageDataFromJS is casting a js.Wrapper into ImageData.
-func ImageDataFromJS(value js.Wrapper) *ImageData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageDataFromJS is casting a js.Value into ImageData.
+func ImageDataFromJS(value js.Value) *ImageData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageDataFromJS is casting from something that holds a js.Value into ImageData.
+func ImageDataFromWrapper(input core.Wrapper) *ImageData {
+	return ImageDataFromJS(input.JSValue())
 }
 
 func NewImageData(data *patch.Uint8ClampedArray, sw uint, sh *uint) (_result *ImageData) {
@@ -2513,15 +2538,19 @@ type OffscreenCanvas struct {
 	domcore.EventTarget
 }
 
-// OffscreenCanvasFromJS is casting a js.Wrapper into OffscreenCanvas.
-func OffscreenCanvasFromJS(value js.Wrapper) *OffscreenCanvas {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OffscreenCanvasFromJS is casting a js.Value into OffscreenCanvas.
+func OffscreenCanvasFromJS(value js.Value) *OffscreenCanvas {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OffscreenCanvas{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OffscreenCanvasFromJS is casting from something that holds a js.Value into OffscreenCanvas.
+func OffscreenCanvasFromWrapper(input core.Wrapper) *OffscreenCanvas {
+	return OffscreenCanvasFromJS(input.JSValue())
 }
 
 func NewOffscreenCanvas(width int, height int) (_result *OffscreenCanvas) {
@@ -2644,15 +2673,19 @@ func (_this *OffscreenCanvasRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OffscreenCanvasRenderingContext2DFromJS is casting a js.Wrapper into OffscreenCanvasRenderingContext2D.
-func OffscreenCanvasRenderingContext2DFromJS(value js.Wrapper) *OffscreenCanvasRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OffscreenCanvasRenderingContext2DFromJS is casting a js.Value into OffscreenCanvasRenderingContext2D.
+func OffscreenCanvasRenderingContext2DFromJS(value js.Value) *OffscreenCanvasRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OffscreenCanvasRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OffscreenCanvasRenderingContext2DFromJS is casting from something that holds a js.Value into OffscreenCanvasRenderingContext2D.
+func OffscreenCanvasRenderingContext2DFromWrapper(input core.Wrapper) *OffscreenCanvasRenderingContext2D {
+	return OffscreenCanvasRenderingContext2DFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -3983,15 +4016,19 @@ func (_this *Path2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Path2DFromJS is casting a js.Wrapper into Path2D.
-func Path2DFromJS(value js.Wrapper) *Path2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Path2DFromJS is casting a js.Value into Path2D.
+func Path2DFromJS(value js.Value) *Path2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Path2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Path2DFromJS is casting from something that holds a js.Value into Path2D.
+func Path2DFromWrapper(input core.Wrapper) *Path2D {
+	return Path2DFromJS(input.JSValue())
 }
 
 func NewPath2D(path *Union) (_result *Path2D) {
@@ -4249,15 +4286,19 @@ func (_this *PromiseImageBitmap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseImageBitmapFromJS is casting a js.Wrapper into PromiseImageBitmap.
-func PromiseImageBitmapFromJS(value js.Wrapper) *PromiseImageBitmap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseImageBitmapFromJS is casting a js.Value into PromiseImageBitmap.
+func PromiseImageBitmapFromJS(value js.Value) *PromiseImageBitmap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseImageBitmap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseImageBitmapFromJS is casting from something that holds a js.Value into PromiseImageBitmap.
+func PromiseImageBitmapFromWrapper(input core.Wrapper) *PromiseImageBitmap {
+	return PromiseImageBitmapFromJS(input.JSValue())
 }
 
 func (_this *PromiseImageBitmap) Then(onFulfilled *PromiseImageBitmapOnFulfilled, onRejected *PromiseImageBitmapOnRejected) (_result *PromiseImageBitmap) {
@@ -4354,15 +4395,19 @@ func (_this *TextMetrics) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TextMetricsFromJS is casting a js.Wrapper into TextMetrics.
-func TextMetricsFromJS(value js.Wrapper) *TextMetrics {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextMetricsFromJS is casting a js.Value into TextMetrics.
+func TextMetricsFromJS(value js.Value) *TextMetrics {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextMetrics{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextMetricsFromJS is casting from something that holds a js.Value into TextMetrics.
+func TextMetricsFromWrapper(input core.Wrapper) *TextMetrics {
+	return TextMetricsFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with

--- a/html/canvas/canvas_js.go
+++ b/html/canvas/canvas_js.go
@@ -5,6 +5,7 @@ package canvas
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -616,7 +617,7 @@ type CanvasRenderingContext2DSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CanvasRenderingContext2DSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -626,15 +627,13 @@ func (_this *CanvasRenderingContext2DSettings) JSValue() js.Value {
 }
 
 // CanvasRenderingContext2DSettingsFromJS is allocating a new
-// CanvasRenderingContext2DSettings object and copy all values from
-// input javascript object
-func CanvasRenderingContext2DSettingsFromJS(value js.Wrapper) *CanvasRenderingContext2DSettings {
-	input := value.JSValue()
+// CanvasRenderingContext2DSettings object and copy all values in the value javascript object.
+func CanvasRenderingContext2DSettingsFromJS(value js.Value) *CanvasRenderingContext2DSettings {
 	var out CanvasRenderingContext2DSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -649,7 +648,7 @@ type ImageBitmapOptions struct {
 	ResizeQuality        ResizeQuality
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageBitmapOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -669,10 +668,8 @@ func (_this *ImageBitmapOptions) JSValue() js.Value {
 }
 
 // ImageBitmapOptionsFromJS is allocating a new
-// ImageBitmapOptions object and copy all values from
-// input javascript object
-func ImageBitmapOptionsFromJS(value js.Wrapper) *ImageBitmapOptions {
-	input := value.JSValue()
+// ImageBitmapOptions object and copy all values in the value javascript object.
+func ImageBitmapOptionsFromJS(value js.Value) *ImageBitmapOptions {
 	var out ImageBitmapOptions
 	var (
 		value0 ImageOrientation     // javascript: ImageOrientation {imageOrientation ImageOrientation imageOrientation}
@@ -682,17 +679,17 @@ func ImageBitmapOptionsFromJS(value js.Wrapper) *ImageBitmapOptions {
 		value4 uint                 // javascript: unsigned long {resizeHeight ResizeHeight resizeHeight}
 		value5 ResizeQuality        // javascript: ResizeQuality {resizeQuality ResizeQuality resizeQuality}
 	)
-	value0 = ImageOrientationFromJS(input.Get("imageOrientation"))
+	value0 = ImageOrientationFromJS(value.Get("imageOrientation"))
 	out.ImageOrientation = value0
-	value1 = PremultiplyAlphaFromJS(input.Get("premultiplyAlpha"))
+	value1 = PremultiplyAlphaFromJS(value.Get("premultiplyAlpha"))
 	out.PremultiplyAlpha = value1
-	value2 = ColorSpaceConversionFromJS(input.Get("colorSpaceConversion"))
+	value2 = ColorSpaceConversionFromJS(value.Get("colorSpaceConversion"))
 	out.ColorSpaceConversion = value2
-	value3 = (uint)((input.Get("resizeWidth")).Int())
+	value3 = (uint)((value.Get("resizeWidth")).Int())
 	out.ResizeWidth = value3
-	value4 = (uint)((input.Get("resizeHeight")).Int())
+	value4 = (uint)((value.Get("resizeHeight")).Int())
 	out.ResizeHeight = value4
-	value5 = ResizeQualityFromJS(input.Get("resizeQuality"))
+	value5 = ResizeQualityFromJS(value.Get("resizeQuality"))
 	out.ResizeQuality = value5
 	return &out
 }
@@ -707,15 +704,19 @@ func (_this *CanvasGradient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasGradientFromJS is casting a js.Wrapper into CanvasGradient.
-func CanvasGradientFromJS(value js.Wrapper) *CanvasGradient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasGradientFromJS is casting a js.Value into CanvasGradient.
+func CanvasGradientFromJS(value js.Value) *CanvasGradient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasGradient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasGradientFromJS is casting from something that holds a js.Value into CanvasGradient.
+func CanvasGradientFromWrapper(input core.Wrapper) *CanvasGradient {
+	return CanvasGradientFromJS(input.JSValue())
 }
 
 func (_this *CanvasGradient) AddColorStop(offset float64, color string) {
@@ -743,15 +744,19 @@ func (_this *CanvasPattern) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasPatternFromJS is casting a js.Wrapper into CanvasPattern.
-func CanvasPatternFromJS(value js.Wrapper) *CanvasPattern {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasPatternFromJS is casting a js.Value into CanvasPattern.
+func CanvasPatternFromJS(value js.Value) *CanvasPattern {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasPattern{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasPatternFromJS is casting from something that holds a js.Value into CanvasPattern.
+func CanvasPatternFromWrapper(input core.Wrapper) *CanvasPattern {
+	return CanvasPatternFromJS(input.JSValue())
 }
 
 func (_this *CanvasPattern) SetTransform(transform *geometry.DOMMatrix2DInit) {
@@ -778,15 +783,19 @@ func (_this *CanvasRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CanvasRenderingContext2DFromJS is casting a js.Wrapper into CanvasRenderingContext2D.
-func CanvasRenderingContext2DFromJS(value js.Wrapper) *CanvasRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasRenderingContext2DFromJS is casting a js.Value into CanvasRenderingContext2D.
+func CanvasRenderingContext2DFromJS(value js.Value) *CanvasRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasRenderingContext2DFromJS is casting from something that holds a js.Value into CanvasRenderingContext2D.
+func CanvasRenderingContext2DFromWrapper(input core.Wrapper) *CanvasRenderingContext2D {
+	return CanvasRenderingContext2DFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -2165,15 +2174,19 @@ type HTMLCanvasElement struct {
 	html.HTMLElement
 }
 
-// HTMLCanvasElementFromJS is casting a js.Wrapper into HTMLCanvasElement.
-func HTMLCanvasElementFromJS(value js.Wrapper) *HTMLCanvasElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLCanvasElementFromJS is casting a js.Value into HTMLCanvasElement.
+func HTMLCanvasElementFromJS(value js.Value) *HTMLCanvasElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLCanvasElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLCanvasElementFromJS is casting from something that holds a js.Value into HTMLCanvasElement.
+func HTMLCanvasElementFromWrapper(input core.Wrapper) *HTMLCanvasElement {
+	return HTMLCanvasElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -2346,15 +2359,19 @@ func (_this *ImageBitmap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageBitmapFromJS is casting a js.Wrapper into ImageBitmap.
-func ImageBitmapFromJS(value js.Wrapper) *ImageBitmap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageBitmapFromJS is casting a js.Value into ImageBitmap.
+func ImageBitmapFromJS(value js.Value) *ImageBitmap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageBitmap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageBitmapFromJS is casting from something that holds a js.Value into ImageBitmap.
+func ImageBitmapFromWrapper(input core.Wrapper) *ImageBitmap {
+	return ImageBitmapFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -2394,15 +2411,19 @@ func (_this *ImageBitmapRenderingContext) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageBitmapRenderingContextFromJS is casting a js.Wrapper into ImageBitmapRenderingContext.
-func ImageBitmapRenderingContextFromJS(value js.Wrapper) *ImageBitmapRenderingContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageBitmapRenderingContextFromJS is casting a js.Value into ImageBitmapRenderingContext.
+func ImageBitmapRenderingContextFromJS(value js.Value) *ImageBitmapRenderingContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageBitmapRenderingContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageBitmapRenderingContextFromJS is casting from something that holds a js.Value into ImageBitmapRenderingContext.
+func ImageBitmapRenderingContextFromWrapper(input core.Wrapper) *ImageBitmapRenderingContext {
+	return ImageBitmapRenderingContextFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -2436,15 +2457,19 @@ func (_this *ImageData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageDataFromJS is casting a js.Wrapper into ImageData.
-func ImageDataFromJS(value js.Wrapper) *ImageData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageDataFromJS is casting a js.Value into ImageData.
+func ImageDataFromJS(value js.Value) *ImageData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageDataFromJS is casting from something that holds a js.Value into ImageData.
+func ImageDataFromWrapper(input core.Wrapper) *ImageData {
+	return ImageDataFromJS(input.JSValue())
 }
 
 func NewImageData(data *patch.Uint8ClampedArray, sw uint, sh *uint) (_result *ImageData) {
@@ -2511,15 +2536,19 @@ type OffscreenCanvas struct {
 	domcore.EventTarget
 }
 
-// OffscreenCanvasFromJS is casting a js.Wrapper into OffscreenCanvas.
-func OffscreenCanvasFromJS(value js.Wrapper) *OffscreenCanvas {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OffscreenCanvasFromJS is casting a js.Value into OffscreenCanvas.
+func OffscreenCanvasFromJS(value js.Value) *OffscreenCanvas {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OffscreenCanvas{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OffscreenCanvasFromJS is casting from something that holds a js.Value into OffscreenCanvas.
+func OffscreenCanvasFromWrapper(input core.Wrapper) *OffscreenCanvas {
+	return OffscreenCanvasFromJS(input.JSValue())
 }
 
 func NewOffscreenCanvas(width int, height int) (_result *OffscreenCanvas) {
@@ -2642,15 +2671,19 @@ func (_this *OffscreenCanvasRenderingContext2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OffscreenCanvasRenderingContext2DFromJS is casting a js.Wrapper into OffscreenCanvasRenderingContext2D.
-func OffscreenCanvasRenderingContext2DFromJS(value js.Wrapper) *OffscreenCanvasRenderingContext2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OffscreenCanvasRenderingContext2DFromJS is casting a js.Value into OffscreenCanvasRenderingContext2D.
+func OffscreenCanvasRenderingContext2DFromJS(value js.Value) *OffscreenCanvasRenderingContext2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OffscreenCanvasRenderingContext2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OffscreenCanvasRenderingContext2DFromJS is casting from something that holds a js.Value into OffscreenCanvasRenderingContext2D.
+func OffscreenCanvasRenderingContext2DFromWrapper(input core.Wrapper) *OffscreenCanvasRenderingContext2D {
+	return OffscreenCanvasRenderingContext2DFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with
@@ -3981,15 +4014,19 @@ func (_this *Path2D) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Path2DFromJS is casting a js.Wrapper into Path2D.
-func Path2DFromJS(value js.Wrapper) *Path2D {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Path2DFromJS is casting a js.Value into Path2D.
+func Path2DFromJS(value js.Value) *Path2D {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Path2D{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Path2DFromJS is casting from something that holds a js.Value into Path2D.
+func Path2DFromWrapper(input core.Wrapper) *Path2D {
+	return Path2DFromJS(input.JSValue())
 }
 
 func NewPath2D(path *Union) (_result *Path2D) {
@@ -4247,15 +4284,19 @@ func (_this *PromiseImageBitmap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseImageBitmapFromJS is casting a js.Wrapper into PromiseImageBitmap.
-func PromiseImageBitmapFromJS(value js.Wrapper) *PromiseImageBitmap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseImageBitmapFromJS is casting a js.Value into PromiseImageBitmap.
+func PromiseImageBitmapFromJS(value js.Value) *PromiseImageBitmap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseImageBitmap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseImageBitmapFromJS is casting from something that holds a js.Value into PromiseImageBitmap.
+func PromiseImageBitmapFromWrapper(input core.Wrapper) *PromiseImageBitmap {
+	return PromiseImageBitmapFromJS(input.JSValue())
 }
 
 func (_this *PromiseImageBitmap) Then(onFulfilled *PromiseImageBitmapOnFulfilled, onRejected *PromiseImageBitmapOnRejected) (_result *PromiseImageBitmap) {
@@ -4352,15 +4393,19 @@ func (_this *TextMetrics) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TextMetricsFromJS is casting a js.Wrapper into TextMetrics.
-func TextMetricsFromJS(value js.Wrapper) *TextMetrics {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextMetricsFromJS is casting a js.Value into TextMetrics.
+func TextMetricsFromJS(value js.Value) *TextMetrics {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextMetrics{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextMetricsFromJS is casting from something that holds a js.Value into TextMetrics.
+func TextMetricsFromWrapper(input core.Wrapper) *TextMetrics {
+	return TextMetricsFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with

--- a/html/channel/channel.go
+++ b/html/channel/channel.go
@@ -7,6 +7,7 @@ package channel
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/javascript"
@@ -96,7 +97,7 @@ type CloseEventInit struct {
 	Reason     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CloseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -116,10 +117,8 @@ func (_this *CloseEventInit) JSValue() js.Value {
 }
 
 // CloseEventInitFromJS is allocating a new
-// CloseEventInit object and copy all values from
-// input javascript object
-func CloseEventInitFromJS(value js.Wrapper) *CloseEventInit {
-	input := value.JSValue()
+// CloseEventInit object and copy all values in the value javascript object.
+func CloseEventInitFromJS(value js.Value) *CloseEventInit {
 	var out CloseEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -129,17 +128,17 @@ func CloseEventInitFromJS(value js.Wrapper) *CloseEventInit {
 		value4 int    // javascript: unsigned short {code Code code}
 		value5 string // javascript: USVString {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("wasClean")).Bool()
+	value3 = (value.Get("wasClean")).Bool()
 	out.WasClean = value3
-	value4 = (input.Get("code")).Int()
+	value4 = (value.Get("code")).Int()
 	out.Code = value4
-	value5 = (input.Get("reason")).String()
+	value5 = (value.Get("reason")).String()
 	out.Reason = value5
 	return &out
 }
@@ -156,7 +155,7 @@ type MessageEventInit struct {
 	Ports       []*MessagePort
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -184,10 +183,8 @@ func (_this *MessageEventInit) JSValue() js.Value {
 }
 
 // MessageEventInitFromJS is allocating a new
-// MessageEventInit object and copy all values from
-// input javascript object
-func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
-	input := value.JSValue()
+// MessageEventInit object and copy all values in the value javascript object.
+func MessageEventInitFromJS(value js.Value) *MessageEventInit {
 	var out MessageEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -199,27 +196,27 @@ func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
 		value6 *Union         // javascript: Union {source Source source}
 		value7 []*MessagePort // javascript: sequence<MessagePort> {ports Ports ports}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("data")
+	value3 = value.Get("data")
 	out.Data = value3
-	value4 = (input.Get("origin")).String()
+	value4 = (value.Get("origin")).String()
 	out.Origin = value4
-	value5 = (input.Get("lastEventId")).String()
+	value5 = (value.Get("lastEventId")).String()
 	out.LastEventId = value5
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value6 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value6 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value6
-	__length7 := input.Get("ports").Length()
+	__length7 := value.Get("ports").Length()
 	__array7 := make([]*MessagePort, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 *MessagePort
-		__seq_in7 := input.Get("ports").Index(__idx7)
+		__seq_in7 := value.Get("ports").Index(__idx7)
 		__seq_out7 = MessagePortFromJS(__seq_in7)
 		__array7[__idx7] = __seq_out7
 	}
@@ -233,7 +230,7 @@ type PostMessageOptions struct {
 	Transfer []*javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PostMessageOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -247,19 +244,17 @@ func (_this *PostMessageOptions) JSValue() js.Value {
 }
 
 // PostMessageOptionsFromJS is allocating a new
-// PostMessageOptions object and copy all values from
-// input javascript object
-func PostMessageOptionsFromJS(value js.Wrapper) *PostMessageOptions {
-	input := value.JSValue()
+// PostMessageOptions object and copy all values in the value javascript object.
+func PostMessageOptionsFromJS(value js.Value) *PostMessageOptions {
 	var out PostMessageOptions
 	var (
 		value0 []*javascript.Object // javascript: sequence<object> {transfer Transfer transfer}
 	)
-	__length0 := input.Get("transfer").Length()
+	__length0 := value.Get("transfer").Length()
 	__array0 := make([]*javascript.Object, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *javascript.Object
-		__seq_in0 := input.Get("transfer").Index(__idx0)
+		__seq_in0 := value.Get("transfer").Index(__idx0)
 		__seq_out0 = javascript.ObjectFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -273,15 +268,19 @@ type BroadcastChannel struct {
 	domcore.EventTarget
 }
 
-// BroadcastChannelFromJS is casting a js.Wrapper into BroadcastChannel.
-func BroadcastChannelFromJS(value js.Wrapper) *BroadcastChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BroadcastChannelFromJS is casting a js.Value into BroadcastChannel.
+func BroadcastChannelFromJS(value js.Value) *BroadcastChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BroadcastChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BroadcastChannelFromJS is casting from something that holds a js.Value into BroadcastChannel.
+func BroadcastChannelFromWrapper(input core.Wrapper) *BroadcastChannel {
+	return BroadcastChannelFromJS(input.JSValue())
 }
 
 func NewBroadcastChannel(name string) (_result *BroadcastChannel) {
@@ -405,15 +404,19 @@ type CloseEvent struct {
 	domcore.Event
 }
 
-// CloseEventFromJS is casting a js.Wrapper into CloseEvent.
-func CloseEventFromJS(value js.Wrapper) *CloseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CloseEventFromJS is casting a js.Value into CloseEvent.
+func CloseEventFromJS(value js.Value) *CloseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CloseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CloseEventFromJS is casting from something that holds a js.Value into CloseEvent.
+func CloseEventFromWrapper(input core.Wrapper) *CloseEvent {
+	return CloseEventFromJS(input.JSValue())
 }
 
 func NewCloseEvent(_type string, eventInitDict *CloseEventInit) (_result *CloseEvent) {
@@ -476,15 +479,19 @@ func (_this *MessageChannel) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MessageChannelFromJS is casting a js.Wrapper into MessageChannel.
-func MessageChannelFromJS(value js.Wrapper) *MessageChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageChannelFromJS is casting a js.Value into MessageChannel.
+func MessageChannelFromJS(value js.Value) *MessageChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageChannelFromJS is casting from something that holds a js.Value into MessageChannel.
+func MessageChannelFromWrapper(input core.Wrapper) *MessageChannel {
+	return MessageChannelFromJS(input.JSValue())
 }
 
 func NewMessageChannel() (_result *MessageChannel) {
@@ -525,15 +532,19 @@ type MessageEvent struct {
 	domcore.Event
 }
 
-// MessageEventFromJS is casting a js.Wrapper into MessageEvent.
-func MessageEventFromJS(value js.Wrapper) *MessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageEventFromJS is casting a js.Value into MessageEvent.
+func MessageEventFromJS(value js.Value) *MessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageEventFromJS is casting from something that holds a js.Value into MessageEvent.
+func MessageEventFromWrapper(input core.Wrapper) *MessageEvent {
+	return MessageEventFromJS(input.JSValue())
 }
 
 func NewMessageEvent(_type string, eventInitDict *MessageEventInit) (_result *MessageEvent) {
@@ -686,15 +697,19 @@ type MessagePort struct {
 	domcore.EventTarget
 }
 
-// MessagePortFromJS is casting a js.Wrapper into MessagePort.
-func MessagePortFromJS(value js.Wrapper) *MessagePort {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessagePortFromJS is casting a js.Value into MessagePort.
+func MessagePortFromJS(value js.Value) *MessagePort {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessagePort{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessagePortFromJS is casting from something that holds a js.Value into MessagePort.
+func MessagePortFromWrapper(input core.Wrapper) *MessagePort {
+	return MessagePortFromJS(input.JSValue())
 }
 
 // OnMessage returning attribute 'onmessage' with
@@ -824,15 +839,19 @@ type WebSocket struct {
 	domcore.EventTarget
 }
 
-// WebSocketFromJS is casting a js.Wrapper into WebSocket.
-func WebSocketFromJS(value js.Wrapper) *WebSocket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WebSocketFromJS is casting a js.Value into WebSocket.
+func WebSocketFromJS(value js.Value) *WebSocket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WebSocket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WebSocketFromJS is casting from something that holds a js.Value into WebSocket.
+func WebSocketFromWrapper(input core.Wrapper) *WebSocket {
+	return WebSocketFromJS(input.JSValue())
 }
 
 const (

--- a/html/channel/channel_js.go
+++ b/html/channel/channel_js.go
@@ -5,6 +5,7 @@ package channel
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/javascript"
@@ -94,7 +95,7 @@ type CloseEventInit struct {
 	Reason     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CloseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -114,10 +115,8 @@ func (_this *CloseEventInit) JSValue() js.Value {
 }
 
 // CloseEventInitFromJS is allocating a new
-// CloseEventInit object and copy all values from
-// input javascript object
-func CloseEventInitFromJS(value js.Wrapper) *CloseEventInit {
-	input := value.JSValue()
+// CloseEventInit object and copy all values in the value javascript object.
+func CloseEventInitFromJS(value js.Value) *CloseEventInit {
 	var out CloseEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -127,17 +126,17 @@ func CloseEventInitFromJS(value js.Wrapper) *CloseEventInit {
 		value4 int    // javascript: unsigned short {code Code code}
 		value5 string // javascript: USVString {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("wasClean")).Bool()
+	value3 = (value.Get("wasClean")).Bool()
 	out.WasClean = value3
-	value4 = (input.Get("code")).Int()
+	value4 = (value.Get("code")).Int()
 	out.Code = value4
-	value5 = (input.Get("reason")).String()
+	value5 = (value.Get("reason")).String()
 	out.Reason = value5
 	return &out
 }
@@ -154,7 +153,7 @@ type MessageEventInit struct {
 	Ports       []*MessagePort
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -182,10 +181,8 @@ func (_this *MessageEventInit) JSValue() js.Value {
 }
 
 // MessageEventInitFromJS is allocating a new
-// MessageEventInit object and copy all values from
-// input javascript object
-func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
-	input := value.JSValue()
+// MessageEventInit object and copy all values in the value javascript object.
+func MessageEventInitFromJS(value js.Value) *MessageEventInit {
 	var out MessageEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -197,27 +194,27 @@ func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
 		value6 *Union         // javascript: Union {source Source source}
 		value7 []*MessagePort // javascript: sequence<MessagePort> {ports Ports ports}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("data")
+	value3 = value.Get("data")
 	out.Data = value3
-	value4 = (input.Get("origin")).String()
+	value4 = (value.Get("origin")).String()
 	out.Origin = value4
-	value5 = (input.Get("lastEventId")).String()
+	value5 = (value.Get("lastEventId")).String()
 	out.LastEventId = value5
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value6 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value6 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value6
-	__length7 := input.Get("ports").Length()
+	__length7 := value.Get("ports").Length()
 	__array7 := make([]*MessagePort, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 *MessagePort
-		__seq_in7 := input.Get("ports").Index(__idx7)
+		__seq_in7 := value.Get("ports").Index(__idx7)
 		__seq_out7 = MessagePortFromJS(__seq_in7)
 		__array7[__idx7] = __seq_out7
 	}
@@ -231,7 +228,7 @@ type PostMessageOptions struct {
 	Transfer []*javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PostMessageOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -245,19 +242,17 @@ func (_this *PostMessageOptions) JSValue() js.Value {
 }
 
 // PostMessageOptionsFromJS is allocating a new
-// PostMessageOptions object and copy all values from
-// input javascript object
-func PostMessageOptionsFromJS(value js.Wrapper) *PostMessageOptions {
-	input := value.JSValue()
+// PostMessageOptions object and copy all values in the value javascript object.
+func PostMessageOptionsFromJS(value js.Value) *PostMessageOptions {
 	var out PostMessageOptions
 	var (
 		value0 []*javascript.Object // javascript: sequence<object> {transfer Transfer transfer}
 	)
-	__length0 := input.Get("transfer").Length()
+	__length0 := value.Get("transfer").Length()
 	__array0 := make([]*javascript.Object, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *javascript.Object
-		__seq_in0 := input.Get("transfer").Index(__idx0)
+		__seq_in0 := value.Get("transfer").Index(__idx0)
 		__seq_out0 = javascript.ObjectFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -271,15 +266,19 @@ type BroadcastChannel struct {
 	domcore.EventTarget
 }
 
-// BroadcastChannelFromJS is casting a js.Wrapper into BroadcastChannel.
-func BroadcastChannelFromJS(value js.Wrapper) *BroadcastChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BroadcastChannelFromJS is casting a js.Value into BroadcastChannel.
+func BroadcastChannelFromJS(value js.Value) *BroadcastChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BroadcastChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BroadcastChannelFromJS is casting from something that holds a js.Value into BroadcastChannel.
+func BroadcastChannelFromWrapper(input core.Wrapper) *BroadcastChannel {
+	return BroadcastChannelFromJS(input.JSValue())
 }
 
 func NewBroadcastChannel(name string) (_result *BroadcastChannel) {
@@ -403,15 +402,19 @@ type CloseEvent struct {
 	domcore.Event
 }
 
-// CloseEventFromJS is casting a js.Wrapper into CloseEvent.
-func CloseEventFromJS(value js.Wrapper) *CloseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CloseEventFromJS is casting a js.Value into CloseEvent.
+func CloseEventFromJS(value js.Value) *CloseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CloseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CloseEventFromJS is casting from something that holds a js.Value into CloseEvent.
+func CloseEventFromWrapper(input core.Wrapper) *CloseEvent {
+	return CloseEventFromJS(input.JSValue())
 }
 
 func NewCloseEvent(_type string, eventInitDict *CloseEventInit) (_result *CloseEvent) {
@@ -474,15 +477,19 @@ func (_this *MessageChannel) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MessageChannelFromJS is casting a js.Wrapper into MessageChannel.
-func MessageChannelFromJS(value js.Wrapper) *MessageChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageChannelFromJS is casting a js.Value into MessageChannel.
+func MessageChannelFromJS(value js.Value) *MessageChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageChannelFromJS is casting from something that holds a js.Value into MessageChannel.
+func MessageChannelFromWrapper(input core.Wrapper) *MessageChannel {
+	return MessageChannelFromJS(input.JSValue())
 }
 
 func NewMessageChannel() (_result *MessageChannel) {
@@ -523,15 +530,19 @@ type MessageEvent struct {
 	domcore.Event
 }
 
-// MessageEventFromJS is casting a js.Wrapper into MessageEvent.
-func MessageEventFromJS(value js.Wrapper) *MessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageEventFromJS is casting a js.Value into MessageEvent.
+func MessageEventFromJS(value js.Value) *MessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageEventFromJS is casting from something that holds a js.Value into MessageEvent.
+func MessageEventFromWrapper(input core.Wrapper) *MessageEvent {
+	return MessageEventFromJS(input.JSValue())
 }
 
 func NewMessageEvent(_type string, eventInitDict *MessageEventInit) (_result *MessageEvent) {
@@ -684,15 +695,19 @@ type MessagePort struct {
 	domcore.EventTarget
 }
 
-// MessagePortFromJS is casting a js.Wrapper into MessagePort.
-func MessagePortFromJS(value js.Wrapper) *MessagePort {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessagePortFromJS is casting a js.Value into MessagePort.
+func MessagePortFromJS(value js.Value) *MessagePort {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessagePort{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessagePortFromJS is casting from something that holds a js.Value into MessagePort.
+func MessagePortFromWrapper(input core.Wrapper) *MessagePort {
+	return MessagePortFromJS(input.JSValue())
 }
 
 // OnMessage returning attribute 'onmessage' with
@@ -822,15 +837,19 @@ type WebSocket struct {
 	domcore.EventTarget
 }
 
-// WebSocketFromJS is casting a js.Wrapper into WebSocket.
-func WebSocketFromJS(value js.Wrapper) *WebSocket {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WebSocketFromJS is casting a js.Value into WebSocket.
+func WebSocketFromJS(value js.Value) *WebSocket {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WebSocket{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WebSocketFromJS is casting from something that holds a js.Value into WebSocket.
+func WebSocketFromWrapper(input core.Wrapper) *WebSocket {
+	return WebSocketFromJS(input.JSValue())
 }
 
 const (

--- a/html/datatransfer/datatransfer.go
+++ b/html/datatransfer/datatransfer.go
@@ -7,6 +7,7 @@ package datatransfer
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/file/entries"
@@ -138,15 +139,19 @@ func (_this *DataTransfer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferFromJS is casting a js.Wrapper into DataTransfer.
-func DataTransferFromJS(value js.Wrapper) *DataTransfer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferFromJS is casting a js.Value into DataTransfer.
+func DataTransferFromJS(value js.Value) *DataTransfer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransfer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferFromJS is casting from something that holds a js.Value into DataTransfer.
+func DataTransferFromWrapper(input core.Wrapper) *DataTransfer {
+	return DataTransferFromJS(input.JSValue())
 }
 
 func NewDataTransfer() (_result *DataTransfer) {
@@ -303,15 +308,19 @@ func (_this *DataTransferItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferItemFromJS is casting a js.Wrapper into DataTransferItem.
-func DataTransferItemFromJS(value js.Wrapper) *DataTransferItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferItemFromJS is casting a js.Value into DataTransferItem.
+func DataTransferItemFromJS(value js.Value) *DataTransferItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransferItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferItemFromJS is casting from something that holds a js.Value into DataTransferItem.
+func DataTransferItemFromWrapper(input core.Wrapper) *DataTransferItem {
+	return DataTransferItemFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -393,15 +402,19 @@ func (_this *DataTransferItemList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferItemListFromJS is casting a js.Wrapper into DataTransferItemList.
-func DataTransferItemListFromJS(value js.Wrapper) *DataTransferItemList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferItemListFromJS is casting a js.Value into DataTransferItemList.
+func DataTransferItemListFromJS(value js.Value) *DataTransferItemList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransferItemList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferItemListFromJS is casting from something that holds a js.Value into DataTransferItemList.
+func DataTransferItemListFromWrapper(input core.Wrapper) *DataTransferItemList {
+	return DataTransferItemListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -502,15 +515,19 @@ func (_this *PromiseDataTransfer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDataTransferFromJS is casting a js.Wrapper into PromiseDataTransfer.
-func PromiseDataTransferFromJS(value js.Wrapper) *PromiseDataTransfer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDataTransferFromJS is casting a js.Value into PromiseDataTransfer.
+func PromiseDataTransferFromJS(value js.Value) *PromiseDataTransfer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDataTransfer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDataTransferFromJS is casting from something that holds a js.Value into PromiseDataTransfer.
+func PromiseDataTransferFromWrapper(input core.Wrapper) *PromiseDataTransfer {
+	return PromiseDataTransferFromJS(input.JSValue())
 }
 
 func (_this *PromiseDataTransfer) Then(onFulfilled *PromiseDataTransferOnFulfilled, onRejected *PromiseDataTransferOnRejected) (_result *PromiseDataTransfer) {

--- a/html/datatransfer/datatransfer_js.go
+++ b/html/datatransfer/datatransfer_js.go
@@ -5,6 +5,7 @@ package datatransfer
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/file/entries"
@@ -136,15 +137,19 @@ func (_this *DataTransfer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferFromJS is casting a js.Wrapper into DataTransfer.
-func DataTransferFromJS(value js.Wrapper) *DataTransfer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferFromJS is casting a js.Value into DataTransfer.
+func DataTransferFromJS(value js.Value) *DataTransfer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransfer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferFromJS is casting from something that holds a js.Value into DataTransfer.
+func DataTransferFromWrapper(input core.Wrapper) *DataTransfer {
+	return DataTransferFromJS(input.JSValue())
 }
 
 func NewDataTransfer() (_result *DataTransfer) {
@@ -301,15 +306,19 @@ func (_this *DataTransferItem) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferItemFromJS is casting a js.Wrapper into DataTransferItem.
-func DataTransferItemFromJS(value js.Wrapper) *DataTransferItem {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferItemFromJS is casting a js.Value into DataTransferItem.
+func DataTransferItemFromJS(value js.Value) *DataTransferItem {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransferItem{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferItemFromJS is casting from something that holds a js.Value into DataTransferItem.
+func DataTransferItemFromWrapper(input core.Wrapper) *DataTransferItem {
+	return DataTransferItemFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -391,15 +400,19 @@ func (_this *DataTransferItemList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataTransferItemListFromJS is casting a js.Wrapper into DataTransferItemList.
-func DataTransferItemListFromJS(value js.Wrapper) *DataTransferItemList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataTransferItemListFromJS is casting a js.Value into DataTransferItemList.
+func DataTransferItemListFromJS(value js.Value) *DataTransferItemList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataTransferItemList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataTransferItemListFromJS is casting from something that holds a js.Value into DataTransferItemList.
+func DataTransferItemListFromWrapper(input core.Wrapper) *DataTransferItemList {
+	return DataTransferItemListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -500,15 +513,19 @@ func (_this *PromiseDataTransfer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDataTransferFromJS is casting a js.Wrapper into PromiseDataTransfer.
-func PromiseDataTransferFromJS(value js.Wrapper) *PromiseDataTransfer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDataTransferFromJS is casting a js.Value into PromiseDataTransfer.
+func PromiseDataTransferFromJS(value js.Value) *PromiseDataTransfer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDataTransfer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDataTransferFromJS is casting from something that holds a js.Value into PromiseDataTransfer.
+func PromiseDataTransferFromWrapper(input core.Wrapper) *PromiseDataTransfer {
+	return PromiseDataTransferFromJS(input.JSValue())
 }
 
 func (_this *PromiseDataTransfer) Then(onFulfilled *PromiseDataTransferOnFulfilled, onRejected *PromiseDataTransferOnRejected) (_result *PromiseDataTransfer) {

--- a/html/html.go
+++ b/html/html.go
@@ -9,6 +9,7 @@ import js "github.com/gowebapi/webapi/core/js"
 import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
 	"github.com/gowebapi/webapi/css/cssom"
@@ -316,7 +317,7 @@ type AssignedNodesOptions struct {
 	Flatten bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AssignedNodesOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -326,15 +327,13 @@ func (_this *AssignedNodesOptions) JSValue() js.Value {
 }
 
 // AssignedNodesOptionsFromJS is allocating a new
-// AssignedNodesOptions object and copy all values from
-// input javascript object
-func AssignedNodesOptionsFromJS(value js.Wrapper) *AssignedNodesOptions {
-	input := value.JSValue()
+// AssignedNodesOptions object and copy all values in the value javascript object.
+func AssignedNodesOptionsFromJS(value js.Value) *AssignedNodesOptions {
 	var out AssignedNodesOptions
 	var (
 		value0 bool // javascript: boolean {flatten Flatten flatten}
 	)
-	value0 = (input.Get("flatten")).Bool()
+	value0 = (value.Get("flatten")).Bool()
 	out.Flatten = value0
 	return &out
 }
@@ -344,7 +343,7 @@ type FocusOptions struct {
 	PreventScroll bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FocusOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -354,15 +353,13 @@ func (_this *FocusOptions) JSValue() js.Value {
 }
 
 // FocusOptionsFromJS is allocating a new
-// FocusOptions object and copy all values from
-// input javascript object
-func FocusOptionsFromJS(value js.Wrapper) *FocusOptions {
-	input := value.JSValue()
+// FocusOptions object and copy all values in the value javascript object.
+func FocusOptionsFromJS(value js.Value) *FocusOptions {
 	var out FocusOptions
 	var (
 		value0 bool // javascript: boolean {preventScroll PreventScroll preventScroll}
 	)
-	value0 = (input.Get("preventScroll")).Bool()
+	value0 = (value.Get("preventScroll")).Bool()
 	out.PreventScroll = value0
 	return &out
 }
@@ -373,7 +370,7 @@ type FormDataEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -389,26 +386,24 @@ func (_this *FormDataEntryIteratorValue) JSValue() js.Value {
 }
 
 // FormDataEntryIteratorValueFromJS is allocating a new
-// FormDataEntryIteratorValue object and copy all values from
-// input javascript object
-func FormDataEntryIteratorValueFromJS(value js.Wrapper) *FormDataEntryIteratorValue {
-	input := value.JSValue()
+// FormDataEntryIteratorValue object and copy all values in the value javascript object.
+func FormDataEntryIteratorValueFromJS(value js.Value) *FormDataEntryIteratorValue {
 	var out FormDataEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -421,7 +416,7 @@ type FormDataEventInit struct {
 	FormData   *FormData
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -437,10 +432,8 @@ func (_this *FormDataEventInit) JSValue() js.Value {
 }
 
 // FormDataEventInitFromJS is allocating a new
-// FormDataEventInit object and copy all values from
-// input javascript object
-func FormDataEventInitFromJS(value js.Wrapper) *FormDataEventInit {
-	input := value.JSValue()
+// FormDataEventInit object and copy all values in the value javascript object.
+func FormDataEventInitFromJS(value js.Value) *FormDataEventInit {
 	var out FormDataEventInit
 	var (
 		value0 bool      // javascript: boolean {bubbles Bubbles bubbles}
@@ -448,13 +441,13 @@ func FormDataEventInitFromJS(value js.Wrapper) *FormDataEventInit {
 		value2 bool      // javascript: boolean {composed Composed composed}
 		value3 *FormData // javascript: FormData {formData FormData formData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = FormDataFromJS(input.Get("formData"))
+	value3 = FormDataFromJS(value.Get("formData"))
 	out.FormData = value3
 	return &out
 }
@@ -465,7 +458,7 @@ type FormDataKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -477,18 +470,16 @@ func (_this *FormDataKeyIteratorValue) JSValue() js.Value {
 }
 
 // FormDataKeyIteratorValueFromJS is allocating a new
-// FormDataKeyIteratorValue object and copy all values from
-// input javascript object
-func FormDataKeyIteratorValueFromJS(value js.Wrapper) *FormDataKeyIteratorValue {
-	input := value.JSValue()
+// FormDataKeyIteratorValue object and copy all values in the value javascript object.
+func FormDataKeyIteratorValueFromJS(value js.Value) *FormDataKeyIteratorValue {
 	var out FormDataKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -499,7 +490,7 @@ type FormDataValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -511,18 +502,16 @@ func (_this *FormDataValueIteratorValue) JSValue() js.Value {
 }
 
 // FormDataValueIteratorValueFromJS is allocating a new
-// FormDataValueIteratorValue object and copy all values from
-// input javascript object
-func FormDataValueIteratorValueFromJS(value js.Wrapper) *FormDataValueIteratorValue {
-	input := value.JSValue()
+// FormDataValueIteratorValue object and copy all values in the value javascript object.
+func FormDataValueIteratorValueFromJS(value js.Value) *FormDataValueIteratorValue {
 	var out FormDataValueIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -533,7 +522,7 @@ type ImageEncodeOptions struct {
 	Quality float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageEncodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -545,18 +534,16 @@ func (_this *ImageEncodeOptions) JSValue() js.Value {
 }
 
 // ImageEncodeOptionsFromJS is allocating a new
-// ImageEncodeOptions object and copy all values from
-// input javascript object
-func ImageEncodeOptionsFromJS(value js.Wrapper) *ImageEncodeOptions {
-	input := value.JSValue()
+// ImageEncodeOptions object and copy all values in the value javascript object.
+func ImageEncodeOptionsFromJS(value js.Value) *ImageEncodeOptions {
 	var out ImageEncodeOptions
 	var (
 		value0 string  // javascript: DOMString {type Type _type}
 		value1 float64 // javascript: unrestricted double {quality Quality quality}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("quality")).Float()
+	value1 = (value.Get("quality")).Float()
 	out.Quality = value1
 	return &out
 }
@@ -571,15 +558,19 @@ func (_this *FormData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataFromJS is casting a js.Wrapper into FormData.
-func FormDataFromJS(value js.Wrapper) *FormData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataFromJS is casting a js.Value into FormData.
+func FormDataFromJS(value js.Value) *FormData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataFromJS is casting from something that holds a js.Value into FormData.
+func FormDataFromWrapper(input core.Wrapper) *FormData {
+	return FormDataFromJS(input.JSValue())
 }
 
 func NewFormData(form *HTMLFormElement) (_result *FormData) {
@@ -833,15 +824,19 @@ func (_this *FormDataEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataEntryIteratorFromJS is casting a js.Wrapper into FormDataEntryIterator.
-func FormDataEntryIteratorFromJS(value js.Wrapper) *FormDataEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataEntryIteratorFromJS is casting a js.Value into FormDataEntryIterator.
+func FormDataEntryIteratorFromJS(value js.Value) *FormDataEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataEntryIteratorFromJS is casting from something that holds a js.Value into FormDataEntryIterator.
+func FormDataEntryIteratorFromWrapper(input core.Wrapper) *FormDataEntryIterator {
+	return FormDataEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataEntryIterator) Next() (_result *FormDataEntryIteratorValue) {
@@ -863,15 +858,19 @@ type FormDataEvent struct {
 	domcore.Event
 }
 
-// FormDataEventFromJS is casting a js.Wrapper into FormDataEvent.
-func FormDataEventFromJS(value js.Wrapper) *FormDataEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataEventFromJS is casting a js.Value into FormDataEvent.
+func FormDataEventFromJS(value js.Value) *FormDataEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataEventFromJS is casting from something that holds a js.Value into FormDataEvent.
+func FormDataEventFromWrapper(input core.Wrapper) *FormDataEvent {
+	return FormDataEventFromJS(input.JSValue())
 }
 
 func NewFormDataEvent(_type string, eventInitDict *FormDataEventInit) (_result *FormDataEvent) {
@@ -916,15 +915,19 @@ func (_this *FormDataKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataKeyIteratorFromJS is casting a js.Wrapper into FormDataKeyIterator.
-func FormDataKeyIteratorFromJS(value js.Wrapper) *FormDataKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataKeyIteratorFromJS is casting a js.Value into FormDataKeyIterator.
+func FormDataKeyIteratorFromJS(value js.Value) *FormDataKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataKeyIteratorFromJS is casting from something that holds a js.Value into FormDataKeyIterator.
+func FormDataKeyIteratorFromWrapper(input core.Wrapper) *FormDataKeyIterator {
+	return FormDataKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataKeyIterator) Next() (_result *FormDataKeyIteratorValue) {
@@ -951,15 +954,19 @@ func (_this *FormDataValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataValueIteratorFromJS is casting a js.Wrapper into FormDataValueIterator.
-func FormDataValueIteratorFromJS(value js.Wrapper) *FormDataValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataValueIteratorFromJS is casting a js.Value into FormDataValueIterator.
+func FormDataValueIteratorFromJS(value js.Value) *FormDataValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataValueIteratorFromJS is casting from something that holds a js.Value into FormDataValueIterator.
+func FormDataValueIteratorFromWrapper(input core.Wrapper) *FormDataValueIterator {
+	return FormDataValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataValueIterator) Next() (_result *FormDataValueIteratorValue) {
@@ -986,15 +993,19 @@ func (_this *HTMLAllCollection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HTMLAllCollectionFromJS is casting a js.Wrapper into HTMLAllCollection.
-func HTMLAllCollectionFromJS(value js.Wrapper) *HTMLAllCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAllCollectionFromJS is casting a js.Value into HTMLAllCollection.
+func HTMLAllCollectionFromJS(value js.Value) *HTMLAllCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAllCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAllCollectionFromJS is casting from something that holds a js.Value into HTMLAllCollection.
+func HTMLAllCollectionFromWrapper(input core.Wrapper) *HTMLAllCollection {
+	return HTMLAllCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1093,15 +1104,19 @@ type HTMLAnchorElement struct {
 	HTMLElement
 }
 
-// HTMLAnchorElementFromJS is casting a js.Wrapper into HTMLAnchorElement.
-func HTMLAnchorElementFromJS(value js.Wrapper) *HTMLAnchorElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAnchorElementFromJS is casting a js.Value into HTMLAnchorElement.
+func HTMLAnchorElementFromJS(value js.Value) *HTMLAnchorElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAnchorElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAnchorElementFromJS is casting from something that holds a js.Value into HTMLAnchorElement.
+func HTMLAnchorElementFromWrapper(input core.Wrapper) *HTMLAnchorElement {
+	return HTMLAnchorElementFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -1500,15 +1515,19 @@ type HTMLAreaElement struct {
 	HTMLElement
 }
 
-// HTMLAreaElementFromJS is casting a js.Wrapper into HTMLAreaElement.
-func HTMLAreaElementFromJS(value js.Wrapper) *HTMLAreaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAreaElementFromJS is casting a js.Value into HTMLAreaElement.
+func HTMLAreaElementFromJS(value js.Value) *HTMLAreaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAreaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAreaElementFromJS is casting from something that holds a js.Value into HTMLAreaElement.
+func HTMLAreaElementFromWrapper(input core.Wrapper) *HTMLAreaElement {
+	return HTMLAreaElementFromJS(input.JSValue())
 }
 
 // Alt returning attribute 'alt' with
@@ -1843,15 +1862,19 @@ type HTMLBRElement struct {
 	HTMLElement
 }
 
-// HTMLBRElementFromJS is casting a js.Wrapper into HTMLBRElement.
-func HTMLBRElementFromJS(value js.Wrapper) *HTMLBRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBRElementFromJS is casting a js.Value into HTMLBRElement.
+func HTMLBRElementFromJS(value js.Value) *HTMLBRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBRElementFromJS is casting from something that holds a js.Value into HTMLBRElement.
+func HTMLBRElementFromWrapper(input core.Wrapper) *HTMLBRElement {
+	return HTMLBRElementFromJS(input.JSValue())
 }
 
 // Clear returning attribute 'clear' with
@@ -1875,15 +1898,19 @@ type HTMLBaseElement struct {
 	HTMLElement
 }
 
-// HTMLBaseElementFromJS is casting a js.Wrapper into HTMLBaseElement.
-func HTMLBaseElementFromJS(value js.Wrapper) *HTMLBaseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBaseElementFromJS is casting a js.Value into HTMLBaseElement.
+func HTMLBaseElementFromJS(value js.Value) *HTMLBaseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBaseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBaseElementFromJS is casting from something that holds a js.Value into HTMLBaseElement.
+func HTMLBaseElementFromWrapper(input core.Wrapper) *HTMLBaseElement {
+	return HTMLBaseElementFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1923,15 +1950,19 @@ type HTMLBodyElement struct {
 	HTMLElement
 }
 
-// HTMLBodyElementFromJS is casting a js.Wrapper into HTMLBodyElement.
-func HTMLBodyElementFromJS(value js.Wrapper) *HTMLBodyElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBodyElementFromJS is casting a js.Value into HTMLBodyElement.
+func HTMLBodyElementFromJS(value js.Value) *HTMLBodyElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBodyElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBodyElementFromJS is casting from something that holds a js.Value into HTMLBodyElement.
+func HTMLBodyElementFromWrapper(input core.Wrapper) *HTMLBodyElement {
+	return HTMLBodyElementFromJS(input.JSValue())
 }
 
 // OnOrientationChange returning attribute 'onorientationchange' with
@@ -2606,15 +2637,19 @@ type HTMLButtonElement struct {
 	HTMLElement
 }
 
-// HTMLButtonElementFromJS is casting a js.Wrapper into HTMLButtonElement.
-func HTMLButtonElementFromJS(value js.Wrapper) *HTMLButtonElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLButtonElementFromJS is casting a js.Value into HTMLButtonElement.
+func HTMLButtonElementFromJS(value js.Value) *HTMLButtonElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLButtonElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLButtonElementFromJS is casting from something that holds a js.Value into HTMLButtonElement.
+func HTMLButtonElementFromWrapper(input core.Wrapper) *HTMLButtonElement {
+	return HTMLButtonElementFromJS(input.JSValue())
 }
 
 // Autofocus returning attribute 'autofocus' with
@@ -2869,15 +2904,19 @@ type HTMLDListElement struct {
 	HTMLElement
 }
 
-// HTMLDListElementFromJS is casting a js.Wrapper into HTMLDListElement.
-func HTMLDListElementFromJS(value js.Wrapper) *HTMLDListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDListElementFromJS is casting a js.Value into HTMLDListElement.
+func HTMLDListElementFromJS(value js.Value) *HTMLDListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDListElementFromJS is casting from something that holds a js.Value into HTMLDListElement.
+func HTMLDListElementFromWrapper(input core.Wrapper) *HTMLDListElement {
+	return HTMLDListElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -2901,15 +2940,19 @@ type HTMLDataElement struct {
 	HTMLElement
 }
 
-// HTMLDataElementFromJS is casting a js.Wrapper into HTMLDataElement.
-func HTMLDataElementFromJS(value js.Wrapper) *HTMLDataElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDataElementFromJS is casting a js.Value into HTMLDataElement.
+func HTMLDataElementFromJS(value js.Value) *HTMLDataElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDataElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDataElementFromJS is casting from something that holds a js.Value into HTMLDataElement.
+func HTMLDataElementFromWrapper(input core.Wrapper) *HTMLDataElement {
+	return HTMLDataElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -2933,15 +2976,19 @@ type HTMLDataListElement struct {
 	HTMLElement
 }
 
-// HTMLDataListElementFromJS is casting a js.Wrapper into HTMLDataListElement.
-func HTMLDataListElementFromJS(value js.Wrapper) *HTMLDataListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDataListElementFromJS is casting a js.Value into HTMLDataListElement.
+func HTMLDataListElementFromJS(value js.Value) *HTMLDataListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDataListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDataListElementFromJS is casting from something that holds a js.Value into HTMLDataListElement.
+func HTMLDataListElementFromWrapper(input core.Wrapper) *HTMLDataListElement {
+	return HTMLDataListElementFromJS(input.JSValue())
 }
 
 // Options returning attribute 'options' with
@@ -2958,15 +3005,19 @@ type HTMLDetailsElement struct {
 	HTMLElement
 }
 
-// HTMLDetailsElementFromJS is casting a js.Wrapper into HTMLDetailsElement.
-func HTMLDetailsElementFromJS(value js.Wrapper) *HTMLDetailsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDetailsElementFromJS is casting a js.Value into HTMLDetailsElement.
+func HTMLDetailsElementFromJS(value js.Value) *HTMLDetailsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDetailsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDetailsElementFromJS is casting from something that holds a js.Value into HTMLDetailsElement.
+func HTMLDetailsElementFromWrapper(input core.Wrapper) *HTMLDetailsElement {
+	return HTMLDetailsElementFromJS(input.JSValue())
 }
 
 // Open returning attribute 'open' with
@@ -2990,15 +3041,19 @@ type HTMLDialogElement struct {
 	HTMLElement
 }
 
-// HTMLDialogElementFromJS is casting a js.Wrapper into HTMLDialogElement.
-func HTMLDialogElementFromJS(value js.Wrapper) *HTMLDialogElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDialogElementFromJS is casting a js.Value into HTMLDialogElement.
+func HTMLDialogElementFromJS(value js.Value) *HTMLDialogElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDialogElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDialogElementFromJS is casting from something that holds a js.Value into HTMLDialogElement.
+func HTMLDialogElementFromWrapper(input core.Wrapper) *HTMLDialogElement {
+	return HTMLDialogElementFromJS(input.JSValue())
 }
 
 // Open returning attribute 'open' with
@@ -3076,15 +3131,19 @@ type HTMLDirectoryElement struct {
 	HTMLElement
 }
 
-// HTMLDirectoryElementFromJS is casting a js.Wrapper into HTMLDirectoryElement.
-func HTMLDirectoryElementFromJS(value js.Wrapper) *HTMLDirectoryElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDirectoryElementFromJS is casting a js.Value into HTMLDirectoryElement.
+func HTMLDirectoryElementFromJS(value js.Value) *HTMLDirectoryElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDirectoryElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDirectoryElementFromJS is casting from something that holds a js.Value into HTMLDirectoryElement.
+func HTMLDirectoryElementFromWrapper(input core.Wrapper) *HTMLDirectoryElement {
+	return HTMLDirectoryElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -3108,15 +3167,19 @@ type HTMLDivElement struct {
 	HTMLElement
 }
 
-// HTMLDivElementFromJS is casting a js.Wrapper into HTMLDivElement.
-func HTMLDivElementFromJS(value js.Wrapper) *HTMLDivElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDivElementFromJS is casting a js.Value into HTMLDivElement.
+func HTMLDivElementFromJS(value js.Value) *HTMLDivElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDivElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDivElementFromJS is casting from something that holds a js.Value into HTMLDivElement.
+func HTMLDivElementFromWrapper(input core.Wrapper) *HTMLDivElement {
+	return HTMLDivElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -3140,15 +3203,19 @@ type HTMLElement struct {
 	dom.Element
 }
 
-// HTMLElementFromJS is casting a js.Wrapper into HTMLElement.
-func HTMLElementFromJS(value js.Wrapper) *HTMLElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLElementFromJS is casting a js.Value into HTMLElement.
+func HTMLElementFromJS(value js.Value) *HTMLElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLElementFromJS is casting from something that holds a js.Value into HTMLElement.
+func HTMLElementFromWrapper(input core.Wrapper) *HTMLElement {
+	return HTMLElementFromJS(input.JSValue())
 }
 
 // Title returning attribute 'title' with
@@ -6174,15 +6241,19 @@ type HTMLFieldSetElement struct {
 	HTMLElement
 }
 
-// HTMLFieldSetElementFromJS is casting a js.Wrapper into HTMLFieldSetElement.
-func HTMLFieldSetElementFromJS(value js.Wrapper) *HTMLFieldSetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFieldSetElementFromJS is casting a js.Value into HTMLFieldSetElement.
+func HTMLFieldSetElementFromJS(value js.Value) *HTMLFieldSetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFieldSetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFieldSetElementFromJS is casting from something that holds a js.Value into HTMLFieldSetElement.
+func HTMLFieldSetElementFromWrapper(input core.Wrapper) *HTMLFieldSetElement {
+	return HTMLFieldSetElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -6318,15 +6389,19 @@ type HTMLFontElement struct {
 	HTMLElement
 }
 
-// HTMLFontElementFromJS is casting a js.Wrapper into HTMLFontElement.
-func HTMLFontElementFromJS(value js.Wrapper) *HTMLFontElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFontElementFromJS is casting a js.Value into HTMLFontElement.
+func HTMLFontElementFromJS(value js.Value) *HTMLFontElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFontElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFontElementFromJS is casting from something that holds a js.Value into HTMLFontElement.
+func HTMLFontElementFromWrapper(input core.Wrapper) *HTMLFontElement {
+	return HTMLFontElementFromJS(input.JSValue())
 }
 
 // Color returning attribute 'color' with
@@ -6382,15 +6457,19 @@ type HTMLFormControlsCollection struct {
 	dom.HTMLCollection
 }
 
-// HTMLFormControlsCollectionFromJS is casting a js.Wrapper into HTMLFormControlsCollection.
-func HTMLFormControlsCollectionFromJS(value js.Wrapper) *HTMLFormControlsCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFormControlsCollectionFromJS is casting a js.Value into HTMLFormControlsCollection.
+func HTMLFormControlsCollectionFromJS(value js.Value) *HTMLFormControlsCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFormControlsCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFormControlsCollectionFromJS is casting from something that holds a js.Value into HTMLFormControlsCollection.
+func HTMLFormControlsCollectionFromWrapper(input core.Wrapper) *HTMLFormControlsCollection {
+	return HTMLFormControlsCollectionFromJS(input.JSValue())
 }
 
 func (_this *HTMLFormControlsCollection) Get2(name string) (_result *Union) {
@@ -6436,15 +6515,19 @@ type HTMLFormElement struct {
 	HTMLElement
 }
 
-// HTMLFormElementFromJS is casting a js.Wrapper into HTMLFormElement.
-func HTMLFormElementFromJS(value js.Wrapper) *HTMLFormElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFormElementFromJS is casting a js.Value into HTMLFormElement.
+func HTMLFormElementFromJS(value js.Value) *HTMLFormElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFormElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFormElementFromJS is casting from something that holds a js.Value into HTMLFormElement.
+func HTMLFormElementFromWrapper(input core.Wrapper) *HTMLFormElement {
+	return HTMLFormElementFromJS(input.JSValue())
 }
 
 // AcceptCharset returning attribute 'acceptCharset' with
@@ -6719,15 +6802,19 @@ type HTMLFrameSetElement struct {
 	HTMLElement
 }
 
-// HTMLFrameSetElementFromJS is casting a js.Wrapper into HTMLFrameSetElement.
-func HTMLFrameSetElementFromJS(value js.Wrapper) *HTMLFrameSetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFrameSetElementFromJS is casting a js.Value into HTMLFrameSetElement.
+func HTMLFrameSetElementFromJS(value js.Value) *HTMLFrameSetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFrameSetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFrameSetElementFromJS is casting from something that holds a js.Value into HTMLFrameSetElement.
+func HTMLFrameSetElementFromWrapper(input core.Wrapper) *HTMLFrameSetElement {
+	return HTMLFrameSetElementFromJS(input.JSValue())
 }
 
 // Cols returning attribute 'cols' with
@@ -7311,15 +7398,19 @@ type HTMLHRElement struct {
 	HTMLElement
 }
 
-// HTMLHRElementFromJS is casting a js.Wrapper into HTMLHRElement.
-func HTMLHRElementFromJS(value js.Wrapper) *HTMLHRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHRElementFromJS is casting a js.Value into HTMLHRElement.
+func HTMLHRElementFromJS(value js.Value) *HTMLHRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHRElementFromJS is casting from something that holds a js.Value into HTMLHRElement.
+func HTMLHRElementFromWrapper(input core.Wrapper) *HTMLHRElement {
+	return HTMLHRElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -7407,15 +7498,19 @@ type HTMLHeadElement struct {
 	HTMLElement
 }
 
-// HTMLHeadElementFromJS is casting a js.Wrapper into HTMLHeadElement.
-func HTMLHeadElementFromJS(value js.Wrapper) *HTMLHeadElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHeadElementFromJS is casting a js.Value into HTMLHeadElement.
+func HTMLHeadElementFromJS(value js.Value) *HTMLHeadElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHeadElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHeadElementFromJS is casting from something that holds a js.Value into HTMLHeadElement.
+func HTMLHeadElementFromWrapper(input core.Wrapper) *HTMLHeadElement {
+	return HTMLHeadElementFromJS(input.JSValue())
 }
 
 // class: HTMLHeadingElement
@@ -7423,15 +7518,19 @@ type HTMLHeadingElement struct {
 	HTMLElement
 }
 
-// HTMLHeadingElementFromJS is casting a js.Wrapper into HTMLHeadingElement.
-func HTMLHeadingElementFromJS(value js.Wrapper) *HTMLHeadingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHeadingElementFromJS is casting a js.Value into HTMLHeadingElement.
+func HTMLHeadingElementFromJS(value js.Value) *HTMLHeadingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHeadingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHeadingElementFromJS is casting from something that holds a js.Value into HTMLHeadingElement.
+func HTMLHeadingElementFromWrapper(input core.Wrapper) *HTMLHeadingElement {
+	return HTMLHeadingElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -7455,15 +7554,19 @@ type HTMLHtmlElement struct {
 	HTMLElement
 }
 
-// HTMLHtmlElementFromJS is casting a js.Wrapper into HTMLHtmlElement.
-func HTMLHtmlElementFromJS(value js.Wrapper) *HTMLHtmlElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHtmlElementFromJS is casting a js.Value into HTMLHtmlElement.
+func HTMLHtmlElementFromJS(value js.Value) *HTMLHtmlElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHtmlElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHtmlElementFromJS is casting from something that holds a js.Value into HTMLHtmlElement.
+func HTMLHtmlElementFromWrapper(input core.Wrapper) *HTMLHtmlElement {
+	return HTMLHtmlElementFromJS(input.JSValue())
 }
 
 // Version returning attribute 'version' with
@@ -7487,15 +7590,19 @@ type HTMLImageElement struct {
 	HTMLElement
 }
 
-// HTMLImageElementFromJS is casting a js.Wrapper into HTMLImageElement.
-func HTMLImageElementFromJS(value js.Wrapper) *HTMLImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLImageElementFromJS is casting a js.Value into HTMLImageElement.
+func HTMLImageElementFromJS(value js.Value) *HTMLImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLImageElementFromJS is casting from something that holds a js.Value into HTMLImageElement.
+func HTMLImageElementFromWrapper(input core.Wrapper) *HTMLImageElement {
+	return HTMLImageElementFromJS(input.JSValue())
 }
 
 // Alt returning attribute 'alt' with
@@ -7867,15 +7974,19 @@ type HTMLInputElement struct {
 	HTMLElement
 }
 
-// HTMLInputElementFromJS is casting a js.Wrapper into HTMLInputElement.
-func HTMLInputElementFromJS(value js.Wrapper) *HTMLInputElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLInputElementFromJS is casting a js.Value into HTMLInputElement.
+func HTMLInputElementFromJS(value js.Value) *HTMLInputElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLInputElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLInputElementFromJS is casting from something that holds a js.Value into HTMLInputElement.
+func HTMLInputElementFromWrapper(input core.Wrapper) *HTMLInputElement {
+	return HTMLInputElementFromJS(input.JSValue())
 }
 
 // Accept returning attribute 'accept' with
@@ -8802,15 +8913,19 @@ type HTMLLIElement struct {
 	HTMLElement
 }
 
-// HTMLLIElementFromJS is casting a js.Wrapper into HTMLLIElement.
-func HTMLLIElementFromJS(value js.Wrapper) *HTMLLIElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLIElementFromJS is casting a js.Value into HTMLLIElement.
+func HTMLLIElementFromJS(value js.Value) *HTMLLIElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLIElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLIElementFromJS is casting from something that holds a js.Value into HTMLLIElement.
+func HTMLLIElementFromWrapper(input core.Wrapper) *HTMLLIElement {
+	return HTMLLIElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -8850,15 +8965,19 @@ type HTMLLabelElement struct {
 	HTMLElement
 }
 
-// HTMLLabelElementFromJS is casting a js.Wrapper into HTMLLabelElement.
-func HTMLLabelElementFromJS(value js.Wrapper) *HTMLLabelElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLabelElementFromJS is casting a js.Value into HTMLLabelElement.
+func HTMLLabelElementFromJS(value js.Value) *HTMLLabelElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLabelElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLabelElementFromJS is casting from something that holds a js.Value into HTMLLabelElement.
+func HTMLLabelElementFromWrapper(input core.Wrapper) *HTMLLabelElement {
+	return HTMLLabelElementFromJS(input.JSValue())
 }
 
 // Form returning attribute 'form' with
@@ -8904,15 +9023,19 @@ type HTMLLegendElement struct {
 	HTMLElement
 }
 
-// HTMLLegendElementFromJS is casting a js.Wrapper into HTMLLegendElement.
-func HTMLLegendElementFromJS(value js.Wrapper) *HTMLLegendElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLegendElementFromJS is casting a js.Value into HTMLLegendElement.
+func HTMLLegendElementFromJS(value js.Value) *HTMLLegendElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLegendElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLegendElementFromJS is casting from something that holds a js.Value into HTMLLegendElement.
+func HTMLLegendElementFromWrapper(input core.Wrapper) *HTMLLegendElement {
+	return HTMLLegendElementFromJS(input.JSValue())
 }
 
 // Form returning attribute 'form' with
@@ -8947,15 +9070,19 @@ type HTMLLinkElement struct {
 	HTMLElement
 }
 
-// HTMLLinkElementFromJS is casting a js.Wrapper into HTMLLinkElement.
-func HTMLLinkElementFromJS(value js.Wrapper) *HTMLLinkElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLinkElementFromJS is casting a js.Value into HTMLLinkElement.
+func HTMLLinkElementFromJS(value js.Value) *HTMLLinkElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLinkElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLinkElementFromJS is casting from something that holds a js.Value into HTMLLinkElement.
+func HTMLLinkElementFromWrapper(input core.Wrapper) *HTMLLinkElement {
+	return HTMLLinkElementFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -9192,15 +9319,19 @@ type HTMLMapElement struct {
 	HTMLElement
 }
 
-// HTMLMapElementFromJS is casting a js.Wrapper into HTMLMapElement.
-func HTMLMapElementFromJS(value js.Wrapper) *HTMLMapElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMapElementFromJS is casting a js.Value into HTMLMapElement.
+func HTMLMapElementFromJS(value js.Value) *HTMLMapElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMapElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMapElementFromJS is casting from something that holds a js.Value into HTMLMapElement.
+func HTMLMapElementFromWrapper(input core.Wrapper) *HTMLMapElement {
+	return HTMLMapElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -9233,15 +9364,19 @@ type HTMLMarqueeElement struct {
 	HTMLElement
 }
 
-// HTMLMarqueeElementFromJS is casting a js.Wrapper into HTMLMarqueeElement.
-func HTMLMarqueeElementFromJS(value js.Wrapper) *HTMLMarqueeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMarqueeElementFromJS is casting a js.Value into HTMLMarqueeElement.
+func HTMLMarqueeElementFromJS(value js.Value) *HTMLMarqueeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMarqueeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMarqueeElementFromJS is casting from something that holds a js.Value into HTMLMarqueeElement.
+func HTMLMarqueeElementFromWrapper(input core.Wrapper) *HTMLMarqueeElement {
+	return HTMLMarqueeElementFromJS(input.JSValue())
 }
 
 // Behavior returning attribute 'behavior' with
@@ -9538,15 +9673,19 @@ type HTMLMenuElement struct {
 	HTMLElement
 }
 
-// HTMLMenuElementFromJS is casting a js.Wrapper into HTMLMenuElement.
-func HTMLMenuElementFromJS(value js.Wrapper) *HTMLMenuElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMenuElementFromJS is casting a js.Value into HTMLMenuElement.
+func HTMLMenuElementFromJS(value js.Value) *HTMLMenuElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMenuElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMenuElementFromJS is casting from something that holds a js.Value into HTMLMenuElement.
+func HTMLMenuElementFromWrapper(input core.Wrapper) *HTMLMenuElement {
+	return HTMLMenuElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -9570,15 +9709,19 @@ type HTMLMetaElement struct {
 	HTMLElement
 }
 
-// HTMLMetaElementFromJS is casting a js.Wrapper into HTMLMetaElement.
-func HTMLMetaElementFromJS(value js.Wrapper) *HTMLMetaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMetaElementFromJS is casting a js.Value into HTMLMetaElement.
+func HTMLMetaElementFromJS(value js.Value) *HTMLMetaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMetaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMetaElementFromJS is casting from something that holds a js.Value into HTMLMetaElement.
+func HTMLMetaElementFromWrapper(input core.Wrapper) *HTMLMetaElement {
+	return HTMLMetaElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -9650,15 +9793,19 @@ type HTMLMeterElement struct {
 	HTMLElement
 }
 
-// HTMLMeterElementFromJS is casting a js.Wrapper into HTMLMeterElement.
-func HTMLMeterElementFromJS(value js.Wrapper) *HTMLMeterElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMeterElementFromJS is casting a js.Value into HTMLMeterElement.
+func HTMLMeterElementFromJS(value js.Value) *HTMLMeterElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMeterElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMeterElementFromJS is casting from something that holds a js.Value into HTMLMeterElement.
+func HTMLMeterElementFromWrapper(input core.Wrapper) *HTMLMeterElement {
+	return HTMLMeterElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -9771,15 +9918,19 @@ type HTMLModElement struct {
 	HTMLElement
 }
 
-// HTMLModElementFromJS is casting a js.Wrapper into HTMLModElement.
-func HTMLModElementFromJS(value js.Wrapper) *HTMLModElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLModElementFromJS is casting a js.Value into HTMLModElement.
+func HTMLModElementFromJS(value js.Value) *HTMLModElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLModElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLModElementFromJS is casting from something that holds a js.Value into HTMLModElement.
+func HTMLModElementFromWrapper(input core.Wrapper) *HTMLModElement {
+	return HTMLModElementFromJS(input.JSValue())
 }
 
 // Cite returning attribute 'cite' with
@@ -9819,15 +9970,19 @@ type HTMLOListElement struct {
 	HTMLElement
 }
 
-// HTMLOListElementFromJS is casting a js.Wrapper into HTMLOListElement.
-func HTMLOListElementFromJS(value js.Wrapper) *HTMLOListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOListElementFromJS is casting a js.Value into HTMLOListElement.
+func HTMLOListElementFromJS(value js.Value) *HTMLOListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOListElementFromJS is casting from something that holds a js.Value into HTMLOListElement.
+func HTMLOListElementFromWrapper(input core.Wrapper) *HTMLOListElement {
+	return HTMLOListElementFromJS(input.JSValue())
 }
 
 // Reversed returning attribute 'reversed' with
@@ -9899,15 +10054,19 @@ type HTMLOptGroupElement struct {
 	HTMLElement
 }
 
-// HTMLOptGroupElementFromJS is casting a js.Wrapper into HTMLOptGroupElement.
-func HTMLOptGroupElementFromJS(value js.Wrapper) *HTMLOptGroupElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptGroupElementFromJS is casting a js.Value into HTMLOptGroupElement.
+func HTMLOptGroupElementFromJS(value js.Value) *HTMLOptGroupElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptGroupElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptGroupElementFromJS is casting from something that holds a js.Value into HTMLOptGroupElement.
+func HTMLOptGroupElementFromWrapper(input core.Wrapper) *HTMLOptGroupElement {
+	return HTMLOptGroupElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -9947,15 +10106,19 @@ type HTMLOptionElement struct {
 	HTMLElement
 }
 
-// HTMLOptionElementFromJS is casting a js.Wrapper into HTMLOptionElement.
-func HTMLOptionElementFromJS(value js.Wrapper) *HTMLOptionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptionElementFromJS is casting a js.Value into HTMLOptionElement.
+func HTMLOptionElementFromJS(value js.Value) *HTMLOptionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptionElementFromJS is casting from something that holds a js.Value into HTMLOptionElement.
+func HTMLOptionElementFromWrapper(input core.Wrapper) *HTMLOptionElement {
+	return HTMLOptionElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -10079,15 +10242,19 @@ type HTMLOptionsCollection struct {
 	dom.HTMLCollection
 }
 
-// HTMLOptionsCollectionFromJS is casting a js.Wrapper into HTMLOptionsCollection.
-func HTMLOptionsCollectionFromJS(value js.Wrapper) *HTMLOptionsCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptionsCollectionFromJS is casting a js.Value into HTMLOptionsCollection.
+func HTMLOptionsCollectionFromJS(value js.Value) *HTMLOptionsCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptionsCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptionsCollectionFromJS is casting from something that holds a js.Value into HTMLOptionsCollection.
+func HTMLOptionsCollectionFromWrapper(input core.Wrapper) *HTMLOptionsCollection {
+	return HTMLOptionsCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -10171,15 +10338,19 @@ type HTMLOutputElement struct {
 	HTMLElement
 }
 
-// HTMLOutputElementFromJS is casting a js.Wrapper into HTMLOutputElement.
-func HTMLOutputElementFromJS(value js.Wrapper) *HTMLOutputElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOutputElementFromJS is casting a js.Value into HTMLOutputElement.
+func HTMLOutputElementFromJS(value js.Value) *HTMLOutputElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOutputElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOutputElementFromJS is casting from something that holds a js.Value into HTMLOutputElement.
+func HTMLOutputElementFromWrapper(input core.Wrapper) *HTMLOutputElement {
+	return HTMLOutputElementFromJS(input.JSValue())
 }
 
 // HtmlFor returning attribute 'htmlFor' with
@@ -10340,15 +10511,19 @@ type HTMLParagraphElement struct {
 	HTMLElement
 }
 
-// HTMLParagraphElementFromJS is casting a js.Wrapper into HTMLParagraphElement.
-func HTMLParagraphElementFromJS(value js.Wrapper) *HTMLParagraphElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLParagraphElementFromJS is casting a js.Value into HTMLParagraphElement.
+func HTMLParagraphElementFromJS(value js.Value) *HTMLParagraphElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLParagraphElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLParagraphElementFromJS is casting from something that holds a js.Value into HTMLParagraphElement.
+func HTMLParagraphElementFromWrapper(input core.Wrapper) *HTMLParagraphElement {
+	return HTMLParagraphElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -10372,15 +10547,19 @@ type HTMLParamElement struct {
 	HTMLElement
 }
 
-// HTMLParamElementFromJS is casting a js.Wrapper into HTMLParamElement.
-func HTMLParamElementFromJS(value js.Wrapper) *HTMLParamElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLParamElementFromJS is casting a js.Value into HTMLParamElement.
+func HTMLParamElementFromJS(value js.Value) *HTMLParamElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLParamElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLParamElementFromJS is casting from something that holds a js.Value into HTMLParamElement.
+func HTMLParamElementFromWrapper(input core.Wrapper) *HTMLParamElement {
+	return HTMLParamElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -10452,15 +10631,19 @@ type HTMLPictureElement struct {
 	HTMLElement
 }
 
-// HTMLPictureElementFromJS is casting a js.Wrapper into HTMLPictureElement.
-func HTMLPictureElementFromJS(value js.Wrapper) *HTMLPictureElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLPictureElementFromJS is casting a js.Value into HTMLPictureElement.
+func HTMLPictureElementFromJS(value js.Value) *HTMLPictureElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLPictureElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLPictureElementFromJS is casting from something that holds a js.Value into HTMLPictureElement.
+func HTMLPictureElementFromWrapper(input core.Wrapper) *HTMLPictureElement {
+	return HTMLPictureElementFromJS(input.JSValue())
 }
 
 // class: HTMLPreElement
@@ -10468,15 +10651,19 @@ type HTMLPreElement struct {
 	HTMLElement
 }
 
-// HTMLPreElementFromJS is casting a js.Wrapper into HTMLPreElement.
-func HTMLPreElementFromJS(value js.Wrapper) *HTMLPreElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLPreElementFromJS is casting a js.Value into HTMLPreElement.
+func HTMLPreElementFromJS(value js.Value) *HTMLPreElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLPreElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLPreElementFromJS is casting from something that holds a js.Value into HTMLPreElement.
+func HTMLPreElementFromWrapper(input core.Wrapper) *HTMLPreElement {
+	return HTMLPreElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -10500,15 +10687,19 @@ type HTMLProgressElement struct {
 	HTMLElement
 }
 
-// HTMLProgressElementFromJS is casting a js.Wrapper into HTMLProgressElement.
-func HTMLProgressElementFromJS(value js.Wrapper) *HTMLProgressElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLProgressElementFromJS is casting a js.Value into HTMLProgressElement.
+func HTMLProgressElementFromJS(value js.Value) *HTMLProgressElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLProgressElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLProgressElementFromJS is casting from something that holds a js.Value into HTMLProgressElement.
+func HTMLProgressElementFromWrapper(input core.Wrapper) *HTMLProgressElement {
+	return HTMLProgressElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -10566,15 +10757,19 @@ type HTMLQuoteElement struct {
 	HTMLElement
 }
 
-// HTMLQuoteElementFromJS is casting a js.Wrapper into HTMLQuoteElement.
-func HTMLQuoteElementFromJS(value js.Wrapper) *HTMLQuoteElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLQuoteElementFromJS is casting a js.Value into HTMLQuoteElement.
+func HTMLQuoteElementFromJS(value js.Value) *HTMLQuoteElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLQuoteElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLQuoteElementFromJS is casting from something that holds a js.Value into HTMLQuoteElement.
+func HTMLQuoteElementFromWrapper(input core.Wrapper) *HTMLQuoteElement {
+	return HTMLQuoteElementFromJS(input.JSValue())
 }
 
 // Cite returning attribute 'cite' with
@@ -10598,15 +10793,19 @@ type HTMLScriptElement struct {
 	HTMLElement
 }
 
-// HTMLScriptElementFromJS is casting a js.Wrapper into HTMLScriptElement.
-func HTMLScriptElementFromJS(value js.Wrapper) *HTMLScriptElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLScriptElementFromJS is casting a js.Value into HTMLScriptElement.
+func HTMLScriptElementFromJS(value js.Value) *HTMLScriptElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLScriptElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLScriptElementFromJS is casting from something that holds a js.Value into HTMLScriptElement.
+func HTMLScriptElementFromWrapper(input core.Wrapper) *HTMLScriptElement {
+	return HTMLScriptElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -10814,15 +11013,19 @@ type HTMLSelectElement struct {
 	HTMLElement
 }
 
-// HTMLSelectElementFromJS is casting a js.Wrapper into HTMLSelectElement.
-func HTMLSelectElementFromJS(value js.Wrapper) *HTMLSelectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSelectElementFromJS is casting a js.Value into HTMLSelectElement.
+func HTMLSelectElementFromJS(value js.Value) *HTMLSelectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSelectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSelectElementFromJS is casting from something that holds a js.Value into HTMLSelectElement.
+func HTMLSelectElementFromWrapper(input core.Wrapper) *HTMLSelectElement {
+	return HTMLSelectElementFromJS(input.JSValue())
 }
 
 // Autocomplete returning attribute 'autocomplete' with
@@ -11214,15 +11417,19 @@ type HTMLSlotElement struct {
 	HTMLElement
 }
 
-// HTMLSlotElementFromJS is casting a js.Wrapper into HTMLSlotElement.
-func HTMLSlotElementFromJS(value js.Wrapper) *HTMLSlotElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSlotElementFromJS is casting a js.Value into HTMLSlotElement.
+func HTMLSlotElementFromJS(value js.Value) *HTMLSlotElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSlotElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSlotElementFromJS is casting from something that holds a js.Value into HTMLSlotElement.
+func HTMLSlotElementFromWrapper(input core.Wrapper) *HTMLSlotElement {
+	return HTMLSlotElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -11300,15 +11507,19 @@ type HTMLSourceElement struct {
 	HTMLElement
 }
 
-// HTMLSourceElementFromJS is casting a js.Wrapper into HTMLSourceElement.
-func HTMLSourceElementFromJS(value js.Wrapper) *HTMLSourceElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSourceElementFromJS is casting a js.Value into HTMLSourceElement.
+func HTMLSourceElementFromJS(value js.Value) *HTMLSourceElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSourceElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSourceElementFromJS is casting from something that holds a js.Value into HTMLSourceElement.
+func HTMLSourceElementFromWrapper(input core.Wrapper) *HTMLSourceElement {
+	return HTMLSourceElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -11396,15 +11607,19 @@ type HTMLSpanElement struct {
 	HTMLElement
 }
 
-// HTMLSpanElementFromJS is casting a js.Wrapper into HTMLSpanElement.
-func HTMLSpanElementFromJS(value js.Wrapper) *HTMLSpanElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSpanElementFromJS is casting a js.Value into HTMLSpanElement.
+func HTMLSpanElementFromJS(value js.Value) *HTMLSpanElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSpanElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSpanElementFromJS is casting from something that holds a js.Value into HTMLSpanElement.
+func HTMLSpanElementFromWrapper(input core.Wrapper) *HTMLSpanElement {
+	return HTMLSpanElementFromJS(input.JSValue())
 }
 
 // class: HTMLStyleElement
@@ -11412,15 +11627,19 @@ type HTMLStyleElement struct {
 	HTMLElement
 }
 
-// HTMLStyleElementFromJS is casting a js.Wrapper into HTMLStyleElement.
-func HTMLStyleElementFromJS(value js.Wrapper) *HTMLStyleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLStyleElementFromJS is casting a js.Value into HTMLStyleElement.
+func HTMLStyleElementFromJS(value js.Value) *HTMLStyleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLStyleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLStyleElementFromJS is casting from something that holds a js.Value into HTMLStyleElement.
+func HTMLStyleElementFromWrapper(input core.Wrapper) *HTMLStyleElement {
+	return HTMLStyleElementFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -11471,15 +11690,19 @@ type HTMLTableCaptionElement struct {
 	HTMLElement
 }
 
-// HTMLTableCaptionElementFromJS is casting a js.Wrapper into HTMLTableCaptionElement.
-func HTMLTableCaptionElementFromJS(value js.Wrapper) *HTMLTableCaptionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableCaptionElementFromJS is casting a js.Value into HTMLTableCaptionElement.
+func HTMLTableCaptionElementFromJS(value js.Value) *HTMLTableCaptionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableCaptionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableCaptionElementFromJS is casting from something that holds a js.Value into HTMLTableCaptionElement.
+func HTMLTableCaptionElementFromWrapper(input core.Wrapper) *HTMLTableCaptionElement {
+	return HTMLTableCaptionElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -11503,15 +11726,19 @@ type HTMLTableCellElement struct {
 	HTMLElement
 }
 
-// HTMLTableCellElementFromJS is casting a js.Wrapper into HTMLTableCellElement.
-func HTMLTableCellElementFromJS(value js.Wrapper) *HTMLTableCellElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableCellElementFromJS is casting a js.Value into HTMLTableCellElement.
+func HTMLTableCellElementFromJS(value js.Value) *HTMLTableCellElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableCellElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableCellElementFromJS is casting from something that holds a js.Value into HTMLTableCellElement.
+func HTMLTableCellElementFromWrapper(input core.Wrapper) *HTMLTableCellElement {
+	return HTMLTableCellElementFromJS(input.JSValue())
 }
 
 // ColSpan returning attribute 'colSpan' with
@@ -11752,15 +11979,19 @@ type HTMLTableColElement struct {
 	HTMLElement
 }
 
-// HTMLTableColElementFromJS is casting a js.Wrapper into HTMLTableColElement.
-func HTMLTableColElementFromJS(value js.Wrapper) *HTMLTableColElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableColElementFromJS is casting a js.Value into HTMLTableColElement.
+func HTMLTableColElementFromJS(value js.Value) *HTMLTableColElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableColElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableColElementFromJS is casting from something that holds a js.Value into HTMLTableColElement.
+func HTMLTableColElementFromWrapper(input core.Wrapper) *HTMLTableColElement {
+	return HTMLTableColElementFromJS(input.JSValue())
 }
 
 // Span returning attribute 'span' with
@@ -11864,15 +12095,19 @@ type HTMLTableElement struct {
 	HTMLElement
 }
 
-// HTMLTableElementFromJS is casting a js.Wrapper into HTMLTableElement.
-func HTMLTableElementFromJS(value js.Wrapper) *HTMLTableElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableElementFromJS is casting a js.Value into HTMLTableElement.
+func HTMLTableElementFromJS(value js.Value) *HTMLTableElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableElementFromJS is casting from something that holds a js.Value into HTMLTableElement.
+func HTMLTableElementFromWrapper(input core.Wrapper) *HTMLTableElement {
+	return HTMLTableElementFromJS(input.JSValue())
 }
 
 // Caption returning attribute 'caption' with
@@ -12216,15 +12451,19 @@ type HTMLTableRowElement struct {
 	HTMLElement
 }
 
-// HTMLTableRowElementFromJS is casting a js.Wrapper into HTMLTableRowElement.
-func HTMLTableRowElementFromJS(value js.Wrapper) *HTMLTableRowElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableRowElementFromJS is casting a js.Value into HTMLTableRowElement.
+func HTMLTableRowElementFromJS(value js.Value) *HTMLTableRowElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableRowElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableRowElementFromJS is casting from something that holds a js.Value into HTMLTableRowElement.
+func HTMLTableRowElementFromWrapper(input core.Wrapper) *HTMLTableRowElement {
+	return HTMLTableRowElementFromJS(input.JSValue())
 }
 
 // RowIndex returning attribute 'rowIndex' with
@@ -12376,15 +12615,19 @@ type HTMLTableSectionElement struct {
 	HTMLElement
 }
 
-// HTMLTableSectionElementFromJS is casting a js.Wrapper into HTMLTableSectionElement.
-func HTMLTableSectionElementFromJS(value js.Wrapper) *HTMLTableSectionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableSectionElementFromJS is casting a js.Value into HTMLTableSectionElement.
+func HTMLTableSectionElementFromJS(value js.Value) *HTMLTableSectionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableSectionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableSectionElementFromJS is casting from something that holds a js.Value into HTMLTableSectionElement.
+func HTMLTableSectionElementFromWrapper(input core.Wrapper) *HTMLTableSectionElement {
+	return HTMLTableSectionElementFromJS(input.JSValue())
 }
 
 // Rows returning attribute 'rows' with
@@ -12502,15 +12745,19 @@ type HTMLTemplateElement struct {
 	HTMLElement
 }
 
-// HTMLTemplateElementFromJS is casting a js.Wrapper into HTMLTemplateElement.
-func HTMLTemplateElementFromJS(value js.Wrapper) *HTMLTemplateElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTemplateElementFromJS is casting a js.Value into HTMLTemplateElement.
+func HTMLTemplateElementFromJS(value js.Value) *HTMLTemplateElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTemplateElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTemplateElementFromJS is casting from something that holds a js.Value into HTMLTemplateElement.
+func HTMLTemplateElementFromWrapper(input core.Wrapper) *HTMLTemplateElement {
+	return HTMLTemplateElementFromJS(input.JSValue())
 }
 
 // Content returning attribute 'content' with
@@ -12527,15 +12774,19 @@ type HTMLTextAreaElement struct {
 	HTMLElement
 }
 
-// HTMLTextAreaElementFromJS is casting a js.Wrapper into HTMLTextAreaElement.
-func HTMLTextAreaElementFromJS(value js.Wrapper) *HTMLTextAreaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTextAreaElementFromJS is casting a js.Value into HTMLTextAreaElement.
+func HTMLTextAreaElementFromJS(value js.Value) *HTMLTextAreaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTextAreaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTextAreaElementFromJS is casting from something that holds a js.Value into HTMLTextAreaElement.
+func HTMLTextAreaElementFromWrapper(input core.Wrapper) *HTMLTextAreaElement {
+	return HTMLTextAreaElementFromJS(input.JSValue())
 }
 
 // Autocomplete returning attribute 'autocomplete' with
@@ -13006,15 +13257,19 @@ type HTMLTimeElement struct {
 	HTMLElement
 }
 
-// HTMLTimeElementFromJS is casting a js.Wrapper into HTMLTimeElement.
-func HTMLTimeElementFromJS(value js.Wrapper) *HTMLTimeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTimeElementFromJS is casting a js.Value into HTMLTimeElement.
+func HTMLTimeElementFromJS(value js.Value) *HTMLTimeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTimeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTimeElementFromJS is casting from something that holds a js.Value into HTMLTimeElement.
+func HTMLTimeElementFromWrapper(input core.Wrapper) *HTMLTimeElement {
+	return HTMLTimeElementFromJS(input.JSValue())
 }
 
 // DateTime returning attribute 'dateTime' with
@@ -13038,15 +13293,19 @@ type HTMLTitleElement struct {
 	HTMLElement
 }
 
-// HTMLTitleElementFromJS is casting a js.Wrapper into HTMLTitleElement.
-func HTMLTitleElementFromJS(value js.Wrapper) *HTMLTitleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTitleElementFromJS is casting a js.Value into HTMLTitleElement.
+func HTMLTitleElementFromJS(value js.Value) *HTMLTitleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTitleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTitleElementFromJS is casting from something that holds a js.Value into HTMLTitleElement.
+func HTMLTitleElementFromWrapper(input core.Wrapper) *HTMLTitleElement {
+	return HTMLTitleElementFromJS(input.JSValue())
 }
 
 // Text returning attribute 'text' with
@@ -13070,15 +13329,19 @@ type HTMLUListElement struct {
 	HTMLElement
 }
 
-// HTMLUListElementFromJS is casting a js.Wrapper into HTMLUListElement.
-func HTMLUListElementFromJS(value js.Wrapper) *HTMLUListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLUListElementFromJS is casting a js.Value into HTMLUListElement.
+func HTMLUListElementFromJS(value js.Value) *HTMLUListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLUListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLUListElementFromJS is casting from something that holds a js.Value into HTMLUListElement.
+func HTMLUListElementFromWrapper(input core.Wrapper) *HTMLUListElement {
+	return HTMLUListElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -13118,15 +13381,19 @@ type HTMLUnknownElement struct {
 	HTMLElement
 }
 
-// HTMLUnknownElementFromJS is casting a js.Wrapper into HTMLUnknownElement.
-func HTMLUnknownElementFromJS(value js.Wrapper) *HTMLUnknownElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLUnknownElementFromJS is casting a js.Value into HTMLUnknownElement.
+func HTMLUnknownElementFromJS(value js.Value) *HTMLUnknownElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLUnknownElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLUnknownElementFromJS is casting from something that holds a js.Value into HTMLUnknownElement.
+func HTMLUnknownElementFromWrapper(input core.Wrapper) *HTMLUnknownElement {
+	return HTMLUnknownElementFromJS(input.JSValue())
 }
 
 // class: Promise
@@ -13139,15 +13406,19 @@ func (_this *PromiseFormData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFormDataFromJS is casting a js.Wrapper into PromiseFormData.
-func PromiseFormDataFromJS(value js.Wrapper) *PromiseFormData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFormDataFromJS is casting a js.Value into PromiseFormData.
+func PromiseFormDataFromJS(value js.Value) *PromiseFormData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFormData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFormDataFromJS is casting from something that holds a js.Value into PromiseFormData.
+func PromiseFormDataFromWrapper(input core.Wrapper) *PromiseFormData {
+	return PromiseFormDataFromJS(input.JSValue())
 }
 
 func (_this *PromiseFormData) Then(onFulfilled *PromiseFormDataOnFulfilled, onRejected *PromiseFormDataOnRejected) (_result *PromiseFormData) {
@@ -13244,15 +13515,19 @@ func (_this *TimeRanges) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TimeRangesFromJS is casting a js.Wrapper into TimeRanges.
-func TimeRangesFromJS(value js.Wrapper) *TimeRanges {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TimeRangesFromJS is casting a js.Value into TimeRanges.
+func TimeRangesFromJS(value js.Value) *TimeRanges {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TimeRanges{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TimeRangesFromJS is casting from something that holds a js.Value into TimeRanges.
+func TimeRangesFromWrapper(input core.Wrapper) *TimeRanges {
+	return TimeRangesFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -13308,15 +13583,19 @@ func (_this *ValidityState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ValidityStateFromJS is casting a js.Wrapper into ValidityState.
-func ValidityStateFromJS(value js.Wrapper) *ValidityState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ValidityStateFromJS is casting a js.Value into ValidityState.
+func ValidityStateFromJS(value js.Value) *ValidityState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ValidityState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ValidityStateFromJS is casting from something that holds a js.Value into ValidityState.
+func ValidityStateFromWrapper(input core.Wrapper) *ValidityState {
+	return ValidityStateFromJS(input.JSValue())
 }
 
 // ValueMissing returning attribute 'valueMissing' with

--- a/html/html_js.go
+++ b/html/html_js.go
@@ -7,6 +7,7 @@ import "syscall/js"
 import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
 	"github.com/gowebapi/webapi/css/cssom"
@@ -314,7 +315,7 @@ type AssignedNodesOptions struct {
 	Flatten bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AssignedNodesOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -324,15 +325,13 @@ func (_this *AssignedNodesOptions) JSValue() js.Value {
 }
 
 // AssignedNodesOptionsFromJS is allocating a new
-// AssignedNodesOptions object and copy all values from
-// input javascript object
-func AssignedNodesOptionsFromJS(value js.Wrapper) *AssignedNodesOptions {
-	input := value.JSValue()
+// AssignedNodesOptions object and copy all values in the value javascript object.
+func AssignedNodesOptionsFromJS(value js.Value) *AssignedNodesOptions {
 	var out AssignedNodesOptions
 	var (
 		value0 bool // javascript: boolean {flatten Flatten flatten}
 	)
-	value0 = (input.Get("flatten")).Bool()
+	value0 = (value.Get("flatten")).Bool()
 	out.Flatten = value0
 	return &out
 }
@@ -342,7 +341,7 @@ type FocusOptions struct {
 	PreventScroll bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FocusOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -352,15 +351,13 @@ func (_this *FocusOptions) JSValue() js.Value {
 }
 
 // FocusOptionsFromJS is allocating a new
-// FocusOptions object and copy all values from
-// input javascript object
-func FocusOptionsFromJS(value js.Wrapper) *FocusOptions {
-	input := value.JSValue()
+// FocusOptions object and copy all values in the value javascript object.
+func FocusOptionsFromJS(value js.Value) *FocusOptions {
 	var out FocusOptions
 	var (
 		value0 bool // javascript: boolean {preventScroll PreventScroll preventScroll}
 	)
-	value0 = (input.Get("preventScroll")).Bool()
+	value0 = (value.Get("preventScroll")).Bool()
 	out.PreventScroll = value0
 	return &out
 }
@@ -371,7 +368,7 @@ type FormDataEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -387,26 +384,24 @@ func (_this *FormDataEntryIteratorValue) JSValue() js.Value {
 }
 
 // FormDataEntryIteratorValueFromJS is allocating a new
-// FormDataEntryIteratorValue object and copy all values from
-// input javascript object
-func FormDataEntryIteratorValueFromJS(value js.Wrapper) *FormDataEntryIteratorValue {
-	input := value.JSValue()
+// FormDataEntryIteratorValue object and copy all values in the value javascript object.
+func FormDataEntryIteratorValueFromJS(value js.Value) *FormDataEntryIteratorValue {
 	var out FormDataEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -419,7 +414,7 @@ type FormDataEventInit struct {
 	FormData   *FormData
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -435,10 +430,8 @@ func (_this *FormDataEventInit) JSValue() js.Value {
 }
 
 // FormDataEventInitFromJS is allocating a new
-// FormDataEventInit object and copy all values from
-// input javascript object
-func FormDataEventInitFromJS(value js.Wrapper) *FormDataEventInit {
-	input := value.JSValue()
+// FormDataEventInit object and copy all values in the value javascript object.
+func FormDataEventInitFromJS(value js.Value) *FormDataEventInit {
 	var out FormDataEventInit
 	var (
 		value0 bool      // javascript: boolean {bubbles Bubbles bubbles}
@@ -446,13 +439,13 @@ func FormDataEventInitFromJS(value js.Wrapper) *FormDataEventInit {
 		value2 bool      // javascript: boolean {composed Composed composed}
 		value3 *FormData // javascript: FormData {formData FormData formData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = FormDataFromJS(input.Get("formData"))
+	value3 = FormDataFromJS(value.Get("formData"))
 	out.FormData = value3
 	return &out
 }
@@ -463,7 +456,7 @@ type FormDataKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -475,18 +468,16 @@ func (_this *FormDataKeyIteratorValue) JSValue() js.Value {
 }
 
 // FormDataKeyIteratorValueFromJS is allocating a new
-// FormDataKeyIteratorValue object and copy all values from
-// input javascript object
-func FormDataKeyIteratorValueFromJS(value js.Wrapper) *FormDataKeyIteratorValue {
-	input := value.JSValue()
+// FormDataKeyIteratorValue object and copy all values in the value javascript object.
+func FormDataKeyIteratorValueFromJS(value js.Value) *FormDataKeyIteratorValue {
 	var out FormDataKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -497,7 +488,7 @@ type FormDataValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FormDataValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -509,18 +500,16 @@ func (_this *FormDataValueIteratorValue) JSValue() js.Value {
 }
 
 // FormDataValueIteratorValueFromJS is allocating a new
-// FormDataValueIteratorValue object and copy all values from
-// input javascript object
-func FormDataValueIteratorValueFromJS(value js.Wrapper) *FormDataValueIteratorValue {
-	input := value.JSValue()
+// FormDataValueIteratorValue object and copy all values in the value javascript object.
+func FormDataValueIteratorValueFromJS(value js.Value) *FormDataValueIteratorValue {
 	var out FormDataValueIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -531,7 +520,7 @@ type ImageEncodeOptions struct {
 	Quality float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageEncodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -543,18 +532,16 @@ func (_this *ImageEncodeOptions) JSValue() js.Value {
 }
 
 // ImageEncodeOptionsFromJS is allocating a new
-// ImageEncodeOptions object and copy all values from
-// input javascript object
-func ImageEncodeOptionsFromJS(value js.Wrapper) *ImageEncodeOptions {
-	input := value.JSValue()
+// ImageEncodeOptions object and copy all values in the value javascript object.
+func ImageEncodeOptionsFromJS(value js.Value) *ImageEncodeOptions {
 	var out ImageEncodeOptions
 	var (
 		value0 string  // javascript: DOMString {type Type _type}
 		value1 float64 // javascript: unrestricted double {quality Quality quality}
 	)
-	value0 = (input.Get("type")).String()
+	value0 = (value.Get("type")).String()
 	out.Type = value0
-	value1 = (input.Get("quality")).Float()
+	value1 = (value.Get("quality")).Float()
 	out.Quality = value1
 	return &out
 }
@@ -569,15 +556,19 @@ func (_this *FormData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataFromJS is casting a js.Wrapper into FormData.
-func FormDataFromJS(value js.Wrapper) *FormData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataFromJS is casting a js.Value into FormData.
+func FormDataFromJS(value js.Value) *FormData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataFromJS is casting from something that holds a js.Value into FormData.
+func FormDataFromWrapper(input core.Wrapper) *FormData {
+	return FormDataFromJS(input.JSValue())
 }
 
 func NewFormData(form *HTMLFormElement) (_result *FormData) {
@@ -831,15 +822,19 @@ func (_this *FormDataEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataEntryIteratorFromJS is casting a js.Wrapper into FormDataEntryIterator.
-func FormDataEntryIteratorFromJS(value js.Wrapper) *FormDataEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataEntryIteratorFromJS is casting a js.Value into FormDataEntryIterator.
+func FormDataEntryIteratorFromJS(value js.Value) *FormDataEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataEntryIteratorFromJS is casting from something that holds a js.Value into FormDataEntryIterator.
+func FormDataEntryIteratorFromWrapper(input core.Wrapper) *FormDataEntryIterator {
+	return FormDataEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataEntryIterator) Next() (_result *FormDataEntryIteratorValue) {
@@ -861,15 +856,19 @@ type FormDataEvent struct {
 	domcore.Event
 }
 
-// FormDataEventFromJS is casting a js.Wrapper into FormDataEvent.
-func FormDataEventFromJS(value js.Wrapper) *FormDataEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataEventFromJS is casting a js.Value into FormDataEvent.
+func FormDataEventFromJS(value js.Value) *FormDataEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataEventFromJS is casting from something that holds a js.Value into FormDataEvent.
+func FormDataEventFromWrapper(input core.Wrapper) *FormDataEvent {
+	return FormDataEventFromJS(input.JSValue())
 }
 
 func NewFormDataEvent(_type string, eventInitDict *FormDataEventInit) (_result *FormDataEvent) {
@@ -914,15 +913,19 @@ func (_this *FormDataKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataKeyIteratorFromJS is casting a js.Wrapper into FormDataKeyIterator.
-func FormDataKeyIteratorFromJS(value js.Wrapper) *FormDataKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataKeyIteratorFromJS is casting a js.Value into FormDataKeyIterator.
+func FormDataKeyIteratorFromJS(value js.Value) *FormDataKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataKeyIteratorFromJS is casting from something that holds a js.Value into FormDataKeyIterator.
+func FormDataKeyIteratorFromWrapper(input core.Wrapper) *FormDataKeyIterator {
+	return FormDataKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataKeyIterator) Next() (_result *FormDataKeyIteratorValue) {
@@ -949,15 +952,19 @@ func (_this *FormDataValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FormDataValueIteratorFromJS is casting a js.Wrapper into FormDataValueIterator.
-func FormDataValueIteratorFromJS(value js.Wrapper) *FormDataValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FormDataValueIteratorFromJS is casting a js.Value into FormDataValueIterator.
+func FormDataValueIteratorFromJS(value js.Value) *FormDataValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FormDataValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FormDataValueIteratorFromJS is casting from something that holds a js.Value into FormDataValueIterator.
+func FormDataValueIteratorFromWrapper(input core.Wrapper) *FormDataValueIterator {
+	return FormDataValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *FormDataValueIterator) Next() (_result *FormDataValueIteratorValue) {
@@ -984,15 +991,19 @@ func (_this *HTMLAllCollection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HTMLAllCollectionFromJS is casting a js.Wrapper into HTMLAllCollection.
-func HTMLAllCollectionFromJS(value js.Wrapper) *HTMLAllCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAllCollectionFromJS is casting a js.Value into HTMLAllCollection.
+func HTMLAllCollectionFromJS(value js.Value) *HTMLAllCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAllCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAllCollectionFromJS is casting from something that holds a js.Value into HTMLAllCollection.
+func HTMLAllCollectionFromWrapper(input core.Wrapper) *HTMLAllCollection {
+	return HTMLAllCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1091,15 +1102,19 @@ type HTMLAnchorElement struct {
 	HTMLElement
 }
 
-// HTMLAnchorElementFromJS is casting a js.Wrapper into HTMLAnchorElement.
-func HTMLAnchorElementFromJS(value js.Wrapper) *HTMLAnchorElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAnchorElementFromJS is casting a js.Value into HTMLAnchorElement.
+func HTMLAnchorElementFromJS(value js.Value) *HTMLAnchorElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAnchorElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAnchorElementFromJS is casting from something that holds a js.Value into HTMLAnchorElement.
+func HTMLAnchorElementFromWrapper(input core.Wrapper) *HTMLAnchorElement {
+	return HTMLAnchorElementFromJS(input.JSValue())
 }
 
 // Target returning attribute 'target' with
@@ -1498,15 +1513,19 @@ type HTMLAreaElement struct {
 	HTMLElement
 }
 
-// HTMLAreaElementFromJS is casting a js.Wrapper into HTMLAreaElement.
-func HTMLAreaElementFromJS(value js.Wrapper) *HTMLAreaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAreaElementFromJS is casting a js.Value into HTMLAreaElement.
+func HTMLAreaElementFromJS(value js.Value) *HTMLAreaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAreaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAreaElementFromJS is casting from something that holds a js.Value into HTMLAreaElement.
+func HTMLAreaElementFromWrapper(input core.Wrapper) *HTMLAreaElement {
+	return HTMLAreaElementFromJS(input.JSValue())
 }
 
 // Alt returning attribute 'alt' with
@@ -1841,15 +1860,19 @@ type HTMLBRElement struct {
 	HTMLElement
 }
 
-// HTMLBRElementFromJS is casting a js.Wrapper into HTMLBRElement.
-func HTMLBRElementFromJS(value js.Wrapper) *HTMLBRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBRElementFromJS is casting a js.Value into HTMLBRElement.
+func HTMLBRElementFromJS(value js.Value) *HTMLBRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBRElementFromJS is casting from something that holds a js.Value into HTMLBRElement.
+func HTMLBRElementFromWrapper(input core.Wrapper) *HTMLBRElement {
+	return HTMLBRElementFromJS(input.JSValue())
 }
 
 // Clear returning attribute 'clear' with
@@ -1873,15 +1896,19 @@ type HTMLBaseElement struct {
 	HTMLElement
 }
 
-// HTMLBaseElementFromJS is casting a js.Wrapper into HTMLBaseElement.
-func HTMLBaseElementFromJS(value js.Wrapper) *HTMLBaseElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBaseElementFromJS is casting a js.Value into HTMLBaseElement.
+func HTMLBaseElementFromJS(value js.Value) *HTMLBaseElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBaseElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBaseElementFromJS is casting from something that holds a js.Value into HTMLBaseElement.
+func HTMLBaseElementFromWrapper(input core.Wrapper) *HTMLBaseElement {
+	return HTMLBaseElementFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1921,15 +1948,19 @@ type HTMLBodyElement struct {
 	HTMLElement
 }
 
-// HTMLBodyElementFromJS is casting a js.Wrapper into HTMLBodyElement.
-func HTMLBodyElementFromJS(value js.Wrapper) *HTMLBodyElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLBodyElementFromJS is casting a js.Value into HTMLBodyElement.
+func HTMLBodyElementFromJS(value js.Value) *HTMLBodyElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLBodyElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLBodyElementFromJS is casting from something that holds a js.Value into HTMLBodyElement.
+func HTMLBodyElementFromWrapper(input core.Wrapper) *HTMLBodyElement {
+	return HTMLBodyElementFromJS(input.JSValue())
 }
 
 // OnOrientationChange returning attribute 'onorientationchange' with
@@ -2604,15 +2635,19 @@ type HTMLButtonElement struct {
 	HTMLElement
 }
 
-// HTMLButtonElementFromJS is casting a js.Wrapper into HTMLButtonElement.
-func HTMLButtonElementFromJS(value js.Wrapper) *HTMLButtonElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLButtonElementFromJS is casting a js.Value into HTMLButtonElement.
+func HTMLButtonElementFromJS(value js.Value) *HTMLButtonElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLButtonElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLButtonElementFromJS is casting from something that holds a js.Value into HTMLButtonElement.
+func HTMLButtonElementFromWrapper(input core.Wrapper) *HTMLButtonElement {
+	return HTMLButtonElementFromJS(input.JSValue())
 }
 
 // Autofocus returning attribute 'autofocus' with
@@ -2867,15 +2902,19 @@ type HTMLDListElement struct {
 	HTMLElement
 }
 
-// HTMLDListElementFromJS is casting a js.Wrapper into HTMLDListElement.
-func HTMLDListElementFromJS(value js.Wrapper) *HTMLDListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDListElementFromJS is casting a js.Value into HTMLDListElement.
+func HTMLDListElementFromJS(value js.Value) *HTMLDListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDListElementFromJS is casting from something that holds a js.Value into HTMLDListElement.
+func HTMLDListElementFromWrapper(input core.Wrapper) *HTMLDListElement {
+	return HTMLDListElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -2899,15 +2938,19 @@ type HTMLDataElement struct {
 	HTMLElement
 }
 
-// HTMLDataElementFromJS is casting a js.Wrapper into HTMLDataElement.
-func HTMLDataElementFromJS(value js.Wrapper) *HTMLDataElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDataElementFromJS is casting a js.Value into HTMLDataElement.
+func HTMLDataElementFromJS(value js.Value) *HTMLDataElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDataElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDataElementFromJS is casting from something that holds a js.Value into HTMLDataElement.
+func HTMLDataElementFromWrapper(input core.Wrapper) *HTMLDataElement {
+	return HTMLDataElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -2931,15 +2974,19 @@ type HTMLDataListElement struct {
 	HTMLElement
 }
 
-// HTMLDataListElementFromJS is casting a js.Wrapper into HTMLDataListElement.
-func HTMLDataListElementFromJS(value js.Wrapper) *HTMLDataListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDataListElementFromJS is casting a js.Value into HTMLDataListElement.
+func HTMLDataListElementFromJS(value js.Value) *HTMLDataListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDataListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDataListElementFromJS is casting from something that holds a js.Value into HTMLDataListElement.
+func HTMLDataListElementFromWrapper(input core.Wrapper) *HTMLDataListElement {
+	return HTMLDataListElementFromJS(input.JSValue())
 }
 
 // Options returning attribute 'options' with
@@ -2956,15 +3003,19 @@ type HTMLDetailsElement struct {
 	HTMLElement
 }
 
-// HTMLDetailsElementFromJS is casting a js.Wrapper into HTMLDetailsElement.
-func HTMLDetailsElementFromJS(value js.Wrapper) *HTMLDetailsElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDetailsElementFromJS is casting a js.Value into HTMLDetailsElement.
+func HTMLDetailsElementFromJS(value js.Value) *HTMLDetailsElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDetailsElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDetailsElementFromJS is casting from something that holds a js.Value into HTMLDetailsElement.
+func HTMLDetailsElementFromWrapper(input core.Wrapper) *HTMLDetailsElement {
+	return HTMLDetailsElementFromJS(input.JSValue())
 }
 
 // Open returning attribute 'open' with
@@ -2988,15 +3039,19 @@ type HTMLDialogElement struct {
 	HTMLElement
 }
 
-// HTMLDialogElementFromJS is casting a js.Wrapper into HTMLDialogElement.
-func HTMLDialogElementFromJS(value js.Wrapper) *HTMLDialogElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDialogElementFromJS is casting a js.Value into HTMLDialogElement.
+func HTMLDialogElementFromJS(value js.Value) *HTMLDialogElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDialogElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDialogElementFromJS is casting from something that holds a js.Value into HTMLDialogElement.
+func HTMLDialogElementFromWrapper(input core.Wrapper) *HTMLDialogElement {
+	return HTMLDialogElementFromJS(input.JSValue())
 }
 
 // Open returning attribute 'open' with
@@ -3074,15 +3129,19 @@ type HTMLDirectoryElement struct {
 	HTMLElement
 }
 
-// HTMLDirectoryElementFromJS is casting a js.Wrapper into HTMLDirectoryElement.
-func HTMLDirectoryElementFromJS(value js.Wrapper) *HTMLDirectoryElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDirectoryElementFromJS is casting a js.Value into HTMLDirectoryElement.
+func HTMLDirectoryElementFromJS(value js.Value) *HTMLDirectoryElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDirectoryElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDirectoryElementFromJS is casting from something that holds a js.Value into HTMLDirectoryElement.
+func HTMLDirectoryElementFromWrapper(input core.Wrapper) *HTMLDirectoryElement {
+	return HTMLDirectoryElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -3106,15 +3165,19 @@ type HTMLDivElement struct {
 	HTMLElement
 }
 
-// HTMLDivElementFromJS is casting a js.Wrapper into HTMLDivElement.
-func HTMLDivElementFromJS(value js.Wrapper) *HTMLDivElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLDivElementFromJS is casting a js.Value into HTMLDivElement.
+func HTMLDivElementFromJS(value js.Value) *HTMLDivElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLDivElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLDivElementFromJS is casting from something that holds a js.Value into HTMLDivElement.
+func HTMLDivElementFromWrapper(input core.Wrapper) *HTMLDivElement {
+	return HTMLDivElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -3138,15 +3201,19 @@ type HTMLElement struct {
 	dom.Element
 }
 
-// HTMLElementFromJS is casting a js.Wrapper into HTMLElement.
-func HTMLElementFromJS(value js.Wrapper) *HTMLElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLElementFromJS is casting a js.Value into HTMLElement.
+func HTMLElementFromJS(value js.Value) *HTMLElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLElementFromJS is casting from something that holds a js.Value into HTMLElement.
+func HTMLElementFromWrapper(input core.Wrapper) *HTMLElement {
+	return HTMLElementFromJS(input.JSValue())
 }
 
 // Title returning attribute 'title' with
@@ -6172,15 +6239,19 @@ type HTMLFieldSetElement struct {
 	HTMLElement
 }
 
-// HTMLFieldSetElementFromJS is casting a js.Wrapper into HTMLFieldSetElement.
-func HTMLFieldSetElementFromJS(value js.Wrapper) *HTMLFieldSetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFieldSetElementFromJS is casting a js.Value into HTMLFieldSetElement.
+func HTMLFieldSetElementFromJS(value js.Value) *HTMLFieldSetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFieldSetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFieldSetElementFromJS is casting from something that holds a js.Value into HTMLFieldSetElement.
+func HTMLFieldSetElementFromWrapper(input core.Wrapper) *HTMLFieldSetElement {
+	return HTMLFieldSetElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -6316,15 +6387,19 @@ type HTMLFontElement struct {
 	HTMLElement
 }
 
-// HTMLFontElementFromJS is casting a js.Wrapper into HTMLFontElement.
-func HTMLFontElementFromJS(value js.Wrapper) *HTMLFontElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFontElementFromJS is casting a js.Value into HTMLFontElement.
+func HTMLFontElementFromJS(value js.Value) *HTMLFontElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFontElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFontElementFromJS is casting from something that holds a js.Value into HTMLFontElement.
+func HTMLFontElementFromWrapper(input core.Wrapper) *HTMLFontElement {
+	return HTMLFontElementFromJS(input.JSValue())
 }
 
 // Color returning attribute 'color' with
@@ -6380,15 +6455,19 @@ type HTMLFormControlsCollection struct {
 	dom.HTMLCollection
 }
 
-// HTMLFormControlsCollectionFromJS is casting a js.Wrapper into HTMLFormControlsCollection.
-func HTMLFormControlsCollectionFromJS(value js.Wrapper) *HTMLFormControlsCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFormControlsCollectionFromJS is casting a js.Value into HTMLFormControlsCollection.
+func HTMLFormControlsCollectionFromJS(value js.Value) *HTMLFormControlsCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFormControlsCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFormControlsCollectionFromJS is casting from something that holds a js.Value into HTMLFormControlsCollection.
+func HTMLFormControlsCollectionFromWrapper(input core.Wrapper) *HTMLFormControlsCollection {
+	return HTMLFormControlsCollectionFromJS(input.JSValue())
 }
 
 func (_this *HTMLFormControlsCollection) Get2(name string) (_result *Union) {
@@ -6434,15 +6513,19 @@ type HTMLFormElement struct {
 	HTMLElement
 }
 
-// HTMLFormElementFromJS is casting a js.Wrapper into HTMLFormElement.
-func HTMLFormElementFromJS(value js.Wrapper) *HTMLFormElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFormElementFromJS is casting a js.Value into HTMLFormElement.
+func HTMLFormElementFromJS(value js.Value) *HTMLFormElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFormElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFormElementFromJS is casting from something that holds a js.Value into HTMLFormElement.
+func HTMLFormElementFromWrapper(input core.Wrapper) *HTMLFormElement {
+	return HTMLFormElementFromJS(input.JSValue())
 }
 
 // AcceptCharset returning attribute 'acceptCharset' with
@@ -6717,15 +6800,19 @@ type HTMLFrameSetElement struct {
 	HTMLElement
 }
 
-// HTMLFrameSetElementFromJS is casting a js.Wrapper into HTMLFrameSetElement.
-func HTMLFrameSetElementFromJS(value js.Wrapper) *HTMLFrameSetElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFrameSetElementFromJS is casting a js.Value into HTMLFrameSetElement.
+func HTMLFrameSetElementFromJS(value js.Value) *HTMLFrameSetElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFrameSetElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFrameSetElementFromJS is casting from something that holds a js.Value into HTMLFrameSetElement.
+func HTMLFrameSetElementFromWrapper(input core.Wrapper) *HTMLFrameSetElement {
+	return HTMLFrameSetElementFromJS(input.JSValue())
 }
 
 // Cols returning attribute 'cols' with
@@ -7309,15 +7396,19 @@ type HTMLHRElement struct {
 	HTMLElement
 }
 
-// HTMLHRElementFromJS is casting a js.Wrapper into HTMLHRElement.
-func HTMLHRElementFromJS(value js.Wrapper) *HTMLHRElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHRElementFromJS is casting a js.Value into HTMLHRElement.
+func HTMLHRElementFromJS(value js.Value) *HTMLHRElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHRElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHRElementFromJS is casting from something that holds a js.Value into HTMLHRElement.
+func HTMLHRElementFromWrapper(input core.Wrapper) *HTMLHRElement {
+	return HTMLHRElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -7405,15 +7496,19 @@ type HTMLHeadElement struct {
 	HTMLElement
 }
 
-// HTMLHeadElementFromJS is casting a js.Wrapper into HTMLHeadElement.
-func HTMLHeadElementFromJS(value js.Wrapper) *HTMLHeadElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHeadElementFromJS is casting a js.Value into HTMLHeadElement.
+func HTMLHeadElementFromJS(value js.Value) *HTMLHeadElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHeadElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHeadElementFromJS is casting from something that holds a js.Value into HTMLHeadElement.
+func HTMLHeadElementFromWrapper(input core.Wrapper) *HTMLHeadElement {
+	return HTMLHeadElementFromJS(input.JSValue())
 }
 
 // class: HTMLHeadingElement
@@ -7421,15 +7516,19 @@ type HTMLHeadingElement struct {
 	HTMLElement
 }
 
-// HTMLHeadingElementFromJS is casting a js.Wrapper into HTMLHeadingElement.
-func HTMLHeadingElementFromJS(value js.Wrapper) *HTMLHeadingElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHeadingElementFromJS is casting a js.Value into HTMLHeadingElement.
+func HTMLHeadingElementFromJS(value js.Value) *HTMLHeadingElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHeadingElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHeadingElementFromJS is casting from something that holds a js.Value into HTMLHeadingElement.
+func HTMLHeadingElementFromWrapper(input core.Wrapper) *HTMLHeadingElement {
+	return HTMLHeadingElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -7453,15 +7552,19 @@ type HTMLHtmlElement struct {
 	HTMLElement
 }
 
-// HTMLHtmlElementFromJS is casting a js.Wrapper into HTMLHtmlElement.
-func HTMLHtmlElementFromJS(value js.Wrapper) *HTMLHtmlElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLHtmlElementFromJS is casting a js.Value into HTMLHtmlElement.
+func HTMLHtmlElementFromJS(value js.Value) *HTMLHtmlElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLHtmlElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLHtmlElementFromJS is casting from something that holds a js.Value into HTMLHtmlElement.
+func HTMLHtmlElementFromWrapper(input core.Wrapper) *HTMLHtmlElement {
+	return HTMLHtmlElementFromJS(input.JSValue())
 }
 
 // Version returning attribute 'version' with
@@ -7485,15 +7588,19 @@ type HTMLImageElement struct {
 	HTMLElement
 }
 
-// HTMLImageElementFromJS is casting a js.Wrapper into HTMLImageElement.
-func HTMLImageElementFromJS(value js.Wrapper) *HTMLImageElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLImageElementFromJS is casting a js.Value into HTMLImageElement.
+func HTMLImageElementFromJS(value js.Value) *HTMLImageElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLImageElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLImageElementFromJS is casting from something that holds a js.Value into HTMLImageElement.
+func HTMLImageElementFromWrapper(input core.Wrapper) *HTMLImageElement {
+	return HTMLImageElementFromJS(input.JSValue())
 }
 
 // Alt returning attribute 'alt' with
@@ -7865,15 +7972,19 @@ type HTMLInputElement struct {
 	HTMLElement
 }
 
-// HTMLInputElementFromJS is casting a js.Wrapper into HTMLInputElement.
-func HTMLInputElementFromJS(value js.Wrapper) *HTMLInputElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLInputElementFromJS is casting a js.Value into HTMLInputElement.
+func HTMLInputElementFromJS(value js.Value) *HTMLInputElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLInputElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLInputElementFromJS is casting from something that holds a js.Value into HTMLInputElement.
+func HTMLInputElementFromWrapper(input core.Wrapper) *HTMLInputElement {
+	return HTMLInputElementFromJS(input.JSValue())
 }
 
 // Accept returning attribute 'accept' with
@@ -8800,15 +8911,19 @@ type HTMLLIElement struct {
 	HTMLElement
 }
 
-// HTMLLIElementFromJS is casting a js.Wrapper into HTMLLIElement.
-func HTMLLIElementFromJS(value js.Wrapper) *HTMLLIElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLIElementFromJS is casting a js.Value into HTMLLIElement.
+func HTMLLIElementFromJS(value js.Value) *HTMLLIElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLIElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLIElementFromJS is casting from something that holds a js.Value into HTMLLIElement.
+func HTMLLIElementFromWrapper(input core.Wrapper) *HTMLLIElement {
+	return HTMLLIElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -8848,15 +8963,19 @@ type HTMLLabelElement struct {
 	HTMLElement
 }
 
-// HTMLLabelElementFromJS is casting a js.Wrapper into HTMLLabelElement.
-func HTMLLabelElementFromJS(value js.Wrapper) *HTMLLabelElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLabelElementFromJS is casting a js.Value into HTMLLabelElement.
+func HTMLLabelElementFromJS(value js.Value) *HTMLLabelElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLabelElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLabelElementFromJS is casting from something that holds a js.Value into HTMLLabelElement.
+func HTMLLabelElementFromWrapper(input core.Wrapper) *HTMLLabelElement {
+	return HTMLLabelElementFromJS(input.JSValue())
 }
 
 // Form returning attribute 'form' with
@@ -8902,15 +9021,19 @@ type HTMLLegendElement struct {
 	HTMLElement
 }
 
-// HTMLLegendElementFromJS is casting a js.Wrapper into HTMLLegendElement.
-func HTMLLegendElementFromJS(value js.Wrapper) *HTMLLegendElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLegendElementFromJS is casting a js.Value into HTMLLegendElement.
+func HTMLLegendElementFromJS(value js.Value) *HTMLLegendElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLegendElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLegendElementFromJS is casting from something that holds a js.Value into HTMLLegendElement.
+func HTMLLegendElementFromWrapper(input core.Wrapper) *HTMLLegendElement {
+	return HTMLLegendElementFromJS(input.JSValue())
 }
 
 // Form returning attribute 'form' with
@@ -8945,15 +9068,19 @@ type HTMLLinkElement struct {
 	HTMLElement
 }
 
-// HTMLLinkElementFromJS is casting a js.Wrapper into HTMLLinkElement.
-func HTMLLinkElementFromJS(value js.Wrapper) *HTMLLinkElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLLinkElementFromJS is casting a js.Value into HTMLLinkElement.
+func HTMLLinkElementFromJS(value js.Value) *HTMLLinkElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLLinkElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLLinkElementFromJS is casting from something that holds a js.Value into HTMLLinkElement.
+func HTMLLinkElementFromWrapper(input core.Wrapper) *HTMLLinkElement {
+	return HTMLLinkElementFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -9190,15 +9317,19 @@ type HTMLMapElement struct {
 	HTMLElement
 }
 
-// HTMLMapElementFromJS is casting a js.Wrapper into HTMLMapElement.
-func HTMLMapElementFromJS(value js.Wrapper) *HTMLMapElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMapElementFromJS is casting a js.Value into HTMLMapElement.
+func HTMLMapElementFromJS(value js.Value) *HTMLMapElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMapElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMapElementFromJS is casting from something that holds a js.Value into HTMLMapElement.
+func HTMLMapElementFromWrapper(input core.Wrapper) *HTMLMapElement {
+	return HTMLMapElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -9231,15 +9362,19 @@ type HTMLMarqueeElement struct {
 	HTMLElement
 }
 
-// HTMLMarqueeElementFromJS is casting a js.Wrapper into HTMLMarqueeElement.
-func HTMLMarqueeElementFromJS(value js.Wrapper) *HTMLMarqueeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMarqueeElementFromJS is casting a js.Value into HTMLMarqueeElement.
+func HTMLMarqueeElementFromJS(value js.Value) *HTMLMarqueeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMarqueeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMarqueeElementFromJS is casting from something that holds a js.Value into HTMLMarqueeElement.
+func HTMLMarqueeElementFromWrapper(input core.Wrapper) *HTMLMarqueeElement {
+	return HTMLMarqueeElementFromJS(input.JSValue())
 }
 
 // Behavior returning attribute 'behavior' with
@@ -9536,15 +9671,19 @@ type HTMLMenuElement struct {
 	HTMLElement
 }
 
-// HTMLMenuElementFromJS is casting a js.Wrapper into HTMLMenuElement.
-func HTMLMenuElementFromJS(value js.Wrapper) *HTMLMenuElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMenuElementFromJS is casting a js.Value into HTMLMenuElement.
+func HTMLMenuElementFromJS(value js.Value) *HTMLMenuElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMenuElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMenuElementFromJS is casting from something that holds a js.Value into HTMLMenuElement.
+func HTMLMenuElementFromWrapper(input core.Wrapper) *HTMLMenuElement {
+	return HTMLMenuElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -9568,15 +9707,19 @@ type HTMLMetaElement struct {
 	HTMLElement
 }
 
-// HTMLMetaElementFromJS is casting a js.Wrapper into HTMLMetaElement.
-func HTMLMetaElementFromJS(value js.Wrapper) *HTMLMetaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMetaElementFromJS is casting a js.Value into HTMLMetaElement.
+func HTMLMetaElementFromJS(value js.Value) *HTMLMetaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMetaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMetaElementFromJS is casting from something that holds a js.Value into HTMLMetaElement.
+func HTMLMetaElementFromWrapper(input core.Wrapper) *HTMLMetaElement {
+	return HTMLMetaElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -9648,15 +9791,19 @@ type HTMLMeterElement struct {
 	HTMLElement
 }
 
-// HTMLMeterElementFromJS is casting a js.Wrapper into HTMLMeterElement.
-func HTMLMeterElementFromJS(value js.Wrapper) *HTMLMeterElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMeterElementFromJS is casting a js.Value into HTMLMeterElement.
+func HTMLMeterElementFromJS(value js.Value) *HTMLMeterElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMeterElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMeterElementFromJS is casting from something that holds a js.Value into HTMLMeterElement.
+func HTMLMeterElementFromWrapper(input core.Wrapper) *HTMLMeterElement {
+	return HTMLMeterElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -9769,15 +9916,19 @@ type HTMLModElement struct {
 	HTMLElement
 }
 
-// HTMLModElementFromJS is casting a js.Wrapper into HTMLModElement.
-func HTMLModElementFromJS(value js.Wrapper) *HTMLModElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLModElementFromJS is casting a js.Value into HTMLModElement.
+func HTMLModElementFromJS(value js.Value) *HTMLModElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLModElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLModElementFromJS is casting from something that holds a js.Value into HTMLModElement.
+func HTMLModElementFromWrapper(input core.Wrapper) *HTMLModElement {
+	return HTMLModElementFromJS(input.JSValue())
 }
 
 // Cite returning attribute 'cite' with
@@ -9817,15 +9968,19 @@ type HTMLOListElement struct {
 	HTMLElement
 }
 
-// HTMLOListElementFromJS is casting a js.Wrapper into HTMLOListElement.
-func HTMLOListElementFromJS(value js.Wrapper) *HTMLOListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOListElementFromJS is casting a js.Value into HTMLOListElement.
+func HTMLOListElementFromJS(value js.Value) *HTMLOListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOListElementFromJS is casting from something that holds a js.Value into HTMLOListElement.
+func HTMLOListElementFromWrapper(input core.Wrapper) *HTMLOListElement {
+	return HTMLOListElementFromJS(input.JSValue())
 }
 
 // Reversed returning attribute 'reversed' with
@@ -9897,15 +10052,19 @@ type HTMLOptGroupElement struct {
 	HTMLElement
 }
 
-// HTMLOptGroupElementFromJS is casting a js.Wrapper into HTMLOptGroupElement.
-func HTMLOptGroupElementFromJS(value js.Wrapper) *HTMLOptGroupElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptGroupElementFromJS is casting a js.Value into HTMLOptGroupElement.
+func HTMLOptGroupElementFromJS(value js.Value) *HTMLOptGroupElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptGroupElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptGroupElementFromJS is casting from something that holds a js.Value into HTMLOptGroupElement.
+func HTMLOptGroupElementFromWrapper(input core.Wrapper) *HTMLOptGroupElement {
+	return HTMLOptGroupElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -9945,15 +10104,19 @@ type HTMLOptionElement struct {
 	HTMLElement
 }
 
-// HTMLOptionElementFromJS is casting a js.Wrapper into HTMLOptionElement.
-func HTMLOptionElementFromJS(value js.Wrapper) *HTMLOptionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptionElementFromJS is casting a js.Value into HTMLOptionElement.
+func HTMLOptionElementFromJS(value js.Value) *HTMLOptionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptionElementFromJS is casting from something that holds a js.Value into HTMLOptionElement.
+func HTMLOptionElementFromWrapper(input core.Wrapper) *HTMLOptionElement {
+	return HTMLOptionElementFromJS(input.JSValue())
 }
 
 // Disabled returning attribute 'disabled' with
@@ -10077,15 +10240,19 @@ type HTMLOptionsCollection struct {
 	dom.HTMLCollection
 }
 
-// HTMLOptionsCollectionFromJS is casting a js.Wrapper into HTMLOptionsCollection.
-func HTMLOptionsCollectionFromJS(value js.Wrapper) *HTMLOptionsCollection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOptionsCollectionFromJS is casting a js.Value into HTMLOptionsCollection.
+func HTMLOptionsCollectionFromJS(value js.Value) *HTMLOptionsCollection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOptionsCollection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOptionsCollectionFromJS is casting from something that holds a js.Value into HTMLOptionsCollection.
+func HTMLOptionsCollectionFromWrapper(input core.Wrapper) *HTMLOptionsCollection {
+	return HTMLOptionsCollectionFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -10169,15 +10336,19 @@ type HTMLOutputElement struct {
 	HTMLElement
 }
 
-// HTMLOutputElementFromJS is casting a js.Wrapper into HTMLOutputElement.
-func HTMLOutputElementFromJS(value js.Wrapper) *HTMLOutputElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLOutputElementFromJS is casting a js.Value into HTMLOutputElement.
+func HTMLOutputElementFromJS(value js.Value) *HTMLOutputElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLOutputElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLOutputElementFromJS is casting from something that holds a js.Value into HTMLOutputElement.
+func HTMLOutputElementFromWrapper(input core.Wrapper) *HTMLOutputElement {
+	return HTMLOutputElementFromJS(input.JSValue())
 }
 
 // HtmlFor returning attribute 'htmlFor' with
@@ -10338,15 +10509,19 @@ type HTMLParagraphElement struct {
 	HTMLElement
 }
 
-// HTMLParagraphElementFromJS is casting a js.Wrapper into HTMLParagraphElement.
-func HTMLParagraphElementFromJS(value js.Wrapper) *HTMLParagraphElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLParagraphElementFromJS is casting a js.Value into HTMLParagraphElement.
+func HTMLParagraphElementFromJS(value js.Value) *HTMLParagraphElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLParagraphElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLParagraphElementFromJS is casting from something that holds a js.Value into HTMLParagraphElement.
+func HTMLParagraphElementFromWrapper(input core.Wrapper) *HTMLParagraphElement {
+	return HTMLParagraphElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -10370,15 +10545,19 @@ type HTMLParamElement struct {
 	HTMLElement
 }
 
-// HTMLParamElementFromJS is casting a js.Wrapper into HTMLParamElement.
-func HTMLParamElementFromJS(value js.Wrapper) *HTMLParamElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLParamElementFromJS is casting a js.Value into HTMLParamElement.
+func HTMLParamElementFromJS(value js.Value) *HTMLParamElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLParamElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLParamElementFromJS is casting from something that holds a js.Value into HTMLParamElement.
+func HTMLParamElementFromWrapper(input core.Wrapper) *HTMLParamElement {
+	return HTMLParamElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -10450,15 +10629,19 @@ type HTMLPictureElement struct {
 	HTMLElement
 }
 
-// HTMLPictureElementFromJS is casting a js.Wrapper into HTMLPictureElement.
-func HTMLPictureElementFromJS(value js.Wrapper) *HTMLPictureElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLPictureElementFromJS is casting a js.Value into HTMLPictureElement.
+func HTMLPictureElementFromJS(value js.Value) *HTMLPictureElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLPictureElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLPictureElementFromJS is casting from something that holds a js.Value into HTMLPictureElement.
+func HTMLPictureElementFromWrapper(input core.Wrapper) *HTMLPictureElement {
+	return HTMLPictureElementFromJS(input.JSValue())
 }
 
 // class: HTMLPreElement
@@ -10466,15 +10649,19 @@ type HTMLPreElement struct {
 	HTMLElement
 }
 
-// HTMLPreElementFromJS is casting a js.Wrapper into HTMLPreElement.
-func HTMLPreElementFromJS(value js.Wrapper) *HTMLPreElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLPreElementFromJS is casting a js.Value into HTMLPreElement.
+func HTMLPreElementFromJS(value js.Value) *HTMLPreElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLPreElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLPreElementFromJS is casting from something that holds a js.Value into HTMLPreElement.
+func HTMLPreElementFromWrapper(input core.Wrapper) *HTMLPreElement {
+	return HTMLPreElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -10498,15 +10685,19 @@ type HTMLProgressElement struct {
 	HTMLElement
 }
 
-// HTMLProgressElementFromJS is casting a js.Wrapper into HTMLProgressElement.
-func HTMLProgressElementFromJS(value js.Wrapper) *HTMLProgressElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLProgressElementFromJS is casting a js.Value into HTMLProgressElement.
+func HTMLProgressElementFromJS(value js.Value) *HTMLProgressElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLProgressElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLProgressElementFromJS is casting from something that holds a js.Value into HTMLProgressElement.
+func HTMLProgressElementFromWrapper(input core.Wrapper) *HTMLProgressElement {
+	return HTMLProgressElementFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -10564,15 +10755,19 @@ type HTMLQuoteElement struct {
 	HTMLElement
 }
 
-// HTMLQuoteElementFromJS is casting a js.Wrapper into HTMLQuoteElement.
-func HTMLQuoteElementFromJS(value js.Wrapper) *HTMLQuoteElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLQuoteElementFromJS is casting a js.Value into HTMLQuoteElement.
+func HTMLQuoteElementFromJS(value js.Value) *HTMLQuoteElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLQuoteElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLQuoteElementFromJS is casting from something that holds a js.Value into HTMLQuoteElement.
+func HTMLQuoteElementFromWrapper(input core.Wrapper) *HTMLQuoteElement {
+	return HTMLQuoteElementFromJS(input.JSValue())
 }
 
 // Cite returning attribute 'cite' with
@@ -10596,15 +10791,19 @@ type HTMLScriptElement struct {
 	HTMLElement
 }
 
-// HTMLScriptElementFromJS is casting a js.Wrapper into HTMLScriptElement.
-func HTMLScriptElementFromJS(value js.Wrapper) *HTMLScriptElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLScriptElementFromJS is casting a js.Value into HTMLScriptElement.
+func HTMLScriptElementFromJS(value js.Value) *HTMLScriptElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLScriptElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLScriptElementFromJS is casting from something that holds a js.Value into HTMLScriptElement.
+func HTMLScriptElementFromWrapper(input core.Wrapper) *HTMLScriptElement {
+	return HTMLScriptElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -10812,15 +11011,19 @@ type HTMLSelectElement struct {
 	HTMLElement
 }
 
-// HTMLSelectElementFromJS is casting a js.Wrapper into HTMLSelectElement.
-func HTMLSelectElementFromJS(value js.Wrapper) *HTMLSelectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSelectElementFromJS is casting a js.Value into HTMLSelectElement.
+func HTMLSelectElementFromJS(value js.Value) *HTMLSelectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSelectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSelectElementFromJS is casting from something that holds a js.Value into HTMLSelectElement.
+func HTMLSelectElementFromWrapper(input core.Wrapper) *HTMLSelectElement {
+	return HTMLSelectElementFromJS(input.JSValue())
 }
 
 // Autocomplete returning attribute 'autocomplete' with
@@ -11212,15 +11415,19 @@ type HTMLSlotElement struct {
 	HTMLElement
 }
 
-// HTMLSlotElementFromJS is casting a js.Wrapper into HTMLSlotElement.
-func HTMLSlotElementFromJS(value js.Wrapper) *HTMLSlotElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSlotElementFromJS is casting a js.Value into HTMLSlotElement.
+func HTMLSlotElementFromJS(value js.Value) *HTMLSlotElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSlotElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSlotElementFromJS is casting from something that holds a js.Value into HTMLSlotElement.
+func HTMLSlotElementFromWrapper(input core.Wrapper) *HTMLSlotElement {
+	return HTMLSlotElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -11298,15 +11505,19 @@ type HTMLSourceElement struct {
 	HTMLElement
 }
 
-// HTMLSourceElementFromJS is casting a js.Wrapper into HTMLSourceElement.
-func HTMLSourceElementFromJS(value js.Wrapper) *HTMLSourceElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSourceElementFromJS is casting a js.Value into HTMLSourceElement.
+func HTMLSourceElementFromJS(value js.Value) *HTMLSourceElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSourceElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSourceElementFromJS is casting from something that holds a js.Value into HTMLSourceElement.
+func HTMLSourceElementFromWrapper(input core.Wrapper) *HTMLSourceElement {
+	return HTMLSourceElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -11394,15 +11605,19 @@ type HTMLSpanElement struct {
 	HTMLElement
 }
 
-// HTMLSpanElementFromJS is casting a js.Wrapper into HTMLSpanElement.
-func HTMLSpanElementFromJS(value js.Wrapper) *HTMLSpanElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLSpanElementFromJS is casting a js.Value into HTMLSpanElement.
+func HTMLSpanElementFromJS(value js.Value) *HTMLSpanElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLSpanElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLSpanElementFromJS is casting from something that holds a js.Value into HTMLSpanElement.
+func HTMLSpanElementFromWrapper(input core.Wrapper) *HTMLSpanElement {
+	return HTMLSpanElementFromJS(input.JSValue())
 }
 
 // class: HTMLStyleElement
@@ -11410,15 +11625,19 @@ type HTMLStyleElement struct {
 	HTMLElement
 }
 
-// HTMLStyleElementFromJS is casting a js.Wrapper into HTMLStyleElement.
-func HTMLStyleElementFromJS(value js.Wrapper) *HTMLStyleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLStyleElementFromJS is casting a js.Value into HTMLStyleElement.
+func HTMLStyleElementFromJS(value js.Value) *HTMLStyleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLStyleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLStyleElementFromJS is casting from something that holds a js.Value into HTMLStyleElement.
+func HTMLStyleElementFromWrapper(input core.Wrapper) *HTMLStyleElement {
+	return HTMLStyleElementFromJS(input.JSValue())
 }
 
 // Media returning attribute 'media' with
@@ -11469,15 +11688,19 @@ type HTMLTableCaptionElement struct {
 	HTMLElement
 }
 
-// HTMLTableCaptionElementFromJS is casting a js.Wrapper into HTMLTableCaptionElement.
-func HTMLTableCaptionElementFromJS(value js.Wrapper) *HTMLTableCaptionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableCaptionElementFromJS is casting a js.Value into HTMLTableCaptionElement.
+func HTMLTableCaptionElementFromJS(value js.Value) *HTMLTableCaptionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableCaptionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableCaptionElementFromJS is casting from something that holds a js.Value into HTMLTableCaptionElement.
+func HTMLTableCaptionElementFromWrapper(input core.Wrapper) *HTMLTableCaptionElement {
+	return HTMLTableCaptionElementFromJS(input.JSValue())
 }
 
 // Align returning attribute 'align' with
@@ -11501,15 +11724,19 @@ type HTMLTableCellElement struct {
 	HTMLElement
 }
 
-// HTMLTableCellElementFromJS is casting a js.Wrapper into HTMLTableCellElement.
-func HTMLTableCellElementFromJS(value js.Wrapper) *HTMLTableCellElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableCellElementFromJS is casting a js.Value into HTMLTableCellElement.
+func HTMLTableCellElementFromJS(value js.Value) *HTMLTableCellElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableCellElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableCellElementFromJS is casting from something that holds a js.Value into HTMLTableCellElement.
+func HTMLTableCellElementFromWrapper(input core.Wrapper) *HTMLTableCellElement {
+	return HTMLTableCellElementFromJS(input.JSValue())
 }
 
 // ColSpan returning attribute 'colSpan' with
@@ -11750,15 +11977,19 @@ type HTMLTableColElement struct {
 	HTMLElement
 }
 
-// HTMLTableColElementFromJS is casting a js.Wrapper into HTMLTableColElement.
-func HTMLTableColElementFromJS(value js.Wrapper) *HTMLTableColElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableColElementFromJS is casting a js.Value into HTMLTableColElement.
+func HTMLTableColElementFromJS(value js.Value) *HTMLTableColElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableColElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableColElementFromJS is casting from something that holds a js.Value into HTMLTableColElement.
+func HTMLTableColElementFromWrapper(input core.Wrapper) *HTMLTableColElement {
+	return HTMLTableColElementFromJS(input.JSValue())
 }
 
 // Span returning attribute 'span' with
@@ -11862,15 +12093,19 @@ type HTMLTableElement struct {
 	HTMLElement
 }
 
-// HTMLTableElementFromJS is casting a js.Wrapper into HTMLTableElement.
-func HTMLTableElementFromJS(value js.Wrapper) *HTMLTableElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableElementFromJS is casting a js.Value into HTMLTableElement.
+func HTMLTableElementFromJS(value js.Value) *HTMLTableElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableElementFromJS is casting from something that holds a js.Value into HTMLTableElement.
+func HTMLTableElementFromWrapper(input core.Wrapper) *HTMLTableElement {
+	return HTMLTableElementFromJS(input.JSValue())
 }
 
 // Caption returning attribute 'caption' with
@@ -12214,15 +12449,19 @@ type HTMLTableRowElement struct {
 	HTMLElement
 }
 
-// HTMLTableRowElementFromJS is casting a js.Wrapper into HTMLTableRowElement.
-func HTMLTableRowElementFromJS(value js.Wrapper) *HTMLTableRowElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableRowElementFromJS is casting a js.Value into HTMLTableRowElement.
+func HTMLTableRowElementFromJS(value js.Value) *HTMLTableRowElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableRowElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableRowElementFromJS is casting from something that holds a js.Value into HTMLTableRowElement.
+func HTMLTableRowElementFromWrapper(input core.Wrapper) *HTMLTableRowElement {
+	return HTMLTableRowElementFromJS(input.JSValue())
 }
 
 // RowIndex returning attribute 'rowIndex' with
@@ -12374,15 +12613,19 @@ type HTMLTableSectionElement struct {
 	HTMLElement
 }
 
-// HTMLTableSectionElementFromJS is casting a js.Wrapper into HTMLTableSectionElement.
-func HTMLTableSectionElementFromJS(value js.Wrapper) *HTMLTableSectionElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTableSectionElementFromJS is casting a js.Value into HTMLTableSectionElement.
+func HTMLTableSectionElementFromJS(value js.Value) *HTMLTableSectionElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTableSectionElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTableSectionElementFromJS is casting from something that holds a js.Value into HTMLTableSectionElement.
+func HTMLTableSectionElementFromWrapper(input core.Wrapper) *HTMLTableSectionElement {
+	return HTMLTableSectionElementFromJS(input.JSValue())
 }
 
 // Rows returning attribute 'rows' with
@@ -12500,15 +12743,19 @@ type HTMLTemplateElement struct {
 	HTMLElement
 }
 
-// HTMLTemplateElementFromJS is casting a js.Wrapper into HTMLTemplateElement.
-func HTMLTemplateElementFromJS(value js.Wrapper) *HTMLTemplateElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTemplateElementFromJS is casting a js.Value into HTMLTemplateElement.
+func HTMLTemplateElementFromJS(value js.Value) *HTMLTemplateElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTemplateElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTemplateElementFromJS is casting from something that holds a js.Value into HTMLTemplateElement.
+func HTMLTemplateElementFromWrapper(input core.Wrapper) *HTMLTemplateElement {
+	return HTMLTemplateElementFromJS(input.JSValue())
 }
 
 // Content returning attribute 'content' with
@@ -12525,15 +12772,19 @@ type HTMLTextAreaElement struct {
 	HTMLElement
 }
 
-// HTMLTextAreaElementFromJS is casting a js.Wrapper into HTMLTextAreaElement.
-func HTMLTextAreaElementFromJS(value js.Wrapper) *HTMLTextAreaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTextAreaElementFromJS is casting a js.Value into HTMLTextAreaElement.
+func HTMLTextAreaElementFromJS(value js.Value) *HTMLTextAreaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTextAreaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTextAreaElementFromJS is casting from something that holds a js.Value into HTMLTextAreaElement.
+func HTMLTextAreaElementFromWrapper(input core.Wrapper) *HTMLTextAreaElement {
+	return HTMLTextAreaElementFromJS(input.JSValue())
 }
 
 // Autocomplete returning attribute 'autocomplete' with
@@ -13004,15 +13255,19 @@ type HTMLTimeElement struct {
 	HTMLElement
 }
 
-// HTMLTimeElementFromJS is casting a js.Wrapper into HTMLTimeElement.
-func HTMLTimeElementFromJS(value js.Wrapper) *HTMLTimeElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTimeElementFromJS is casting a js.Value into HTMLTimeElement.
+func HTMLTimeElementFromJS(value js.Value) *HTMLTimeElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTimeElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTimeElementFromJS is casting from something that holds a js.Value into HTMLTimeElement.
+func HTMLTimeElementFromWrapper(input core.Wrapper) *HTMLTimeElement {
+	return HTMLTimeElementFromJS(input.JSValue())
 }
 
 // DateTime returning attribute 'dateTime' with
@@ -13036,15 +13291,19 @@ type HTMLTitleElement struct {
 	HTMLElement
 }
 
-// HTMLTitleElementFromJS is casting a js.Wrapper into HTMLTitleElement.
-func HTMLTitleElementFromJS(value js.Wrapper) *HTMLTitleElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTitleElementFromJS is casting a js.Value into HTMLTitleElement.
+func HTMLTitleElementFromJS(value js.Value) *HTMLTitleElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTitleElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTitleElementFromJS is casting from something that holds a js.Value into HTMLTitleElement.
+func HTMLTitleElementFromWrapper(input core.Wrapper) *HTMLTitleElement {
+	return HTMLTitleElementFromJS(input.JSValue())
 }
 
 // Text returning attribute 'text' with
@@ -13068,15 +13327,19 @@ type HTMLUListElement struct {
 	HTMLElement
 }
 
-// HTMLUListElementFromJS is casting a js.Wrapper into HTMLUListElement.
-func HTMLUListElementFromJS(value js.Wrapper) *HTMLUListElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLUListElementFromJS is casting a js.Value into HTMLUListElement.
+func HTMLUListElementFromJS(value js.Value) *HTMLUListElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLUListElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLUListElementFromJS is casting from something that holds a js.Value into HTMLUListElement.
+func HTMLUListElementFromWrapper(input core.Wrapper) *HTMLUListElement {
+	return HTMLUListElementFromJS(input.JSValue())
 }
 
 // Compact returning attribute 'compact' with
@@ -13116,15 +13379,19 @@ type HTMLUnknownElement struct {
 	HTMLElement
 }
 
-// HTMLUnknownElementFromJS is casting a js.Wrapper into HTMLUnknownElement.
-func HTMLUnknownElementFromJS(value js.Wrapper) *HTMLUnknownElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLUnknownElementFromJS is casting a js.Value into HTMLUnknownElement.
+func HTMLUnknownElementFromJS(value js.Value) *HTMLUnknownElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLUnknownElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLUnknownElementFromJS is casting from something that holds a js.Value into HTMLUnknownElement.
+func HTMLUnknownElementFromWrapper(input core.Wrapper) *HTMLUnknownElement {
+	return HTMLUnknownElementFromJS(input.JSValue())
 }
 
 // class: Promise
@@ -13137,15 +13404,19 @@ func (_this *PromiseFormData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFormDataFromJS is casting a js.Wrapper into PromiseFormData.
-func PromiseFormDataFromJS(value js.Wrapper) *PromiseFormData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFormDataFromJS is casting a js.Value into PromiseFormData.
+func PromiseFormDataFromJS(value js.Value) *PromiseFormData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFormData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFormDataFromJS is casting from something that holds a js.Value into PromiseFormData.
+func PromiseFormDataFromWrapper(input core.Wrapper) *PromiseFormData {
+	return PromiseFormDataFromJS(input.JSValue())
 }
 
 func (_this *PromiseFormData) Then(onFulfilled *PromiseFormDataOnFulfilled, onRejected *PromiseFormDataOnRejected) (_result *PromiseFormData) {
@@ -13242,15 +13513,19 @@ func (_this *TimeRanges) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TimeRangesFromJS is casting a js.Wrapper into TimeRanges.
-func TimeRangesFromJS(value js.Wrapper) *TimeRanges {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TimeRangesFromJS is casting a js.Value into TimeRanges.
+func TimeRangesFromJS(value js.Value) *TimeRanges {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TimeRanges{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TimeRangesFromJS is casting from something that holds a js.Value into TimeRanges.
+func TimeRangesFromWrapper(input core.Wrapper) *TimeRanges {
+	return TimeRangesFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -13306,15 +13581,19 @@ func (_this *ValidityState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ValidityStateFromJS is casting a js.Wrapper into ValidityState.
-func ValidityStateFromJS(value js.Wrapper) *ValidityState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ValidityStateFromJS is casting a js.Value into ValidityState.
+func ValidityStateFromJS(value js.Value) *ValidityState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ValidityState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ValidityStateFromJS is casting from something that holds a js.Value into ValidityState.
+func ValidityStateFromWrapper(input core.Wrapper) *ValidityState {
+	return ValidityStateFromJS(input.JSValue())
 }
 
 // ValueMissing returning attribute 'valueMissing' with

--- a/html/htmlcommon/htmlcommon.go
+++ b/html/htmlcommon/htmlcommon.go
@@ -7,6 +7,7 @@ package htmlcommon
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -277,15 +278,19 @@ type BeforeUnloadEvent struct {
 	domcore.Event
 }
 
-// BeforeUnloadEventFromJS is casting a js.Wrapper into BeforeUnloadEvent.
-func BeforeUnloadEventFromJS(value js.Wrapper) *BeforeUnloadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BeforeUnloadEventFromJS is casting a js.Value into BeforeUnloadEvent.
+func BeforeUnloadEventFromJS(value js.Value) *BeforeUnloadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BeforeUnloadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BeforeUnloadEventFromJS is casting from something that holds a js.Value into BeforeUnloadEvent.
+func BeforeUnloadEventFromWrapper(input core.Wrapper) *BeforeUnloadEvent {
+	return BeforeUnloadEventFromJS(input.JSValue())
 }
 
 // ReturnValue returning attribute 'returnValue' with

--- a/html/htmlcommon/htmlcommon_js.go
+++ b/html/htmlcommon/htmlcommon_js.go
@@ -5,6 +5,7 @@ package htmlcommon
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -275,15 +276,19 @@ type BeforeUnloadEvent struct {
 	domcore.Event
 }
 
-// BeforeUnloadEventFromJS is casting a js.Wrapper into BeforeUnloadEvent.
-func BeforeUnloadEventFromJS(value js.Wrapper) *BeforeUnloadEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BeforeUnloadEventFromJS is casting a js.Value into BeforeUnloadEvent.
+func BeforeUnloadEventFromJS(value js.Value) *BeforeUnloadEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BeforeUnloadEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BeforeUnloadEventFromJS is casting from something that holds a js.Value into BeforeUnloadEvent.
+func BeforeUnloadEventFromWrapper(input core.Wrapper) *BeforeUnloadEvent {
+	return BeforeUnloadEventFromJS(input.JSValue())
 }
 
 // ReturnValue returning attribute 'returnValue' with

--- a/html/htmlevent/htmlevent.go
+++ b/html/htmlevent/htmlevent.go
@@ -7,6 +7,7 @@ package htmlevent
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/inputcapabilities"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -60,7 +61,7 @@ type CompositionEventInit struct {
 	Data               string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CompositionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -82,10 +83,8 @@ func (_this *CompositionEventInit) JSValue() js.Value {
 }
 
 // CompositionEventInitFromJS is allocating a new
-// CompositionEventInit object and copy all values from
-// input javascript object
-func CompositionEventInitFromJS(value js.Wrapper) *CompositionEventInit {
-	input := value.JSValue()
+// CompositionEventInit object and copy all values in the value javascript object.
+func CompositionEventInitFromJS(value js.Value) *CompositionEventInit {
 	var out CompositionEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -96,21 +95,21 @@ func CompositionEventInitFromJS(value js.Wrapper) *CompositionEventInit {
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 		value6 string                                     // javascript: DOMString {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("data")).String()
+	value6 = (value.Get("data")).String()
 	out.Data = value6
 	return &out
 }
@@ -149,7 +148,7 @@ type DragEventInit struct {
 	DataTransfer       *datatransfer.DataTransfer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DragEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -217,10 +216,8 @@ func (_this *DragEventInit) JSValue() js.Value {
 }
 
 // DragEventInitFromJS is allocating a new
-// DragEventInit object and copy all values from
-// input javascript object
-func DragEventInitFromJS(value js.Wrapper) *DragEventInit {
-	input := value.JSValue()
+// DragEventInit object and copy all values in the value javascript object.
+func DragEventInitFromJS(value js.Value) *DragEventInit {
 	var out DragEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -254,70 +251,70 @@ func DragEventInitFromJS(value js.Wrapper) *DragEventInit {
 		value28 int                                        // javascript: long {movementY MovementY movementY}
 		value29 *datatransfer.DataTransfer                 // javascript: DataTransfer {dataTransfer DataTransfer dataTransfer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	if input.Get("dataTransfer").Type() != js.TypeNull && input.Get("dataTransfer").Type() != js.TypeUndefined {
-		value29 = datatransfer.DataTransferFromJS(input.Get("dataTransfer"))
+	if value.Get("dataTransfer").Type() != js.TypeNull && value.Get("dataTransfer").Type() != js.TypeUndefined {
+		value29 = datatransfer.DataTransferFromJS(value.Get("dataTransfer"))
 	}
 	out.DataTransfer = value29
 	return &out
@@ -335,7 +332,7 @@ type ErrorEventInit struct {
 	Error      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -359,10 +356,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -374,21 +369,21 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value6 uint     // javascript: unsigned long {colno Colno colno}
 		value7 js.Value // javascript: any {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("message")).String()
+	value3 = (value.Get("message")).String()
 	out.Message = value3
-	value4 = (input.Get("filename")).String()
+	value4 = (value.Get("filename")).String()
 	out.Filename = value4
-	value5 = (uint)((input.Get("lineno")).Int())
+	value5 = (uint)((value.Get("lineno")).Int())
 	out.Lineno = value5
-	value6 = (uint)((input.Get("colno")).Int())
+	value6 = (uint)((value.Get("colno")).Int())
 	out.Colno = value6
-	value7 = input.Get("error")
+	value7 = value.Get("error")
 	out.Error = value7
 	return &out
 }
@@ -417,7 +412,7 @@ type EventModifierInit struct {
 	ModifierSymbolLock bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventModifierInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -465,10 +460,8 @@ func (_this *EventModifierInit) JSValue() js.Value {
 }
 
 // EventModifierInitFromJS is allocating a new
-// EventModifierInit object and copy all values from
-// input javascript object
-func EventModifierInitFromJS(value js.Wrapper) *EventModifierInit {
-	input := value.JSValue()
+// EventModifierInit object and copy all values in the value javascript object.
+func EventModifierInitFromJS(value js.Value) *EventModifierInit {
 	var out EventModifierInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -492,47 +485,47 @@ func EventModifierInitFromJS(value js.Wrapper) *EventModifierInit {
 		value18 bool                                       // javascript: boolean {modifierSymbol ModifierSymbol modifierSymbol}
 		value19 bool                                       // javascript: boolean {modifierSymbolLock ModifierSymbolLock modifierSymbolLock}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
 	return &out
 }
@@ -548,7 +541,7 @@ type FocusEventInit struct {
 	RelatedTarget      *domcore.EventTarget
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FocusEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -570,10 +563,8 @@ func (_this *FocusEventInit) JSValue() js.Value {
 }
 
 // FocusEventInitFromJS is allocating a new
-// FocusEventInit object and copy all values from
-// input javascript object
-func FocusEventInitFromJS(value js.Wrapper) *FocusEventInit {
-	input := value.JSValue()
+// FocusEventInit object and copy all values in the value javascript object.
+func FocusEventInitFromJS(value js.Value) *FocusEventInit {
 	var out FocusEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -584,22 +575,22 @@ func FocusEventInitFromJS(value js.Wrapper) *FocusEventInit {
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 		value6 *domcore.EventTarget                       // javascript: EventTarget {relatedTarget RelatedTarget relatedTarget}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value6 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value6 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value6
 	return &out
@@ -614,7 +605,7 @@ type HashChangeEventInit struct {
 	NewURL     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HashChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -632,10 +623,8 @@ func (_this *HashChangeEventInit) JSValue() js.Value {
 }
 
 // HashChangeEventInitFromJS is allocating a new
-// HashChangeEventInit object and copy all values from
-// input javascript object
-func HashChangeEventInitFromJS(value js.Wrapper) *HashChangeEventInit {
-	input := value.JSValue()
+// HashChangeEventInit object and copy all values in the value javascript object.
+func HashChangeEventInitFromJS(value js.Value) *HashChangeEventInit {
 	var out HashChangeEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -644,15 +633,15 @@ func HashChangeEventInitFromJS(value js.Wrapper) *HashChangeEventInit {
 		value3 string // javascript: USVString {oldURL OldURL oldURL}
 		value4 string // javascript: USVString {newURL NewURL newURL}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("oldURL")).String()
+	value3 = (value.Get("oldURL")).String()
 	out.OldURL = value3
-	value4 = (input.Get("newURL")).String()
+	value4 = (value.Get("newURL")).String()
 	out.NewURL = value4
 	return &out
 }
@@ -672,7 +661,7 @@ type InputEventInit struct {
 	TargetRanges       []*dom.StaticRange
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -712,10 +701,8 @@ func (_this *InputEventInit) JSValue() js.Value {
 }
 
 // InputEventInitFromJS is allocating a new
-// InputEventInit object and copy all values from
-// input javascript object
-func InputEventInitFromJS(value js.Wrapper) *InputEventInit {
-	input := value.JSValue()
+// InputEventInit object and copy all values in the value javascript object.
+func InputEventInitFromJS(value js.Value) *InputEventInit {
 	var out InputEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -730,38 +717,38 @@ func InputEventInitFromJS(value js.Wrapper) *InputEventInit {
 		value9  *datatransfer.DataTransfer                 // javascript: DataTransfer {dataTransfer DataTransfer dataTransfer}
 		value10 []*dom.StaticRange                         // javascript: sequence<StaticRange> {targetRanges TargetRanges targetRanges}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	if input.Get("data").Type() != js.TypeNull && input.Get("data").Type() != js.TypeUndefined {
-		__tmp := (input.Get("data")).String()
+	if value.Get("data").Type() != js.TypeNull && value.Get("data").Type() != js.TypeUndefined {
+		__tmp := (value.Get("data")).String()
 		value6 = &__tmp
 	}
 	out.Data = value6
-	value7 = (input.Get("isComposing")).Bool()
+	value7 = (value.Get("isComposing")).Bool()
 	out.IsComposing = value7
-	value8 = (input.Get("inputType")).String()
+	value8 = (value.Get("inputType")).String()
 	out.InputType = value8
-	if input.Get("dataTransfer").Type() != js.TypeNull && input.Get("dataTransfer").Type() != js.TypeUndefined {
-		value9 = datatransfer.DataTransferFromJS(input.Get("dataTransfer"))
+	if value.Get("dataTransfer").Type() != js.TypeNull && value.Get("dataTransfer").Type() != js.TypeUndefined {
+		value9 = datatransfer.DataTransferFromJS(value.Get("dataTransfer"))
 	}
 	out.DataTransfer = value9
-	__length10 := input.Get("targetRanges").Length()
+	__length10 := value.Get("targetRanges").Length()
 	__array10 := make([]*dom.StaticRange, __length10, __length10)
 	for __idx10 := 0; __idx10 < __length10; __idx10++ {
 		var __seq_out10 *dom.StaticRange
-		__seq_in10 := input.Get("targetRanges").Index(__idx10)
+		__seq_in10 := value.Get("targetRanges").Index(__idx10)
 		__seq_out10 = dom.StaticRangeFromJS(__seq_in10)
 		__array10[__idx10] = __seq_out10
 	}
@@ -799,7 +786,7 @@ type KeyboardEventInit struct {
 	IsComposing        bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyboardEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -857,10 +844,8 @@ func (_this *KeyboardEventInit) JSValue() js.Value {
 }
 
 // KeyboardEventInitFromJS is allocating a new
-// KeyboardEventInit object and copy all values from
-// input javascript object
-func KeyboardEventInitFromJS(value js.Wrapper) *KeyboardEventInit {
-	input := value.JSValue()
+// KeyboardEventInit object and copy all values in the value javascript object.
+func KeyboardEventInitFromJS(value js.Value) *KeyboardEventInit {
 	var out KeyboardEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -889,57 +874,57 @@ func KeyboardEventInitFromJS(value js.Wrapper) *KeyboardEventInit {
 		value23 bool                                       // javascript: boolean {repeat Repeat repeat}
 		value24 bool                                       // javascript: boolean {isComposing IsComposing isComposing}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("key")).String()
+	value20 = (value.Get("key")).String()
 	out.Key = value20
-	value21 = (input.Get("code")).String()
+	value21 = (value.Get("code")).String()
 	out.Code = value21
-	value22 = (uint)((input.Get("location")).Int())
+	value22 = (uint)((value.Get("location")).Int())
 	out.Location = value22
-	value23 = (input.Get("repeat")).Bool()
+	value23 = (value.Get("repeat")).Bool()
 	out.Repeat = value23
-	value24 = (input.Get("isComposing")).Bool()
+	value24 = (value.Get("isComposing")).Bool()
 	out.IsComposing = value24
 	return &out
 }
@@ -977,7 +962,7 @@ type MouseEventInit struct {
 	MovementY          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MouseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1043,10 +1028,8 @@ func (_this *MouseEventInit) JSValue() js.Value {
 }
 
 // MouseEventInitFromJS is allocating a new
-// MouseEventInit object and copy all values from
-// input javascript object
-func MouseEventInitFromJS(value js.Wrapper) *MouseEventInit {
-	input := value.JSValue()
+// MouseEventInit object and copy all values in the value javascript object.
+func MouseEventInitFromJS(value js.Value) *MouseEventInit {
 	var out MouseEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1079,67 +1062,67 @@ func MouseEventInitFromJS(value js.Wrapper) *MouseEventInit {
 		value27 int                                        // javascript: long {movementX MovementX movementX}
 		value28 int                                        // javascript: long {movementY MovementY movementY}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
 	return &out
 }
@@ -1152,7 +1135,7 @@ type PageTransitionEventInit struct {
 	Persisted  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PageTransitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1168,10 +1151,8 @@ func (_this *PageTransitionEventInit) JSValue() js.Value {
 }
 
 // PageTransitionEventInitFromJS is allocating a new
-// PageTransitionEventInit object and copy all values from
-// input javascript object
-func PageTransitionEventInitFromJS(value js.Wrapper) *PageTransitionEventInit {
-	input := value.JSValue()
+// PageTransitionEventInit object and copy all values in the value javascript object.
+func PageTransitionEventInitFromJS(value js.Value) *PageTransitionEventInit {
 	var out PageTransitionEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -1179,13 +1160,13 @@ func PageTransitionEventInitFromJS(value js.Wrapper) *PageTransitionEventInit {
 		value2 bool // javascript: boolean {composed Composed composed}
 		value3 bool // javascript: boolean {persisted Persisted persisted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("persisted")).Bool()
+	value3 = (value.Get("persisted")).Bool()
 	out.Persisted = value3
 	return &out
 }
@@ -1235,7 +1216,7 @@ type PointerEventInit struct {
 	PredictedEvents    []*PointerEvent
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PointerEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1333,10 +1314,8 @@ func (_this *PointerEventInit) JSValue() js.Value {
 }
 
 // PointerEventInitFromJS is allocating a new
-// PointerEventInit object and copy all values from
-// input javascript object
-func PointerEventInitFromJS(value js.Wrapper) *PointerEventInit {
-	input := value.JSValue()
+// PointerEventInit object and copy all values in the value javascript object.
+func PointerEventInitFromJS(value js.Value) *PointerEventInit {
 	var out PointerEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1381,103 +1360,103 @@ func PointerEventInitFromJS(value js.Wrapper) *PointerEventInit {
 		value39 []*PointerEvent                            // javascript: sequence<PointerEvent> {coalescedEvents CoalescedEvents coalescedEvents}
 		value40 []*PointerEvent                            // javascript: sequence<PointerEvent> {predictedEvents PredictedEvents predictedEvents}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	value29 = (input.Get("pointerId")).Int()
+	value29 = (value.Get("pointerId")).Int()
 	out.PointerId = value29
-	value30 = (input.Get("width")).Float()
+	value30 = (value.Get("width")).Float()
 	out.Width = value30
-	value31 = (input.Get("height")).Float()
+	value31 = (value.Get("height")).Float()
 	out.Height = value31
-	value32 = (float32)((input.Get("pressure")).Float())
+	value32 = (float32)((value.Get("pressure")).Float())
 	out.Pressure = value32
-	value33 = (float32)((input.Get("tangentialPressure")).Float())
+	value33 = (float32)((value.Get("tangentialPressure")).Float())
 	out.TangentialPressure = value33
-	value34 = (input.Get("tiltX")).Int()
+	value34 = (value.Get("tiltX")).Int()
 	out.TiltX = value34
-	value35 = (input.Get("tiltY")).Int()
+	value35 = (value.Get("tiltY")).Int()
 	out.TiltY = value35
-	value36 = (input.Get("twist")).Int()
+	value36 = (value.Get("twist")).Int()
 	out.Twist = value36
-	value37 = (input.Get("pointerType")).String()
+	value37 = (value.Get("pointerType")).String()
 	out.PointerType = value37
-	value38 = (input.Get("isPrimary")).Bool()
+	value38 = (value.Get("isPrimary")).Bool()
 	out.IsPrimary = value38
-	__length39 := input.Get("coalescedEvents").Length()
+	__length39 := value.Get("coalescedEvents").Length()
 	__array39 := make([]*PointerEvent, __length39, __length39)
 	for __idx39 := 0; __idx39 < __length39; __idx39++ {
 		var __seq_out39 *PointerEvent
-		__seq_in39 := input.Get("coalescedEvents").Index(__idx39)
+		__seq_in39 := value.Get("coalescedEvents").Index(__idx39)
 		__seq_out39 = PointerEventFromJS(__seq_in39)
 		__array39[__idx39] = __seq_out39
 	}
 	value39 = __array39
 	out.CoalescedEvents = value39
-	__length40 := input.Get("predictedEvents").Length()
+	__length40 := value.Get("predictedEvents").Length()
 	__array40 := make([]*PointerEvent, __length40, __length40)
 	for __idx40 := 0; __idx40 < __length40; __idx40++ {
 		var __seq_out40 *PointerEvent
-		__seq_in40 := input.Get("predictedEvents").Index(__idx40)
+		__seq_in40 := value.Get("predictedEvents").Index(__idx40)
 		__seq_out40 = PointerEventFromJS(__seq_in40)
 		__array40[__idx40] = __seq_out40
 	}
@@ -1494,7 +1473,7 @@ type PopStateEventInit struct {
 	State      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PopStateEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1510,10 +1489,8 @@ func (_this *PopStateEventInit) JSValue() js.Value {
 }
 
 // PopStateEventInitFromJS is allocating a new
-// PopStateEventInit object and copy all values from
-// input javascript object
-func PopStateEventInitFromJS(value js.Wrapper) *PopStateEventInit {
-	input := value.JSValue()
+// PopStateEventInit object and copy all values in the value javascript object.
+func PopStateEventInitFromJS(value js.Value) *PopStateEventInit {
 	var out PopStateEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1521,13 +1498,13 @@ func PopStateEventInitFromJS(value js.Wrapper) *PopStateEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {state State state}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("state")
+	value3 = value.Get("state")
 	out.State = value3
 	return &out
 }
@@ -1541,7 +1518,7 @@ type PromiseRejectionEventInit struct {
 	Reason     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PromiseRejectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1559,10 +1536,8 @@ func (_this *PromiseRejectionEventInit) JSValue() js.Value {
 }
 
 // PromiseRejectionEventInitFromJS is allocating a new
-// PromiseRejectionEventInit object and copy all values from
-// input javascript object
-func PromiseRejectionEventInitFromJS(value js.Wrapper) *PromiseRejectionEventInit {
-	input := value.JSValue()
+// PromiseRejectionEventInit object and copy all values in the value javascript object.
+func PromiseRejectionEventInitFromJS(value js.Value) *PromiseRejectionEventInit {
 	var out PromiseRejectionEventInit
 	var (
 		value0 bool                // javascript: boolean {bubbles Bubbles bubbles}
@@ -1571,15 +1546,15 @@ func PromiseRejectionEventInitFromJS(value js.Wrapper) *PromiseRejectionEventIni
 		value3 *javascript.Promise // javascript: Promise {promise Promise promise}
 		value4 js.Value            // javascript: any {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = javascript.PromiseFromJS(input.Get("promise"))
+	value3 = javascript.PromiseFromJS(value.Get("promise"))
 	out.Promise = value3
-	value4 = input.Get("reason")
+	value4 = value.Get("reason")
 	out.Reason = value4
 	return &out
 }
@@ -1596,7 +1571,7 @@ type StorageEventInit struct {
 	StorageArea *Storage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StorageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1638,10 +1613,8 @@ func (_this *StorageEventInit) JSValue() js.Value {
 }
 
 // StorageEventInitFromJS is allocating a new
-// StorageEventInit object and copy all values from
-// input javascript object
-func StorageEventInitFromJS(value js.Wrapper) *StorageEventInit {
-	input := value.JSValue()
+// StorageEventInit object and copy all values in the value javascript object.
+func StorageEventInitFromJS(value js.Value) *StorageEventInit {
 	var out StorageEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1653,31 +1626,31 @@ func StorageEventInitFromJS(value js.Wrapper) *StorageEventInit {
 		value6 string   // javascript: USVString {url Url url}
 		value7 *Storage // javascript: Storage {storageArea StorageArea storageArea}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("key").Type() != js.TypeNull && input.Get("key").Type() != js.TypeUndefined {
-		__tmp := (input.Get("key")).String()
+	if value.Get("key").Type() != js.TypeNull && value.Get("key").Type() != js.TypeUndefined {
+		__tmp := (value.Get("key")).String()
 		value3 = &__tmp
 	}
 	out.Key = value3
-	if input.Get("oldValue").Type() != js.TypeNull && input.Get("oldValue").Type() != js.TypeUndefined {
-		__tmp := (input.Get("oldValue")).String()
+	if value.Get("oldValue").Type() != js.TypeNull && value.Get("oldValue").Type() != js.TypeUndefined {
+		__tmp := (value.Get("oldValue")).String()
 		value4 = &__tmp
 	}
 	out.OldValue = value4
-	if input.Get("newValue").Type() != js.TypeNull && input.Get("newValue").Type() != js.TypeUndefined {
-		__tmp := (input.Get("newValue")).String()
+	if value.Get("newValue").Type() != js.TypeNull && value.Get("newValue").Type() != js.TypeUndefined {
+		__tmp := (value.Get("newValue")).String()
 		value5 = &__tmp
 	}
 	out.NewValue = value5
-	value6 = (input.Get("url")).String()
+	value6 = (value.Get("url")).String()
 	out.Url = value6
-	if input.Get("storageArea").Type() != js.TypeNull && input.Get("storageArea").Type() != js.TypeUndefined {
-		value7 = StorageFromJS(input.Get("storageArea"))
+	if value.Get("storageArea").Type() != js.TypeNull && value.Get("storageArea").Type() != js.TypeUndefined {
+		value7 = StorageFromJS(value.Get("storageArea"))
 	}
 	out.StorageArea = value7
 	return &out
@@ -1691,7 +1664,7 @@ type TrackEventInit struct {
 	Track      *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1707,10 +1680,8 @@ func (_this *TrackEventInit) JSValue() js.Value {
 }
 
 // TrackEventInitFromJS is allocating a new
-// TrackEventInit object and copy all values from
-// input javascript object
-func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
-	input := value.JSValue()
+// TrackEventInit object and copy all values in the value javascript object.
+func TrackEventInitFromJS(value js.Value) *TrackEventInit {
 	var out TrackEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1718,14 +1689,14 @@ func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Union // javascript: Union {track Track track}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("track").Type() != js.TypeNull && input.Get("track").Type() != js.TypeUndefined {
-		value3 = UnionFromJS(input.Get("track"))
+	if value.Get("track").Type() != js.TypeNull && value.Get("track").Type() != js.TypeUndefined {
+		value3 = UnionFromJS(value.Get("track"))
 	}
 	out.Track = value3
 	return &out
@@ -1741,7 +1712,7 @@ type UIEventInit struct {
 	SourceCapabilities *inputcapabilities.InputDeviceCapabilities
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *UIEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1761,10 +1732,8 @@ func (_this *UIEventInit) JSValue() js.Value {
 }
 
 // UIEventInitFromJS is allocating a new
-// UIEventInit object and copy all values from
-// input javascript object
-func UIEventInitFromJS(value js.Wrapper) *UIEventInit {
-	input := value.JSValue()
+// UIEventInit object and copy all values in the value javascript object.
+func UIEventInitFromJS(value js.Value) *UIEventInit {
 	var out UIEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1774,18 +1743,18 @@ func UIEventInitFromJS(value js.Wrapper) *UIEventInit {
 		value4 int                                        // javascript: long {detail Detail detail}
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
 	return &out
@@ -1828,7 +1797,7 @@ type WheelEventInit struct {
 	DeltaMode          uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WheelEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1902,10 +1871,8 @@ func (_this *WheelEventInit) JSValue() js.Value {
 }
 
 // WheelEventInitFromJS is allocating a new
-// WheelEventInit object and copy all values from
-// input javascript object
-func WheelEventInitFromJS(value js.Wrapper) *WheelEventInit {
-	input := value.JSValue()
+// WheelEventInit object and copy all values in the value javascript object.
+func WheelEventInitFromJS(value js.Value) *WheelEventInit {
 	var out WheelEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1942,75 +1909,75 @@ func WheelEventInitFromJS(value js.Wrapper) *WheelEventInit {
 		value31 float64                                    // javascript: double {deltaZ DeltaZ deltaZ}
 		value32 uint                                       // javascript: unsigned long {deltaMode DeltaMode deltaMode}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	value29 = (input.Get("deltaX")).Float()
+	value29 = (value.Get("deltaX")).Float()
 	out.DeltaX = value29
-	value30 = (input.Get("deltaY")).Float()
+	value30 = (value.Get("deltaY")).Float()
 	out.DeltaY = value30
-	value31 = (input.Get("deltaZ")).Float()
+	value31 = (value.Get("deltaZ")).Float()
 	out.DeltaZ = value31
-	value32 = (uint)((input.Get("deltaMode")).Int())
+	value32 = (uint)((value.Get("deltaMode")).Int())
 	out.DeltaMode = value32
 	return &out
 }
@@ -2020,15 +1987,19 @@ type CompositionEvent struct {
 	UIEvent
 }
 
-// CompositionEventFromJS is casting a js.Wrapper into CompositionEvent.
-func CompositionEventFromJS(value js.Wrapper) *CompositionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CompositionEventFromJS is casting a js.Value into CompositionEvent.
+func CompositionEventFromJS(value js.Value) *CompositionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CompositionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CompositionEventFromJS is casting from something that holds a js.Value into CompositionEvent.
+func CompositionEventFromWrapper(input core.Wrapper) *CompositionEvent {
+	return CompositionEventFromJS(input.JSValue())
 }
 
 func NewCompositionEvent(_type string, eventInitDict *CompositionEventInit) (_result *CompositionEvent) {
@@ -2068,15 +2039,19 @@ type DragEvent struct {
 	MouseEvent
 }
 
-// DragEventFromJS is casting a js.Wrapper into DragEvent.
-func DragEventFromJS(value js.Wrapper) *DragEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DragEventFromJS is casting a js.Value into DragEvent.
+func DragEventFromJS(value js.Value) *DragEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DragEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DragEventFromJS is casting from something that holds a js.Value into DragEvent.
+func DragEventFromWrapper(input core.Wrapper) *DragEvent {
+	return DragEventFromJS(input.JSValue())
 }
 
 func NewDragEvent(_type string, eventInitDict *DragEventInit) (_result *DragEvent) {
@@ -2118,15 +2093,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewErrorEvent(_type string, eventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -2202,15 +2181,19 @@ type FocusEvent struct {
 	UIEvent
 }
 
-// FocusEventFromJS is casting a js.Wrapper into FocusEvent.
-func FocusEventFromJS(value js.Wrapper) *FocusEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FocusEventFromJS is casting a js.Value into FocusEvent.
+func FocusEventFromJS(value js.Value) *FocusEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FocusEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FocusEventFromJS is casting from something that holds a js.Value into FocusEvent.
+func FocusEventFromWrapper(input core.Wrapper) *FocusEvent {
+	return FocusEventFromJS(input.JSValue())
 }
 
 func NewFocusEvent(_type string, eventInitDict *FocusEventInit) (_result *FocusEvent) {
@@ -2252,15 +2235,19 @@ type HashChangeEvent struct {
 	domcore.Event
 }
 
-// HashChangeEventFromJS is casting a js.Wrapper into HashChangeEvent.
-func HashChangeEventFromJS(value js.Wrapper) *HashChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HashChangeEventFromJS is casting a js.Value into HashChangeEvent.
+func HashChangeEventFromJS(value js.Value) *HashChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HashChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HashChangeEventFromJS is casting from something that holds a js.Value into HashChangeEvent.
+func HashChangeEventFromWrapper(input core.Wrapper) *HashChangeEvent {
+	return HashChangeEventFromJS(input.JSValue())
 }
 
 func NewHashChangeEvent(_type string, eventInitDict *HashChangeEventInit) (_result *HashChangeEvent) {
@@ -2309,15 +2296,19 @@ type InputEvent struct {
 	UIEvent
 }
 
-// InputEventFromJS is casting a js.Wrapper into InputEvent.
-func InputEventFromJS(value js.Wrapper) *InputEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputEventFromJS is casting a js.Value into InputEvent.
+func InputEventFromJS(value js.Value) *InputEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputEventFromJS is casting from something that holds a js.Value into InputEvent.
+func InputEventFromWrapper(input core.Wrapper) *InputEvent {
+	return InputEventFromJS(input.JSValue())
 }
 
 func NewInputEvent(_type string, eventInitDict *InputEventInit) (_result *InputEvent) {
@@ -2411,15 +2402,19 @@ type KeyboardEvent struct {
 	UIEvent
 }
 
-// KeyboardEventFromJS is casting a js.Wrapper into KeyboardEvent.
-func KeyboardEventFromJS(value js.Wrapper) *KeyboardEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyboardEventFromJS is casting a js.Value into KeyboardEvent.
+func KeyboardEventFromJS(value js.Value) *KeyboardEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &KeyboardEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyboardEventFromJS is casting from something that holds a js.Value into KeyboardEvent.
+func KeyboardEventFromWrapper(input core.Wrapper) *KeyboardEvent {
+	return KeyboardEventFromJS(input.JSValue())
 }
 
 const (
@@ -2573,15 +2568,19 @@ type MouseEvent struct {
 	UIEvent
 }
 
-// MouseEventFromJS is casting a js.Wrapper into MouseEvent.
-func MouseEventFromJS(value js.Wrapper) *MouseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MouseEventFromJS is casting a js.Value into MouseEvent.
+func MouseEventFromJS(value js.Value) *MouseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MouseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MouseEventFromJS is casting from something that holds a js.Value into MouseEvent.
+func MouseEventFromWrapper(input core.Wrapper) *MouseEvent {
+	return MouseEventFromJS(input.JSValue())
 }
 
 func NewMouseEvent(_type string, eventInitDict *MouseEventInit) (_result *MouseEvent) {
@@ -2802,15 +2801,19 @@ type PageTransitionEvent struct {
 	domcore.Event
 }
 
-// PageTransitionEventFromJS is casting a js.Wrapper into PageTransitionEvent.
-func PageTransitionEventFromJS(value js.Wrapper) *PageTransitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PageTransitionEventFromJS is casting a js.Value into PageTransitionEvent.
+func PageTransitionEventFromJS(value js.Value) *PageTransitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PageTransitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PageTransitionEventFromJS is casting from something that holds a js.Value into PageTransitionEvent.
+func PageTransitionEventFromWrapper(input core.Wrapper) *PageTransitionEvent {
+	return PageTransitionEventFromJS(input.JSValue())
 }
 
 func NewPageTransitionEvent(_type string, eventInitDict *PageTransitionEventInit) (_result *PageTransitionEvent) {
@@ -2850,15 +2853,19 @@ type PointerEvent struct {
 	MouseEvent
 }
 
-// PointerEventFromJS is casting a js.Wrapper into PointerEvent.
-func PointerEventFromJS(value js.Wrapper) *PointerEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PointerEventFromJS is casting a js.Value into PointerEvent.
+func PointerEventFromJS(value js.Value) *PointerEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PointerEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PointerEventFromJS is casting from something that holds a js.Value into PointerEvent.
+func PointerEventFromWrapper(input core.Wrapper) *PointerEvent {
+	return PointerEventFromJS(input.JSValue())
 }
 
 func NewPointerEvent(_type string, eventInitDict *PointerEventInit) (_result *PointerEvent) {
@@ -3023,15 +3030,19 @@ type PopStateEvent struct {
 	domcore.Event
 }
 
-// PopStateEventFromJS is casting a js.Wrapper into PopStateEvent.
-func PopStateEventFromJS(value js.Wrapper) *PopStateEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PopStateEventFromJS is casting a js.Value into PopStateEvent.
+func PopStateEventFromJS(value js.Value) *PopStateEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PopStateEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PopStateEventFromJS is casting from something that holds a js.Value into PopStateEvent.
+func PopStateEventFromWrapper(input core.Wrapper) *PopStateEvent {
+	return PopStateEventFromJS(input.JSValue())
 }
 
 func NewPopStateEvent(_type string, eventInitDict *PopStateEventInit) (_result *PopStateEvent) {
@@ -3071,15 +3082,19 @@ type PromiseRejectionEvent struct {
 	domcore.Event
 }
 
-// PromiseRejectionEventFromJS is casting a js.Wrapper into PromiseRejectionEvent.
-func PromiseRejectionEventFromJS(value js.Wrapper) *PromiseRejectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRejectionEventFromJS is casting a js.Value into PromiseRejectionEvent.
+func PromiseRejectionEventFromJS(value js.Value) *PromiseRejectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRejectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRejectionEventFromJS is casting from something that holds a js.Value into PromiseRejectionEvent.
+func PromiseRejectionEventFromWrapper(input core.Wrapper) *PromiseRejectionEvent {
+	return PromiseRejectionEventFromJS(input.JSValue())
 }
 
 func NewPromiseRejectionEvent(_type string, eventInitDict *PromiseRejectionEventInit) (_result *PromiseRejectionEvent) {
@@ -3131,15 +3146,19 @@ func (_this *Storage) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StorageFromJS is casting a js.Wrapper into Storage.
-func StorageFromJS(value js.Wrapper) *Storage {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageFromJS is casting a js.Value into Storage.
+func StorageFromJS(value js.Value) *Storage {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Storage{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageFromJS is casting from something that holds a js.Value into Storage.
+func StorageFromWrapper(input core.Wrapper) *Storage {
+	return StorageFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -3279,15 +3298,19 @@ type StorageEvent struct {
 	domcore.Event
 }
 
-// StorageEventFromJS is casting a js.Wrapper into StorageEvent.
-func StorageEventFromJS(value js.Wrapper) *StorageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageEventFromJS is casting a js.Value into StorageEvent.
+func StorageEventFromJS(value js.Value) *StorageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StorageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageEventFromJS is casting from something that holds a js.Value into StorageEvent.
+func StorageEventFromWrapper(input core.Wrapper) *StorageEvent {
+	return StorageEventFromJS(input.JSValue())
 }
 
 func NewStorageEvent(_type string, eventInitDict *StorageEventInit) (_result *StorageEvent) {
@@ -3457,15 +3480,19 @@ type TrackEvent struct {
 	domcore.Event
 }
 
-// TrackEventFromJS is casting a js.Wrapper into TrackEvent.
-func TrackEventFromJS(value js.Wrapper) *TrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TrackEventFromJS is casting a js.Value into TrackEvent.
+func TrackEventFromJS(value js.Value) *TrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TrackEventFromJS is casting from something that holds a js.Value into TrackEvent.
+func TrackEventFromWrapper(input core.Wrapper) *TrackEvent {
+	return TrackEventFromJS(input.JSValue())
 }
 
 func NewTrackEvent(_type string, eventInitDict *TrackEventInit) (_result *TrackEvent) {
@@ -3507,15 +3534,19 @@ type UIEvent struct {
 	domcore.Event
 }
 
-// UIEventFromJS is casting a js.Wrapper into UIEvent.
-func UIEventFromJS(value js.Wrapper) *UIEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UIEventFromJS is casting a js.Value into UIEvent.
+func UIEventFromJS(value js.Value) *UIEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UIEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UIEventFromJS is casting from something that holds a js.Value into UIEvent.
+func UIEventFromWrapper(input core.Wrapper) *UIEvent {
+	return UIEventFromJS(input.JSValue())
 }
 
 func NewUIEvent(_type string, eventInitDict *UIEventInit) (_result *UIEvent) {
@@ -3584,15 +3615,19 @@ type WheelEvent struct {
 	MouseEvent
 }
 
-// WheelEventFromJS is casting a js.Wrapper into WheelEvent.
-func WheelEventFromJS(value js.Wrapper) *WheelEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WheelEventFromJS is casting a js.Value into WheelEvent.
+func WheelEventFromJS(value js.Value) *WheelEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WheelEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WheelEventFromJS is casting from something that holds a js.Value into WheelEvent.
+func WheelEventFromWrapper(input core.Wrapper) *WheelEvent {
+	return WheelEventFromJS(input.JSValue())
 }
 
 const (

--- a/html/htmlevent/htmlevent_js.go
+++ b/html/htmlevent/htmlevent_js.go
@@ -5,6 +5,7 @@ package htmlevent
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/device/inputcapabilities"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -58,7 +59,7 @@ type CompositionEventInit struct {
 	Data               string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CompositionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -80,10 +81,8 @@ func (_this *CompositionEventInit) JSValue() js.Value {
 }
 
 // CompositionEventInitFromJS is allocating a new
-// CompositionEventInit object and copy all values from
-// input javascript object
-func CompositionEventInitFromJS(value js.Wrapper) *CompositionEventInit {
-	input := value.JSValue()
+// CompositionEventInit object and copy all values in the value javascript object.
+func CompositionEventInitFromJS(value js.Value) *CompositionEventInit {
 	var out CompositionEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -94,21 +93,21 @@ func CompositionEventInitFromJS(value js.Wrapper) *CompositionEventInit {
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 		value6 string                                     // javascript: DOMString {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("data")).String()
+	value6 = (value.Get("data")).String()
 	out.Data = value6
 	return &out
 }
@@ -147,7 +146,7 @@ type DragEventInit struct {
 	DataTransfer       *datatransfer.DataTransfer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DragEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -215,10 +214,8 @@ func (_this *DragEventInit) JSValue() js.Value {
 }
 
 // DragEventInitFromJS is allocating a new
-// DragEventInit object and copy all values from
-// input javascript object
-func DragEventInitFromJS(value js.Wrapper) *DragEventInit {
-	input := value.JSValue()
+// DragEventInit object and copy all values in the value javascript object.
+func DragEventInitFromJS(value js.Value) *DragEventInit {
 	var out DragEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -252,70 +249,70 @@ func DragEventInitFromJS(value js.Wrapper) *DragEventInit {
 		value28 int                                        // javascript: long {movementY MovementY movementY}
 		value29 *datatransfer.DataTransfer                 // javascript: DataTransfer {dataTransfer DataTransfer dataTransfer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	if input.Get("dataTransfer").Type() != js.TypeNull && input.Get("dataTransfer").Type() != js.TypeUndefined {
-		value29 = datatransfer.DataTransferFromJS(input.Get("dataTransfer"))
+	if value.Get("dataTransfer").Type() != js.TypeNull && value.Get("dataTransfer").Type() != js.TypeUndefined {
+		value29 = datatransfer.DataTransferFromJS(value.Get("dataTransfer"))
 	}
 	out.DataTransfer = value29
 	return &out
@@ -333,7 +330,7 @@ type ErrorEventInit struct {
 	Error      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -357,10 +354,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -372,21 +367,21 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value6 uint     // javascript: unsigned long {colno Colno colno}
 		value7 js.Value // javascript: any {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("message")).String()
+	value3 = (value.Get("message")).String()
 	out.Message = value3
-	value4 = (input.Get("filename")).String()
+	value4 = (value.Get("filename")).String()
 	out.Filename = value4
-	value5 = (uint)((input.Get("lineno")).Int())
+	value5 = (uint)((value.Get("lineno")).Int())
 	out.Lineno = value5
-	value6 = (uint)((input.Get("colno")).Int())
+	value6 = (uint)((value.Get("colno")).Int())
 	out.Colno = value6
-	value7 = input.Get("error")
+	value7 = value.Get("error")
 	out.Error = value7
 	return &out
 }
@@ -415,7 +410,7 @@ type EventModifierInit struct {
 	ModifierSymbolLock bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventModifierInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -463,10 +458,8 @@ func (_this *EventModifierInit) JSValue() js.Value {
 }
 
 // EventModifierInitFromJS is allocating a new
-// EventModifierInit object and copy all values from
-// input javascript object
-func EventModifierInitFromJS(value js.Wrapper) *EventModifierInit {
-	input := value.JSValue()
+// EventModifierInit object and copy all values in the value javascript object.
+func EventModifierInitFromJS(value js.Value) *EventModifierInit {
 	var out EventModifierInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -490,47 +483,47 @@ func EventModifierInitFromJS(value js.Wrapper) *EventModifierInit {
 		value18 bool                                       // javascript: boolean {modifierSymbol ModifierSymbol modifierSymbol}
 		value19 bool                                       // javascript: boolean {modifierSymbolLock ModifierSymbolLock modifierSymbolLock}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
 	return &out
 }
@@ -546,7 +539,7 @@ type FocusEventInit struct {
 	RelatedTarget      *domcore.EventTarget
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FocusEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -568,10 +561,8 @@ func (_this *FocusEventInit) JSValue() js.Value {
 }
 
 // FocusEventInitFromJS is allocating a new
-// FocusEventInit object and copy all values from
-// input javascript object
-func FocusEventInitFromJS(value js.Wrapper) *FocusEventInit {
-	input := value.JSValue()
+// FocusEventInit object and copy all values in the value javascript object.
+func FocusEventInitFromJS(value js.Value) *FocusEventInit {
 	var out FocusEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -582,22 +573,22 @@ func FocusEventInitFromJS(value js.Wrapper) *FocusEventInit {
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 		value6 *domcore.EventTarget                       // javascript: EventTarget {relatedTarget RelatedTarget relatedTarget}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value6 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value6 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value6
 	return &out
@@ -612,7 +603,7 @@ type HashChangeEventInit struct {
 	NewURL     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *HashChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -630,10 +621,8 @@ func (_this *HashChangeEventInit) JSValue() js.Value {
 }
 
 // HashChangeEventInitFromJS is allocating a new
-// HashChangeEventInit object and copy all values from
-// input javascript object
-func HashChangeEventInitFromJS(value js.Wrapper) *HashChangeEventInit {
-	input := value.JSValue()
+// HashChangeEventInit object and copy all values in the value javascript object.
+func HashChangeEventInitFromJS(value js.Value) *HashChangeEventInit {
 	var out HashChangeEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -642,15 +631,15 @@ func HashChangeEventInitFromJS(value js.Wrapper) *HashChangeEventInit {
 		value3 string // javascript: USVString {oldURL OldURL oldURL}
 		value4 string // javascript: USVString {newURL NewURL newURL}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("oldURL")).String()
+	value3 = (value.Get("oldURL")).String()
 	out.OldURL = value3
-	value4 = (input.Get("newURL")).String()
+	value4 = (value.Get("newURL")).String()
 	out.NewURL = value4
 	return &out
 }
@@ -670,7 +659,7 @@ type InputEventInit struct {
 	TargetRanges       []*dom.StaticRange
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -710,10 +699,8 @@ func (_this *InputEventInit) JSValue() js.Value {
 }
 
 // InputEventInitFromJS is allocating a new
-// InputEventInit object and copy all values from
-// input javascript object
-func InputEventInitFromJS(value js.Wrapper) *InputEventInit {
-	input := value.JSValue()
+// InputEventInit object and copy all values in the value javascript object.
+func InputEventInitFromJS(value js.Value) *InputEventInit {
 	var out InputEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -728,38 +715,38 @@ func InputEventInitFromJS(value js.Wrapper) *InputEventInit {
 		value9  *datatransfer.DataTransfer                 // javascript: DataTransfer {dataTransfer DataTransfer dataTransfer}
 		value10 []*dom.StaticRange                         // javascript: sequence<StaticRange> {targetRanges TargetRanges targetRanges}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	if input.Get("data").Type() != js.TypeNull && input.Get("data").Type() != js.TypeUndefined {
-		__tmp := (input.Get("data")).String()
+	if value.Get("data").Type() != js.TypeNull && value.Get("data").Type() != js.TypeUndefined {
+		__tmp := (value.Get("data")).String()
 		value6 = &__tmp
 	}
 	out.Data = value6
-	value7 = (input.Get("isComposing")).Bool()
+	value7 = (value.Get("isComposing")).Bool()
 	out.IsComposing = value7
-	value8 = (input.Get("inputType")).String()
+	value8 = (value.Get("inputType")).String()
 	out.InputType = value8
-	if input.Get("dataTransfer").Type() != js.TypeNull && input.Get("dataTransfer").Type() != js.TypeUndefined {
-		value9 = datatransfer.DataTransferFromJS(input.Get("dataTransfer"))
+	if value.Get("dataTransfer").Type() != js.TypeNull && value.Get("dataTransfer").Type() != js.TypeUndefined {
+		value9 = datatransfer.DataTransferFromJS(value.Get("dataTransfer"))
 	}
 	out.DataTransfer = value9
-	__length10 := input.Get("targetRanges").Length()
+	__length10 := value.Get("targetRanges").Length()
 	__array10 := make([]*dom.StaticRange, __length10, __length10)
 	for __idx10 := 0; __idx10 < __length10; __idx10++ {
 		var __seq_out10 *dom.StaticRange
-		__seq_in10 := input.Get("targetRanges").Index(__idx10)
+		__seq_in10 := value.Get("targetRanges").Index(__idx10)
 		__seq_out10 = dom.StaticRangeFromJS(__seq_in10)
 		__array10[__idx10] = __seq_out10
 	}
@@ -797,7 +784,7 @@ type KeyboardEventInit struct {
 	IsComposing        bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *KeyboardEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -855,10 +842,8 @@ func (_this *KeyboardEventInit) JSValue() js.Value {
 }
 
 // KeyboardEventInitFromJS is allocating a new
-// KeyboardEventInit object and copy all values from
-// input javascript object
-func KeyboardEventInitFromJS(value js.Wrapper) *KeyboardEventInit {
-	input := value.JSValue()
+// KeyboardEventInit object and copy all values in the value javascript object.
+func KeyboardEventInitFromJS(value js.Value) *KeyboardEventInit {
 	var out KeyboardEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -887,57 +872,57 @@ func KeyboardEventInitFromJS(value js.Wrapper) *KeyboardEventInit {
 		value23 bool                                       // javascript: boolean {repeat Repeat repeat}
 		value24 bool                                       // javascript: boolean {isComposing IsComposing isComposing}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("key")).String()
+	value20 = (value.Get("key")).String()
 	out.Key = value20
-	value21 = (input.Get("code")).String()
+	value21 = (value.Get("code")).String()
 	out.Code = value21
-	value22 = (uint)((input.Get("location")).Int())
+	value22 = (uint)((value.Get("location")).Int())
 	out.Location = value22
-	value23 = (input.Get("repeat")).Bool()
+	value23 = (value.Get("repeat")).Bool()
 	out.Repeat = value23
-	value24 = (input.Get("isComposing")).Bool()
+	value24 = (value.Get("isComposing")).Bool()
 	out.IsComposing = value24
 	return &out
 }
@@ -975,7 +960,7 @@ type MouseEventInit struct {
 	MovementY          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MouseEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1041,10 +1026,8 @@ func (_this *MouseEventInit) JSValue() js.Value {
 }
 
 // MouseEventInitFromJS is allocating a new
-// MouseEventInit object and copy all values from
-// input javascript object
-func MouseEventInitFromJS(value js.Wrapper) *MouseEventInit {
-	input := value.JSValue()
+// MouseEventInit object and copy all values in the value javascript object.
+func MouseEventInitFromJS(value js.Value) *MouseEventInit {
 	var out MouseEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1077,67 +1060,67 @@ func MouseEventInitFromJS(value js.Wrapper) *MouseEventInit {
 		value27 int                                        // javascript: long {movementX MovementX movementX}
 		value28 int                                        // javascript: long {movementY MovementY movementY}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
 	return &out
 }
@@ -1150,7 +1133,7 @@ type PageTransitionEventInit struct {
 	Persisted  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PageTransitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1166,10 +1149,8 @@ func (_this *PageTransitionEventInit) JSValue() js.Value {
 }
 
 // PageTransitionEventInitFromJS is allocating a new
-// PageTransitionEventInit object and copy all values from
-// input javascript object
-func PageTransitionEventInitFromJS(value js.Wrapper) *PageTransitionEventInit {
-	input := value.JSValue()
+// PageTransitionEventInit object and copy all values in the value javascript object.
+func PageTransitionEventInitFromJS(value js.Value) *PageTransitionEventInit {
 	var out PageTransitionEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -1177,13 +1158,13 @@ func PageTransitionEventInitFromJS(value js.Wrapper) *PageTransitionEventInit {
 		value2 bool // javascript: boolean {composed Composed composed}
 		value3 bool // javascript: boolean {persisted Persisted persisted}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("persisted")).Bool()
+	value3 = (value.Get("persisted")).Bool()
 	out.Persisted = value3
 	return &out
 }
@@ -1233,7 +1214,7 @@ type PointerEventInit struct {
 	PredictedEvents    []*PointerEvent
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PointerEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1331,10 +1312,8 @@ func (_this *PointerEventInit) JSValue() js.Value {
 }
 
 // PointerEventInitFromJS is allocating a new
-// PointerEventInit object and copy all values from
-// input javascript object
-func PointerEventInitFromJS(value js.Wrapper) *PointerEventInit {
-	input := value.JSValue()
+// PointerEventInit object and copy all values in the value javascript object.
+func PointerEventInitFromJS(value js.Value) *PointerEventInit {
 	var out PointerEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1379,103 +1358,103 @@ func PointerEventInitFromJS(value js.Wrapper) *PointerEventInit {
 		value39 []*PointerEvent                            // javascript: sequence<PointerEvent> {coalescedEvents CoalescedEvents coalescedEvents}
 		value40 []*PointerEvent                            // javascript: sequence<PointerEvent> {predictedEvents PredictedEvents predictedEvents}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	value29 = (input.Get("pointerId")).Int()
+	value29 = (value.Get("pointerId")).Int()
 	out.PointerId = value29
-	value30 = (input.Get("width")).Float()
+	value30 = (value.Get("width")).Float()
 	out.Width = value30
-	value31 = (input.Get("height")).Float()
+	value31 = (value.Get("height")).Float()
 	out.Height = value31
-	value32 = (float32)((input.Get("pressure")).Float())
+	value32 = (float32)((value.Get("pressure")).Float())
 	out.Pressure = value32
-	value33 = (float32)((input.Get("tangentialPressure")).Float())
+	value33 = (float32)((value.Get("tangentialPressure")).Float())
 	out.TangentialPressure = value33
-	value34 = (input.Get("tiltX")).Int()
+	value34 = (value.Get("tiltX")).Int()
 	out.TiltX = value34
-	value35 = (input.Get("tiltY")).Int()
+	value35 = (value.Get("tiltY")).Int()
 	out.TiltY = value35
-	value36 = (input.Get("twist")).Int()
+	value36 = (value.Get("twist")).Int()
 	out.Twist = value36
-	value37 = (input.Get("pointerType")).String()
+	value37 = (value.Get("pointerType")).String()
 	out.PointerType = value37
-	value38 = (input.Get("isPrimary")).Bool()
+	value38 = (value.Get("isPrimary")).Bool()
 	out.IsPrimary = value38
-	__length39 := input.Get("coalescedEvents").Length()
+	__length39 := value.Get("coalescedEvents").Length()
 	__array39 := make([]*PointerEvent, __length39, __length39)
 	for __idx39 := 0; __idx39 < __length39; __idx39++ {
 		var __seq_out39 *PointerEvent
-		__seq_in39 := input.Get("coalescedEvents").Index(__idx39)
+		__seq_in39 := value.Get("coalescedEvents").Index(__idx39)
 		__seq_out39 = PointerEventFromJS(__seq_in39)
 		__array39[__idx39] = __seq_out39
 	}
 	value39 = __array39
 	out.CoalescedEvents = value39
-	__length40 := input.Get("predictedEvents").Length()
+	__length40 := value.Get("predictedEvents").Length()
 	__array40 := make([]*PointerEvent, __length40, __length40)
 	for __idx40 := 0; __idx40 < __length40; __idx40++ {
 		var __seq_out40 *PointerEvent
-		__seq_in40 := input.Get("predictedEvents").Index(__idx40)
+		__seq_in40 := value.Get("predictedEvents").Index(__idx40)
 		__seq_out40 = PointerEventFromJS(__seq_in40)
 		__array40[__idx40] = __seq_out40
 	}
@@ -1492,7 +1471,7 @@ type PopStateEventInit struct {
 	State      js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PopStateEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1508,10 +1487,8 @@ func (_this *PopStateEventInit) JSValue() js.Value {
 }
 
 // PopStateEventInitFromJS is allocating a new
-// PopStateEventInit object and copy all values from
-// input javascript object
-func PopStateEventInitFromJS(value js.Wrapper) *PopStateEventInit {
-	input := value.JSValue()
+// PopStateEventInit object and copy all values in the value javascript object.
+func PopStateEventInitFromJS(value js.Value) *PopStateEventInit {
 	var out PopStateEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1519,13 +1496,13 @@ func PopStateEventInitFromJS(value js.Wrapper) *PopStateEventInit {
 		value2 bool     // javascript: boolean {composed Composed composed}
 		value3 js.Value // javascript: any {state State state}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("state")
+	value3 = value.Get("state")
 	out.State = value3
 	return &out
 }
@@ -1539,7 +1516,7 @@ type PromiseRejectionEventInit struct {
 	Reason     js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PromiseRejectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1557,10 +1534,8 @@ func (_this *PromiseRejectionEventInit) JSValue() js.Value {
 }
 
 // PromiseRejectionEventInitFromJS is allocating a new
-// PromiseRejectionEventInit object and copy all values from
-// input javascript object
-func PromiseRejectionEventInitFromJS(value js.Wrapper) *PromiseRejectionEventInit {
-	input := value.JSValue()
+// PromiseRejectionEventInit object and copy all values in the value javascript object.
+func PromiseRejectionEventInitFromJS(value js.Value) *PromiseRejectionEventInit {
 	var out PromiseRejectionEventInit
 	var (
 		value0 bool                // javascript: boolean {bubbles Bubbles bubbles}
@@ -1569,15 +1544,15 @@ func PromiseRejectionEventInitFromJS(value js.Wrapper) *PromiseRejectionEventIni
 		value3 *javascript.Promise // javascript: Promise {promise Promise promise}
 		value4 js.Value            // javascript: any {reason Reason reason}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = javascript.PromiseFromJS(input.Get("promise"))
+	value3 = javascript.PromiseFromJS(value.Get("promise"))
 	out.Promise = value3
-	value4 = input.Get("reason")
+	value4 = value.Get("reason")
 	out.Reason = value4
 	return &out
 }
@@ -1594,7 +1569,7 @@ type StorageEventInit struct {
 	StorageArea *Storage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StorageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1636,10 +1611,8 @@ func (_this *StorageEventInit) JSValue() js.Value {
 }
 
 // StorageEventInitFromJS is allocating a new
-// StorageEventInit object and copy all values from
-// input javascript object
-func StorageEventInitFromJS(value js.Wrapper) *StorageEventInit {
-	input := value.JSValue()
+// StorageEventInit object and copy all values in the value javascript object.
+func StorageEventInitFromJS(value js.Value) *StorageEventInit {
 	var out StorageEventInit
 	var (
 		value0 bool     // javascript: boolean {bubbles Bubbles bubbles}
@@ -1651,31 +1624,31 @@ func StorageEventInitFromJS(value js.Wrapper) *StorageEventInit {
 		value6 string   // javascript: USVString {url Url url}
 		value7 *Storage // javascript: Storage {storageArea StorageArea storageArea}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("key").Type() != js.TypeNull && input.Get("key").Type() != js.TypeUndefined {
-		__tmp := (input.Get("key")).String()
+	if value.Get("key").Type() != js.TypeNull && value.Get("key").Type() != js.TypeUndefined {
+		__tmp := (value.Get("key")).String()
 		value3 = &__tmp
 	}
 	out.Key = value3
-	if input.Get("oldValue").Type() != js.TypeNull && input.Get("oldValue").Type() != js.TypeUndefined {
-		__tmp := (input.Get("oldValue")).String()
+	if value.Get("oldValue").Type() != js.TypeNull && value.Get("oldValue").Type() != js.TypeUndefined {
+		__tmp := (value.Get("oldValue")).String()
 		value4 = &__tmp
 	}
 	out.OldValue = value4
-	if input.Get("newValue").Type() != js.TypeNull && input.Get("newValue").Type() != js.TypeUndefined {
-		__tmp := (input.Get("newValue")).String()
+	if value.Get("newValue").Type() != js.TypeNull && value.Get("newValue").Type() != js.TypeUndefined {
+		__tmp := (value.Get("newValue")).String()
 		value5 = &__tmp
 	}
 	out.NewValue = value5
-	value6 = (input.Get("url")).String()
+	value6 = (value.Get("url")).String()
 	out.Url = value6
-	if input.Get("storageArea").Type() != js.TypeNull && input.Get("storageArea").Type() != js.TypeUndefined {
-		value7 = StorageFromJS(input.Get("storageArea"))
+	if value.Get("storageArea").Type() != js.TypeNull && value.Get("storageArea").Type() != js.TypeUndefined {
+		value7 = StorageFromJS(value.Get("storageArea"))
 	}
 	out.StorageArea = value7
 	return &out
@@ -1689,7 +1662,7 @@ type TrackEventInit struct {
 	Track      *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1705,10 +1678,8 @@ func (_this *TrackEventInit) JSValue() js.Value {
 }
 
 // TrackEventInitFromJS is allocating a new
-// TrackEventInit object and copy all values from
-// input javascript object
-func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
-	input := value.JSValue()
+// TrackEventInit object and copy all values in the value javascript object.
+func TrackEventInitFromJS(value js.Value) *TrackEventInit {
 	var out TrackEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1716,14 +1687,14 @@ func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Union // javascript: Union {track Track track}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("track").Type() != js.TypeNull && input.Get("track").Type() != js.TypeUndefined {
-		value3 = UnionFromJS(input.Get("track"))
+	if value.Get("track").Type() != js.TypeNull && value.Get("track").Type() != js.TypeUndefined {
+		value3 = UnionFromJS(value.Get("track"))
 	}
 	out.Track = value3
 	return &out
@@ -1739,7 +1710,7 @@ type UIEventInit struct {
 	SourceCapabilities *inputcapabilities.InputDeviceCapabilities
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *UIEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1759,10 +1730,8 @@ func (_this *UIEventInit) JSValue() js.Value {
 }
 
 // UIEventInitFromJS is allocating a new
-// UIEventInit object and copy all values from
-// input javascript object
-func UIEventInitFromJS(value js.Wrapper) *UIEventInit {
-	input := value.JSValue()
+// UIEventInit object and copy all values in the value javascript object.
+func UIEventInitFromJS(value js.Value) *UIEventInit {
 	var out UIEventInit
 	var (
 		value0 bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1772,18 +1741,18 @@ func UIEventInitFromJS(value js.Wrapper) *UIEventInit {
 		value4 int                                        // javascript: long {detail Detail detail}
 		value5 *inputcapabilities.InputDeviceCapabilities // javascript: InputDeviceCapabilities {sourceCapabilities SourceCapabilities sourceCapabilities}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
 	return &out
@@ -1826,7 +1795,7 @@ type WheelEventInit struct {
 	DeltaMode          uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WheelEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1900,10 +1869,8 @@ func (_this *WheelEventInit) JSValue() js.Value {
 }
 
 // WheelEventInitFromJS is allocating a new
-// WheelEventInit object and copy all values from
-// input javascript object
-func WheelEventInitFromJS(value js.Wrapper) *WheelEventInit {
-	input := value.JSValue()
+// WheelEventInit object and copy all values in the value javascript object.
+func WheelEventInitFromJS(value js.Value) *WheelEventInit {
 	var out WheelEventInit
 	var (
 		value0  bool                                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -1940,75 +1907,75 @@ func WheelEventInitFromJS(value js.Wrapper) *WheelEventInit {
 		value31 float64                                    // javascript: double {deltaZ DeltaZ deltaZ}
 		value32 uint                                       // javascript: unsigned long {deltaMode DeltaMode deltaMode}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("view")
+	value3 = value.Get("view")
 	out.View = value3
-	value4 = (input.Get("detail")).Int()
+	value4 = (value.Get("detail")).Int()
 	out.Detail = value4
-	if input.Get("sourceCapabilities").Type() != js.TypeNull && input.Get("sourceCapabilities").Type() != js.TypeUndefined {
-		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(input.Get("sourceCapabilities"))
+	if value.Get("sourceCapabilities").Type() != js.TypeNull && value.Get("sourceCapabilities").Type() != js.TypeUndefined {
+		value5 = inputcapabilities.InputDeviceCapabilitiesFromJS(value.Get("sourceCapabilities"))
 	}
 	out.SourceCapabilities = value5
-	value6 = (input.Get("ctrlKey")).Bool()
+	value6 = (value.Get("ctrlKey")).Bool()
 	out.CtrlKey = value6
-	value7 = (input.Get("shiftKey")).Bool()
+	value7 = (value.Get("shiftKey")).Bool()
 	out.ShiftKey = value7
-	value8 = (input.Get("altKey")).Bool()
+	value8 = (value.Get("altKey")).Bool()
 	out.AltKey = value8
-	value9 = (input.Get("metaKey")).Bool()
+	value9 = (value.Get("metaKey")).Bool()
 	out.MetaKey = value9
-	value10 = (input.Get("modifierAltGraph")).Bool()
+	value10 = (value.Get("modifierAltGraph")).Bool()
 	out.ModifierAltGraph = value10
-	value11 = (input.Get("modifierCapsLock")).Bool()
+	value11 = (value.Get("modifierCapsLock")).Bool()
 	out.ModifierCapsLock = value11
-	value12 = (input.Get("modifierFn")).Bool()
+	value12 = (value.Get("modifierFn")).Bool()
 	out.ModifierFn = value12
-	value13 = (input.Get("modifierFnLock")).Bool()
+	value13 = (value.Get("modifierFnLock")).Bool()
 	out.ModifierFnLock = value13
-	value14 = (input.Get("modifierHyper")).Bool()
+	value14 = (value.Get("modifierHyper")).Bool()
 	out.ModifierHyper = value14
-	value15 = (input.Get("modifierNumLock")).Bool()
+	value15 = (value.Get("modifierNumLock")).Bool()
 	out.ModifierNumLock = value15
-	value16 = (input.Get("modifierScrollLock")).Bool()
+	value16 = (value.Get("modifierScrollLock")).Bool()
 	out.ModifierScrollLock = value16
-	value17 = (input.Get("modifierSuper")).Bool()
+	value17 = (value.Get("modifierSuper")).Bool()
 	out.ModifierSuper = value17
-	value18 = (input.Get("modifierSymbol")).Bool()
+	value18 = (value.Get("modifierSymbol")).Bool()
 	out.ModifierSymbol = value18
-	value19 = (input.Get("modifierSymbolLock")).Bool()
+	value19 = (value.Get("modifierSymbolLock")).Bool()
 	out.ModifierSymbolLock = value19
-	value20 = (input.Get("button")).Int()
+	value20 = (value.Get("button")).Int()
 	out.Button = value20
-	value21 = (input.Get("buttons")).Int()
+	value21 = (value.Get("buttons")).Int()
 	out.Buttons = value21
-	if input.Get("relatedTarget").Type() != js.TypeNull && input.Get("relatedTarget").Type() != js.TypeUndefined {
-		value22 = domcore.EventTargetFromJS(input.Get("relatedTarget"))
+	if value.Get("relatedTarget").Type() != js.TypeNull && value.Get("relatedTarget").Type() != js.TypeUndefined {
+		value22 = domcore.EventTargetFromJS(value.Get("relatedTarget"))
 	}
 	out.RelatedTarget = value22
-	value23 = (input.Get("screenX")).Float()
+	value23 = (value.Get("screenX")).Float()
 	out.ScreenX = value23
-	value24 = (input.Get("screenY")).Float()
+	value24 = (value.Get("screenY")).Float()
 	out.ScreenY = value24
-	value25 = (input.Get("clientX")).Float()
+	value25 = (value.Get("clientX")).Float()
 	out.ClientX = value25
-	value26 = (input.Get("clientY")).Float()
+	value26 = (value.Get("clientY")).Float()
 	out.ClientY = value26
-	value27 = (input.Get("movementX")).Int()
+	value27 = (value.Get("movementX")).Int()
 	out.MovementX = value27
-	value28 = (input.Get("movementY")).Int()
+	value28 = (value.Get("movementY")).Int()
 	out.MovementY = value28
-	value29 = (input.Get("deltaX")).Float()
+	value29 = (value.Get("deltaX")).Float()
 	out.DeltaX = value29
-	value30 = (input.Get("deltaY")).Float()
+	value30 = (value.Get("deltaY")).Float()
 	out.DeltaY = value30
-	value31 = (input.Get("deltaZ")).Float()
+	value31 = (value.Get("deltaZ")).Float()
 	out.DeltaZ = value31
-	value32 = (uint)((input.Get("deltaMode")).Int())
+	value32 = (uint)((value.Get("deltaMode")).Int())
 	out.DeltaMode = value32
 	return &out
 }
@@ -2018,15 +1985,19 @@ type CompositionEvent struct {
 	UIEvent
 }
 
-// CompositionEventFromJS is casting a js.Wrapper into CompositionEvent.
-func CompositionEventFromJS(value js.Wrapper) *CompositionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CompositionEventFromJS is casting a js.Value into CompositionEvent.
+func CompositionEventFromJS(value js.Value) *CompositionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CompositionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CompositionEventFromJS is casting from something that holds a js.Value into CompositionEvent.
+func CompositionEventFromWrapper(input core.Wrapper) *CompositionEvent {
+	return CompositionEventFromJS(input.JSValue())
 }
 
 func NewCompositionEvent(_type string, eventInitDict *CompositionEventInit) (_result *CompositionEvent) {
@@ -2066,15 +2037,19 @@ type DragEvent struct {
 	MouseEvent
 }
 
-// DragEventFromJS is casting a js.Wrapper into DragEvent.
-func DragEventFromJS(value js.Wrapper) *DragEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DragEventFromJS is casting a js.Value into DragEvent.
+func DragEventFromJS(value js.Value) *DragEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DragEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DragEventFromJS is casting from something that holds a js.Value into DragEvent.
+func DragEventFromWrapper(input core.Wrapper) *DragEvent {
+	return DragEventFromJS(input.JSValue())
 }
 
 func NewDragEvent(_type string, eventInitDict *DragEventInit) (_result *DragEvent) {
@@ -2116,15 +2091,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewErrorEvent(_type string, eventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -2200,15 +2179,19 @@ type FocusEvent struct {
 	UIEvent
 }
 
-// FocusEventFromJS is casting a js.Wrapper into FocusEvent.
-func FocusEventFromJS(value js.Wrapper) *FocusEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FocusEventFromJS is casting a js.Value into FocusEvent.
+func FocusEventFromJS(value js.Value) *FocusEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FocusEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FocusEventFromJS is casting from something that holds a js.Value into FocusEvent.
+func FocusEventFromWrapper(input core.Wrapper) *FocusEvent {
+	return FocusEventFromJS(input.JSValue())
 }
 
 func NewFocusEvent(_type string, eventInitDict *FocusEventInit) (_result *FocusEvent) {
@@ -2250,15 +2233,19 @@ type HashChangeEvent struct {
 	domcore.Event
 }
 
-// HashChangeEventFromJS is casting a js.Wrapper into HashChangeEvent.
-func HashChangeEventFromJS(value js.Wrapper) *HashChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HashChangeEventFromJS is casting a js.Value into HashChangeEvent.
+func HashChangeEventFromJS(value js.Value) *HashChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HashChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HashChangeEventFromJS is casting from something that holds a js.Value into HashChangeEvent.
+func HashChangeEventFromWrapper(input core.Wrapper) *HashChangeEvent {
+	return HashChangeEventFromJS(input.JSValue())
 }
 
 func NewHashChangeEvent(_type string, eventInitDict *HashChangeEventInit) (_result *HashChangeEvent) {
@@ -2307,15 +2294,19 @@ type InputEvent struct {
 	UIEvent
 }
 
-// InputEventFromJS is casting a js.Wrapper into InputEvent.
-func InputEventFromJS(value js.Wrapper) *InputEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputEventFromJS is casting a js.Value into InputEvent.
+func InputEventFromJS(value js.Value) *InputEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputEventFromJS is casting from something that holds a js.Value into InputEvent.
+func InputEventFromWrapper(input core.Wrapper) *InputEvent {
+	return InputEventFromJS(input.JSValue())
 }
 
 func NewInputEvent(_type string, eventInitDict *InputEventInit) (_result *InputEvent) {
@@ -2409,15 +2400,19 @@ type KeyboardEvent struct {
 	UIEvent
 }
 
-// KeyboardEventFromJS is casting a js.Wrapper into KeyboardEvent.
-func KeyboardEventFromJS(value js.Wrapper) *KeyboardEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// KeyboardEventFromJS is casting a js.Value into KeyboardEvent.
+func KeyboardEventFromJS(value js.Value) *KeyboardEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &KeyboardEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// KeyboardEventFromJS is casting from something that holds a js.Value into KeyboardEvent.
+func KeyboardEventFromWrapper(input core.Wrapper) *KeyboardEvent {
+	return KeyboardEventFromJS(input.JSValue())
 }
 
 const (
@@ -2571,15 +2566,19 @@ type MouseEvent struct {
 	UIEvent
 }
 
-// MouseEventFromJS is casting a js.Wrapper into MouseEvent.
-func MouseEventFromJS(value js.Wrapper) *MouseEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MouseEventFromJS is casting a js.Value into MouseEvent.
+func MouseEventFromJS(value js.Value) *MouseEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MouseEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MouseEventFromJS is casting from something that holds a js.Value into MouseEvent.
+func MouseEventFromWrapper(input core.Wrapper) *MouseEvent {
+	return MouseEventFromJS(input.JSValue())
 }
 
 func NewMouseEvent(_type string, eventInitDict *MouseEventInit) (_result *MouseEvent) {
@@ -2800,15 +2799,19 @@ type PageTransitionEvent struct {
 	domcore.Event
 }
 
-// PageTransitionEventFromJS is casting a js.Wrapper into PageTransitionEvent.
-func PageTransitionEventFromJS(value js.Wrapper) *PageTransitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PageTransitionEventFromJS is casting a js.Value into PageTransitionEvent.
+func PageTransitionEventFromJS(value js.Value) *PageTransitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PageTransitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PageTransitionEventFromJS is casting from something that holds a js.Value into PageTransitionEvent.
+func PageTransitionEventFromWrapper(input core.Wrapper) *PageTransitionEvent {
+	return PageTransitionEventFromJS(input.JSValue())
 }
 
 func NewPageTransitionEvent(_type string, eventInitDict *PageTransitionEventInit) (_result *PageTransitionEvent) {
@@ -2848,15 +2851,19 @@ type PointerEvent struct {
 	MouseEvent
 }
 
-// PointerEventFromJS is casting a js.Wrapper into PointerEvent.
-func PointerEventFromJS(value js.Wrapper) *PointerEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PointerEventFromJS is casting a js.Value into PointerEvent.
+func PointerEventFromJS(value js.Value) *PointerEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PointerEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PointerEventFromJS is casting from something that holds a js.Value into PointerEvent.
+func PointerEventFromWrapper(input core.Wrapper) *PointerEvent {
+	return PointerEventFromJS(input.JSValue())
 }
 
 func NewPointerEvent(_type string, eventInitDict *PointerEventInit) (_result *PointerEvent) {
@@ -3021,15 +3028,19 @@ type PopStateEvent struct {
 	domcore.Event
 }
 
-// PopStateEventFromJS is casting a js.Wrapper into PopStateEvent.
-func PopStateEventFromJS(value js.Wrapper) *PopStateEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PopStateEventFromJS is casting a js.Value into PopStateEvent.
+func PopStateEventFromJS(value js.Value) *PopStateEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PopStateEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PopStateEventFromJS is casting from something that holds a js.Value into PopStateEvent.
+func PopStateEventFromWrapper(input core.Wrapper) *PopStateEvent {
+	return PopStateEventFromJS(input.JSValue())
 }
 
 func NewPopStateEvent(_type string, eventInitDict *PopStateEventInit) (_result *PopStateEvent) {
@@ -3069,15 +3080,19 @@ type PromiseRejectionEvent struct {
 	domcore.Event
 }
 
-// PromiseRejectionEventFromJS is casting a js.Wrapper into PromiseRejectionEvent.
-func PromiseRejectionEventFromJS(value js.Wrapper) *PromiseRejectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseRejectionEventFromJS is casting a js.Value into PromiseRejectionEvent.
+func PromiseRejectionEventFromJS(value js.Value) *PromiseRejectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseRejectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseRejectionEventFromJS is casting from something that holds a js.Value into PromiseRejectionEvent.
+func PromiseRejectionEventFromWrapper(input core.Wrapper) *PromiseRejectionEvent {
+	return PromiseRejectionEventFromJS(input.JSValue())
 }
 
 func NewPromiseRejectionEvent(_type string, eventInitDict *PromiseRejectionEventInit) (_result *PromiseRejectionEvent) {
@@ -3129,15 +3144,19 @@ func (_this *Storage) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StorageFromJS is casting a js.Wrapper into Storage.
-func StorageFromJS(value js.Wrapper) *Storage {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageFromJS is casting a js.Value into Storage.
+func StorageFromJS(value js.Value) *Storage {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Storage{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageFromJS is casting from something that holds a js.Value into Storage.
+func StorageFromWrapper(input core.Wrapper) *Storage {
+	return StorageFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -3277,15 +3296,19 @@ type StorageEvent struct {
 	domcore.Event
 }
 
-// StorageEventFromJS is casting a js.Wrapper into StorageEvent.
-func StorageEventFromJS(value js.Wrapper) *StorageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageEventFromJS is casting a js.Value into StorageEvent.
+func StorageEventFromJS(value js.Value) *StorageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StorageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageEventFromJS is casting from something that holds a js.Value into StorageEvent.
+func StorageEventFromWrapper(input core.Wrapper) *StorageEvent {
+	return StorageEventFromJS(input.JSValue())
 }
 
 func NewStorageEvent(_type string, eventInitDict *StorageEventInit) (_result *StorageEvent) {
@@ -3455,15 +3478,19 @@ type TrackEvent struct {
 	domcore.Event
 }
 
-// TrackEventFromJS is casting a js.Wrapper into TrackEvent.
-func TrackEventFromJS(value js.Wrapper) *TrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TrackEventFromJS is casting a js.Value into TrackEvent.
+func TrackEventFromJS(value js.Value) *TrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TrackEventFromJS is casting from something that holds a js.Value into TrackEvent.
+func TrackEventFromWrapper(input core.Wrapper) *TrackEvent {
+	return TrackEventFromJS(input.JSValue())
 }
 
 func NewTrackEvent(_type string, eventInitDict *TrackEventInit) (_result *TrackEvent) {
@@ -3505,15 +3532,19 @@ type UIEvent struct {
 	domcore.Event
 }
 
-// UIEventFromJS is casting a js.Wrapper into UIEvent.
-func UIEventFromJS(value js.Wrapper) *UIEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// UIEventFromJS is casting a js.Value into UIEvent.
+func UIEventFromJS(value js.Value) *UIEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &UIEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// UIEventFromJS is casting from something that holds a js.Value into UIEvent.
+func UIEventFromWrapper(input core.Wrapper) *UIEvent {
+	return UIEventFromJS(input.JSValue())
 }
 
 func NewUIEvent(_type string, eventInitDict *UIEventInit) (_result *UIEvent) {
@@ -3582,15 +3613,19 @@ type WheelEvent struct {
 	MouseEvent
 }
 
-// WheelEventFromJS is casting a js.Wrapper into WheelEvent.
-func WheelEventFromJS(value js.Wrapper) *WheelEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WheelEventFromJS is casting a js.Value into WheelEvent.
+func WheelEventFromJS(value js.Value) *WheelEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WheelEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WheelEventFromJS is casting from something that holds a js.Value into WheelEvent.
+func WheelEventFromWrapper(input core.Wrapper) *WheelEvent {
+	return WheelEventFromJS(input.JSValue())
 }
 
 const (

--- a/html/htmlmisc/htmlmisc.go
+++ b/html/htmlmisc/htmlmisc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gowebapi/webapi/communication/bluetooth"
 	"github.com/gowebapi/webapi/communication/netinfo"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto/credential"
 	"github.com/gowebapi/webapi/device/battery"
 	"github.com/gowebapi/webapi/device/gamepad"
@@ -186,7 +187,7 @@ type ElementDefinitionOptions struct {
 	Extends string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ElementDefinitionOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -196,15 +197,13 @@ func (_this *ElementDefinitionOptions) JSValue() js.Value {
 }
 
 // ElementDefinitionOptionsFromJS is allocating a new
-// ElementDefinitionOptions object and copy all values from
-// input javascript object
-func ElementDefinitionOptionsFromJS(value js.Wrapper) *ElementDefinitionOptions {
-	input := value.JSValue()
+// ElementDefinitionOptions object and copy all values in the value javascript object.
+func ElementDefinitionOptionsFromJS(value js.Value) *ElementDefinitionOptions {
 	var out ElementDefinitionOptions
 	var (
 		value0 string // javascript: DOMString {extends Extends extends}
 	)
-	value0 = (input.Get("extends")).String()
+	value0 = (value.Get("extends")).String()
 	out.Extends = value0
 	return &out
 }
@@ -214,7 +213,7 @@ type EventSourceInit struct {
 	WithCredentials bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventSourceInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -224,15 +223,13 @@ func (_this *EventSourceInit) JSValue() js.Value {
 }
 
 // EventSourceInitFromJS is allocating a new
-// EventSourceInit object and copy all values from
-// input javascript object
-func EventSourceInitFromJS(value js.Wrapper) *EventSourceInit {
-	input := value.JSValue()
+// EventSourceInit object and copy all values in the value javascript object.
+func EventSourceInitFromJS(value js.Value) *EventSourceInit {
 	var out EventSourceInit
 	var (
 		value0 bool // javascript: boolean {withCredentials WithCredentials withCredentials}
 	)
-	value0 = (input.Get("withCredentials")).Bool()
+	value0 = (value.Get("withCredentials")).Bool()
 	out.WithCredentials = value0
 	return &out
 }
@@ -242,7 +239,7 @@ type ImageBitmapRenderingContextSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageBitmapRenderingContextSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -252,15 +249,13 @@ func (_this *ImageBitmapRenderingContextSettings) JSValue() js.Value {
 }
 
 // ImageBitmapRenderingContextSettingsFromJS is allocating a new
-// ImageBitmapRenderingContextSettings object and copy all values from
-// input javascript object
-func ImageBitmapRenderingContextSettingsFromJS(value js.Wrapper) *ImageBitmapRenderingContextSettings {
-	input := value.JSValue()
+// ImageBitmapRenderingContextSettings object and copy all values in the value javascript object.
+func ImageBitmapRenderingContextSettingsFromJS(value js.Value) *ImageBitmapRenderingContextSettings {
 	var out ImageBitmapRenderingContextSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -270,15 +265,19 @@ type ApplicationCache struct {
 	domcore.EventTarget
 }
 
-// ApplicationCacheFromJS is casting a js.Wrapper into ApplicationCache.
-func ApplicationCacheFromJS(value js.Wrapper) *ApplicationCache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ApplicationCacheFromJS is casting a js.Value into ApplicationCache.
+func ApplicationCacheFromJS(value js.Value) *ApplicationCache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ApplicationCache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ApplicationCacheFromJS is casting from something that holds a js.Value into ApplicationCache.
+func ApplicationCacheFromWrapper(input core.Wrapper) *ApplicationCache {
+	return ApplicationCacheFromJS(input.JSValue())
 }
 
 const (
@@ -580,15 +579,19 @@ func (_this *BarProp) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BarPropFromJS is casting a js.Wrapper into BarProp.
-func BarPropFromJS(value js.Wrapper) *BarProp {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BarPropFromJS is casting a js.Value into BarProp.
+func BarPropFromJS(value js.Value) *BarProp {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BarProp{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BarPropFromJS is casting from something that holds a js.Value into BarProp.
+func BarPropFromWrapper(input core.Wrapper) *BarProp {
+	return BarPropFromJS(input.JSValue())
 }
 
 // Visible returning attribute 'visible' with
@@ -610,15 +613,19 @@ func (_this *CustomElementRegistry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CustomElementRegistryFromJS is casting a js.Wrapper into CustomElementRegistry.
-func CustomElementRegistryFromJS(value js.Wrapper) *CustomElementRegistry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CustomElementRegistryFromJS is casting a js.Value into CustomElementRegistry.
+func CustomElementRegistryFromJS(value js.Value) *CustomElementRegistry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CustomElementRegistry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CustomElementRegistryFromJS is casting from something that holds a js.Value into CustomElementRegistry.
+func CustomElementRegistryFromWrapper(input core.Wrapper) *CustomElementRegistry {
+	return CustomElementRegistryFromJS(input.JSValue())
 }
 
 func (_this *CustomElementRegistry) Define(name string, constructor *CustomElementConstructor, options *ElementDefinitionOptions) {
@@ -699,15 +706,19 @@ type EventSource struct {
 	domcore.EventTarget
 }
 
-// EventSourceFromJS is casting a js.Wrapper into EventSource.
-func EventSourceFromJS(value js.Wrapper) *EventSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventSourceFromJS is casting a js.Value into EventSource.
+func EventSourceFromJS(value js.Value) *EventSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventSourceFromJS is casting from something that holds a js.Value into EventSource.
+func EventSourceFromWrapper(input core.Wrapper) *EventSource {
+	return EventSourceFromJS(input.JSValue())
 }
 
 const (
@@ -908,15 +919,19 @@ func (_this *External) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ExternalFromJS is casting a js.Wrapper into External.
-func ExternalFromJS(value js.Wrapper) *External {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExternalFromJS is casting a js.Value into External.
+func ExternalFromJS(value js.Value) *External {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &External{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExternalFromJS is casting from something that holds a js.Value into External.
+func ExternalFromWrapper(input core.Wrapper) *External {
+	return ExternalFromJS(input.JSValue())
 }
 
 func (_this *External) AddSearchProvider() {
@@ -947,15 +962,19 @@ func (_this *History) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HistoryFromJS is casting a js.Wrapper into History.
-func HistoryFromJS(value js.Wrapper) *History {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HistoryFromJS is casting a js.Value into History.
+func HistoryFromJS(value js.Value) *History {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &History{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HistoryFromJS is casting from something that holds a js.Value into History.
+func HistoryFromWrapper(input core.Wrapper) *History {
+	return HistoryFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1092,15 +1111,19 @@ func (_this *Location) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LocationFromJS is casting a js.Wrapper into Location.
-func LocationFromJS(value js.Wrapper) *Location {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LocationFromJS is casting a js.Value into Location.
+func LocationFromJS(value js.Value) *Location {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Location{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LocationFromJS is casting from something that holds a js.Value into Location.
+func LocationFromWrapper(input core.Wrapper) *Location {
+	return LocationFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1297,15 +1320,19 @@ func (_this *MimeType) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MimeTypeFromJS is casting a js.Wrapper into MimeType.
-func MimeTypeFromJS(value js.Wrapper) *MimeType {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MimeTypeFromJS is casting a js.Value into MimeType.
+func MimeTypeFromJS(value js.Value) *MimeType {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MimeType{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MimeTypeFromJS is casting from something that holds a js.Value into MimeType.
+func MimeTypeFromWrapper(input core.Wrapper) *MimeType {
+	return MimeTypeFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -1354,15 +1381,19 @@ func (_this *MimeTypeArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MimeTypeArrayFromJS is casting a js.Wrapper into MimeTypeArray.
-func MimeTypeArrayFromJS(value js.Wrapper) *MimeTypeArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MimeTypeArrayFromJS is casting a js.Value into MimeTypeArray.
+func MimeTypeArrayFromJS(value js.Value) *MimeTypeArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MimeTypeArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MimeTypeArrayFromJS is casting from something that holds a js.Value into MimeTypeArray.
+func MimeTypeArrayFromWrapper(input core.Wrapper) *MimeTypeArray {
+	return MimeTypeArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1460,15 +1491,19 @@ func (_this *Navigator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NavigatorFromJS is casting a js.Wrapper into Navigator.
-func NavigatorFromJS(value js.Wrapper) *Navigator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigatorFromJS is casting a js.Value into Navigator.
+func NavigatorFromJS(value js.Value) *Navigator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Navigator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigatorFromJS is casting from something that holds a js.Value into Navigator.
+func NavigatorFromWrapper(input core.Wrapper) *Navigator {
+	return NavigatorFromJS(input.JSValue())
 }
 
 // Clipboard returning attribute 'clipboard' with
@@ -2057,15 +2092,19 @@ func (_this *Plugin) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PluginFromJS is casting a js.Wrapper into Plugin.
-func PluginFromJS(value js.Wrapper) *Plugin {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PluginFromJS is casting a js.Value into Plugin.
+func PluginFromJS(value js.Value) *Plugin {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Plugin{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PluginFromJS is casting from something that holds a js.Value into Plugin.
+func PluginFromWrapper(input core.Wrapper) *Plugin {
+	return PluginFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -2190,15 +2229,19 @@ func (_this *PluginArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PluginArrayFromJS is casting a js.Wrapper into PluginArray.
-func PluginArrayFromJS(value js.Wrapper) *PluginArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PluginArrayFromJS is casting a js.Value into PluginArray.
+func PluginArrayFromJS(value js.Value) *PluginArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PluginArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PluginArrayFromJS is casting from something that holds a js.Value into PluginArray.
+func PluginArrayFromWrapper(input core.Wrapper) *PluginArray {
+	return PluginArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2311,15 +2354,19 @@ type RadioNodeList struct {
 	dom.NodeList
 }
 
-// RadioNodeListFromJS is casting a js.Wrapper into RadioNodeList.
-func RadioNodeListFromJS(value js.Wrapper) *RadioNodeList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RadioNodeListFromJS is casting a js.Value into RadioNodeList.
+func RadioNodeListFromJS(value js.Value) *RadioNodeList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RadioNodeList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RadioNodeListFromJS is casting from something that holds a js.Value into RadioNodeList.
+func RadioNodeListFromWrapper(input core.Wrapper) *RadioNodeList {
+	return RadioNodeListFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with

--- a/html/htmlmisc/htmlmisc_js.go
+++ b/html/htmlmisc/htmlmisc_js.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gowebapi/webapi/communication/bluetooth"
 	"github.com/gowebapi/webapi/communication/netinfo"
 	"github.com/gowebapi/webapi/communication/xhr"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto/credential"
 	"github.com/gowebapi/webapi/device/battery"
 	"github.com/gowebapi/webapi/device/gamepad"
@@ -184,7 +185,7 @@ type ElementDefinitionOptions struct {
 	Extends string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ElementDefinitionOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -194,15 +195,13 @@ func (_this *ElementDefinitionOptions) JSValue() js.Value {
 }
 
 // ElementDefinitionOptionsFromJS is allocating a new
-// ElementDefinitionOptions object and copy all values from
-// input javascript object
-func ElementDefinitionOptionsFromJS(value js.Wrapper) *ElementDefinitionOptions {
-	input := value.JSValue()
+// ElementDefinitionOptions object and copy all values in the value javascript object.
+func ElementDefinitionOptionsFromJS(value js.Value) *ElementDefinitionOptions {
 	var out ElementDefinitionOptions
 	var (
 		value0 string // javascript: DOMString {extends Extends extends}
 	)
-	value0 = (input.Get("extends")).String()
+	value0 = (value.Get("extends")).String()
 	out.Extends = value0
 	return &out
 }
@@ -212,7 +211,7 @@ type EventSourceInit struct {
 	WithCredentials bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventSourceInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -222,15 +221,13 @@ func (_this *EventSourceInit) JSValue() js.Value {
 }
 
 // EventSourceInitFromJS is allocating a new
-// EventSourceInit object and copy all values from
-// input javascript object
-func EventSourceInitFromJS(value js.Wrapper) *EventSourceInit {
-	input := value.JSValue()
+// EventSourceInit object and copy all values in the value javascript object.
+func EventSourceInitFromJS(value js.Value) *EventSourceInit {
 	var out EventSourceInit
 	var (
 		value0 bool // javascript: boolean {withCredentials WithCredentials withCredentials}
 	)
-	value0 = (input.Get("withCredentials")).Bool()
+	value0 = (value.Get("withCredentials")).Bool()
 	out.WithCredentials = value0
 	return &out
 }
@@ -240,7 +237,7 @@ type ImageBitmapRenderingContextSettings struct {
 	Alpha bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageBitmapRenderingContextSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -250,15 +247,13 @@ func (_this *ImageBitmapRenderingContextSettings) JSValue() js.Value {
 }
 
 // ImageBitmapRenderingContextSettingsFromJS is allocating a new
-// ImageBitmapRenderingContextSettings object and copy all values from
-// input javascript object
-func ImageBitmapRenderingContextSettingsFromJS(value js.Wrapper) *ImageBitmapRenderingContextSettings {
-	input := value.JSValue()
+// ImageBitmapRenderingContextSettings object and copy all values in the value javascript object.
+func ImageBitmapRenderingContextSettingsFromJS(value js.Value) *ImageBitmapRenderingContextSettings {
 	var out ImageBitmapRenderingContextSettings
 	var (
 		value0 bool // javascript: boolean {alpha Alpha alpha}
 	)
-	value0 = (input.Get("alpha")).Bool()
+	value0 = (value.Get("alpha")).Bool()
 	out.Alpha = value0
 	return &out
 }
@@ -268,15 +263,19 @@ type ApplicationCache struct {
 	domcore.EventTarget
 }
 
-// ApplicationCacheFromJS is casting a js.Wrapper into ApplicationCache.
-func ApplicationCacheFromJS(value js.Wrapper) *ApplicationCache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ApplicationCacheFromJS is casting a js.Value into ApplicationCache.
+func ApplicationCacheFromJS(value js.Value) *ApplicationCache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ApplicationCache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ApplicationCacheFromJS is casting from something that holds a js.Value into ApplicationCache.
+func ApplicationCacheFromWrapper(input core.Wrapper) *ApplicationCache {
+	return ApplicationCacheFromJS(input.JSValue())
 }
 
 const (
@@ -578,15 +577,19 @@ func (_this *BarProp) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BarPropFromJS is casting a js.Wrapper into BarProp.
-func BarPropFromJS(value js.Wrapper) *BarProp {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BarPropFromJS is casting a js.Value into BarProp.
+func BarPropFromJS(value js.Value) *BarProp {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BarProp{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BarPropFromJS is casting from something that holds a js.Value into BarProp.
+func BarPropFromWrapper(input core.Wrapper) *BarProp {
+	return BarPropFromJS(input.JSValue())
 }
 
 // Visible returning attribute 'visible' with
@@ -608,15 +611,19 @@ func (_this *CustomElementRegistry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CustomElementRegistryFromJS is casting a js.Wrapper into CustomElementRegistry.
-func CustomElementRegistryFromJS(value js.Wrapper) *CustomElementRegistry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CustomElementRegistryFromJS is casting a js.Value into CustomElementRegistry.
+func CustomElementRegistryFromJS(value js.Value) *CustomElementRegistry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CustomElementRegistry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CustomElementRegistryFromJS is casting from something that holds a js.Value into CustomElementRegistry.
+func CustomElementRegistryFromWrapper(input core.Wrapper) *CustomElementRegistry {
+	return CustomElementRegistryFromJS(input.JSValue())
 }
 
 func (_this *CustomElementRegistry) Define(name string, constructor *CustomElementConstructor, options *ElementDefinitionOptions) {
@@ -697,15 +704,19 @@ type EventSource struct {
 	domcore.EventTarget
 }
 
-// EventSourceFromJS is casting a js.Wrapper into EventSource.
-func EventSourceFromJS(value js.Wrapper) *EventSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventSourceFromJS is casting a js.Value into EventSource.
+func EventSourceFromJS(value js.Value) *EventSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventSourceFromJS is casting from something that holds a js.Value into EventSource.
+func EventSourceFromWrapper(input core.Wrapper) *EventSource {
+	return EventSourceFromJS(input.JSValue())
 }
 
 const (
@@ -906,15 +917,19 @@ func (_this *External) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ExternalFromJS is casting a js.Wrapper into External.
-func ExternalFromJS(value js.Wrapper) *External {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExternalFromJS is casting a js.Value into External.
+func ExternalFromJS(value js.Value) *External {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &External{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExternalFromJS is casting from something that holds a js.Value into External.
+func ExternalFromWrapper(input core.Wrapper) *External {
+	return ExternalFromJS(input.JSValue())
 }
 
 func (_this *External) AddSearchProvider() {
@@ -945,15 +960,19 @@ func (_this *History) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// HistoryFromJS is casting a js.Wrapper into History.
-func HistoryFromJS(value js.Wrapper) *History {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HistoryFromJS is casting a js.Value into History.
+func HistoryFromJS(value js.Value) *History {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &History{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HistoryFromJS is casting from something that holds a js.Value into History.
+func HistoryFromWrapper(input core.Wrapper) *History {
+	return HistoryFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1090,15 +1109,19 @@ func (_this *Location) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// LocationFromJS is casting a js.Wrapper into Location.
-func LocationFromJS(value js.Wrapper) *Location {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LocationFromJS is casting a js.Value into Location.
+func LocationFromJS(value js.Value) *Location {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Location{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LocationFromJS is casting from something that holds a js.Value into Location.
+func LocationFromWrapper(input core.Wrapper) *Location {
+	return LocationFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1295,15 +1318,19 @@ func (_this *MimeType) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MimeTypeFromJS is casting a js.Wrapper into MimeType.
-func MimeTypeFromJS(value js.Wrapper) *MimeType {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MimeTypeFromJS is casting a js.Value into MimeType.
+func MimeTypeFromJS(value js.Value) *MimeType {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MimeType{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MimeTypeFromJS is casting from something that holds a js.Value into MimeType.
+func MimeTypeFromWrapper(input core.Wrapper) *MimeType {
+	return MimeTypeFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -1352,15 +1379,19 @@ func (_this *MimeTypeArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MimeTypeArrayFromJS is casting a js.Wrapper into MimeTypeArray.
-func MimeTypeArrayFromJS(value js.Wrapper) *MimeTypeArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MimeTypeArrayFromJS is casting a js.Value into MimeTypeArray.
+func MimeTypeArrayFromJS(value js.Value) *MimeTypeArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MimeTypeArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MimeTypeArrayFromJS is casting from something that holds a js.Value into MimeTypeArray.
+func MimeTypeArrayFromWrapper(input core.Wrapper) *MimeTypeArray {
+	return MimeTypeArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1458,15 +1489,19 @@ func (_this *Navigator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NavigatorFromJS is casting a js.Wrapper into Navigator.
-func NavigatorFromJS(value js.Wrapper) *Navigator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigatorFromJS is casting a js.Value into Navigator.
+func NavigatorFromJS(value js.Value) *Navigator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Navigator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigatorFromJS is casting from something that holds a js.Value into Navigator.
+func NavigatorFromWrapper(input core.Wrapper) *Navigator {
+	return NavigatorFromJS(input.JSValue())
 }
 
 // Clipboard returning attribute 'clipboard' with
@@ -2055,15 +2090,19 @@ func (_this *Plugin) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PluginFromJS is casting a js.Wrapper into Plugin.
-func PluginFromJS(value js.Wrapper) *Plugin {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PluginFromJS is casting a js.Value into Plugin.
+func PluginFromJS(value js.Value) *Plugin {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Plugin{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PluginFromJS is casting from something that holds a js.Value into Plugin.
+func PluginFromWrapper(input core.Wrapper) *Plugin {
+	return PluginFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -2188,15 +2227,19 @@ func (_this *PluginArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PluginArrayFromJS is casting a js.Wrapper into PluginArray.
-func PluginArrayFromJS(value js.Wrapper) *PluginArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PluginArrayFromJS is casting a js.Value into PluginArray.
+func PluginArrayFromJS(value js.Value) *PluginArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PluginArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PluginArrayFromJS is casting from something that holds a js.Value into PluginArray.
+func PluginArrayFromWrapper(input core.Wrapper) *PluginArray {
+	return PluginArrayFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2309,15 +2352,19 @@ type RadioNodeList struct {
 	dom.NodeList
 }
 
-// RadioNodeListFromJS is casting a js.Wrapper into RadioNodeList.
-func RadioNodeListFromJS(value js.Wrapper) *RadioNodeList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RadioNodeListFromJS is casting a js.Value into RadioNodeList.
+func RadioNodeListFromJS(value js.Value) *RadioNodeList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RadioNodeList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RadioNodeListFromJS is casting from something that holds a js.Value into RadioNodeList.
+func RadioNodeListFromWrapper(input core.Wrapper) *RadioNodeList {
+	return RadioNodeListFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with

--- a/html/media/media.go
+++ b/html/media/media.go
@@ -7,6 +7,7 @@ package media
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html"
 	"github.com/gowebapi/webapi/html/htmlevent"
@@ -326,15 +327,19 @@ func (_this *AudioTrack) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioTrackFromJS is casting a js.Wrapper into AudioTrack.
-func AudioTrackFromJS(value js.Wrapper) *AudioTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioTrackFromJS is casting a js.Value into AudioTrack.
+func AudioTrackFromJS(value js.Value) *AudioTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioTrackFromJS is casting from something that holds a js.Value into AudioTrack.
+func AudioTrackFromWrapper(input core.Wrapper) *AudioTrack {
+	return AudioTrackFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -405,15 +410,19 @@ type AudioTrackList struct {
 	domcore.EventTarget
 }
 
-// AudioTrackListFromJS is casting a js.Wrapper into AudioTrackList.
-func AudioTrackListFromJS(value js.Wrapper) *AudioTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioTrackListFromJS is casting a js.Value into AudioTrackList.
+func AudioTrackListFromJS(value js.Value) *AudioTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioTrackListFromJS is casting from something that holds a js.Value into AudioTrackList.
+func AudioTrackListFromWrapper(input core.Wrapper) *AudioTrackList {
+	return AudioTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -575,15 +584,19 @@ type HTMLAudioElement struct {
 	HTMLMediaElement
 }
 
-// HTMLAudioElementFromJS is casting a js.Wrapper into HTMLAudioElement.
-func HTMLAudioElementFromJS(value js.Wrapper) *HTMLAudioElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAudioElementFromJS is casting a js.Value into HTMLAudioElement.
+func HTMLAudioElementFromJS(value js.Value) *HTMLAudioElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAudioElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAudioElementFromJS is casting from something that holds a js.Value into HTMLAudioElement.
+func HTMLAudioElementFromWrapper(input core.Wrapper) *HTMLAudioElement {
+	return HTMLAudioElementFromJS(input.JSValue())
 }
 
 // class: HTMLMediaElement
@@ -591,15 +604,19 @@ type HTMLMediaElement struct {
 	html.HTMLElement
 }
 
-// HTMLMediaElementFromJS is casting a js.Wrapper into HTMLMediaElement.
-func HTMLMediaElementFromJS(value js.Wrapper) *HTMLMediaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMediaElementFromJS is casting a js.Value into HTMLMediaElement.
+func HTMLMediaElementFromJS(value js.Value) *HTMLMediaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMediaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMediaElementFromJS is casting from something that holds a js.Value into HTMLMediaElement.
+func HTMLMediaElementFromWrapper(input core.Wrapper) *HTMLMediaElement {
+	return HTMLMediaElementFromJS(input.JSValue())
 }
 
 const (
@@ -1254,15 +1271,19 @@ type HTMLTrackElement struct {
 	html.HTMLElement
 }
 
-// HTMLTrackElementFromJS is casting a js.Wrapper into HTMLTrackElement.
-func HTMLTrackElementFromJS(value js.Wrapper) *HTMLTrackElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTrackElementFromJS is casting a js.Value into HTMLTrackElement.
+func HTMLTrackElementFromJS(value js.Value) *HTMLTrackElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTrackElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTrackElementFromJS is casting from something that holds a js.Value into HTMLTrackElement.
+func HTMLTrackElementFromWrapper(input core.Wrapper) *HTMLTrackElement {
+	return HTMLTrackElementFromJS(input.JSValue())
 }
 
 const (
@@ -1375,15 +1396,19 @@ type HTMLVideoElement struct {
 	HTMLMediaElement
 }
 
-// HTMLVideoElementFromJS is casting a js.Wrapper into HTMLVideoElement.
-func HTMLVideoElementFromJS(value js.Wrapper) *HTMLVideoElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLVideoElementFromJS is casting a js.Value into HTMLVideoElement.
+func HTMLVideoElementFromJS(value js.Value) *HTMLVideoElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLVideoElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLVideoElementFromJS is casting from something that holds a js.Value into HTMLVideoElement.
+func HTMLVideoElementFromWrapper(input core.Wrapper) *HTMLVideoElement {
+	return HTMLVideoElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -1606,15 +1631,19 @@ func (_this *MediaError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaErrorFromJS is casting a js.Wrapper into MediaError.
-func MediaErrorFromJS(value js.Wrapper) *MediaError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaErrorFromJS is casting a js.Value into MediaError.
+func MediaErrorFromJS(value js.Value) *MediaError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaErrorFromJS is casting from something that holds a js.Value into MediaError.
+func MediaErrorFromWrapper(input core.Wrapper) *MediaError {
+	return MediaErrorFromJS(input.JSValue())
 }
 
 const (
@@ -1647,15 +1676,19 @@ type MediaSource struct {
 	domcore.EventTarget
 }
 
-// MediaSourceFromJS is casting a js.Wrapper into MediaSource.
-func MediaSourceFromJS(value js.Wrapper) *MediaSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSourceFromJS is casting a js.Value into MediaSource.
+func MediaSourceFromJS(value js.Value) *MediaSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSourceFromJS is casting from something that holds a js.Value into MediaSource.
+func MediaSourceFromWrapper(input core.Wrapper) *MediaSource {
+	return MediaSourceFromJS(input.JSValue())
 }
 
 func IsTypeSupported(_type string) (_result bool) {
@@ -1902,15 +1935,19 @@ type SourceBuffer struct {
 	domcore.EventTarget
 }
 
-// SourceBufferFromJS is casting a js.Wrapper into SourceBuffer.
-func SourceBufferFromJS(value js.Wrapper) *SourceBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SourceBufferFromJS is casting a js.Value into SourceBuffer.
+func SourceBufferFromJS(value js.Value) *SourceBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SourceBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SourceBufferFromJS is casting from something that holds a js.Value into SourceBuffer.
+func SourceBufferFromWrapper(input core.Wrapper) *SourceBuffer {
+	return SourceBufferFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -2212,15 +2249,19 @@ type SourceBufferList struct {
 	domcore.EventTarget
 }
 
-// SourceBufferListFromJS is casting a js.Wrapper into SourceBufferList.
-func SourceBufferListFromJS(value js.Wrapper) *SourceBufferList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SourceBufferListFromJS is casting a js.Value into SourceBufferList.
+func SourceBufferListFromJS(value js.Value) *SourceBufferList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SourceBufferList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SourceBufferListFromJS is casting from something that holds a js.Value into SourceBufferList.
+func SourceBufferListFromWrapper(input core.Wrapper) *SourceBufferList {
+	return SourceBufferListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2322,15 +2363,19 @@ type TextTrack struct {
 	domcore.EventTarget
 }
 
-// TextTrackFromJS is casting a js.Wrapper into TextTrack.
-func TextTrackFromJS(value js.Wrapper) *TextTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackFromJS is casting a js.Value into TextTrack.
+func TextTrackFromJS(value js.Value) *TextTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackFromJS is casting from something that holds a js.Value into TextTrack.
+func TextTrackFromWrapper(input core.Wrapper) *TextTrack {
+	return TextTrackFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -2497,15 +2542,19 @@ type TextTrackCue struct {
 	domcore.EventTarget
 }
 
-// TextTrackCueFromJS is casting a js.Wrapper into TextTrackCue.
-func TextTrackCueFromJS(value js.Wrapper) *TextTrackCue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackCueFromJS is casting a js.Value into TextTrackCue.
+func TextTrackCueFromJS(value js.Value) *TextTrackCue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackCue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackCueFromJS is casting from something that holds a js.Value into TextTrackCue.
+func TextTrackCueFromWrapper(input core.Wrapper) *TextTrackCue {
+	return TextTrackCueFromJS(input.JSValue())
 }
 
 // Track returning attribute 'track' with
@@ -2661,15 +2710,19 @@ func (_this *TextTrackCueList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TextTrackCueListFromJS is casting a js.Wrapper into TextTrackCueList.
-func TextTrackCueListFromJS(value js.Wrapper) *TextTrackCueList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackCueListFromJS is casting a js.Value into TextTrackCueList.
+func TextTrackCueListFromJS(value js.Value) *TextTrackCueList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackCueList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackCueListFromJS is casting from something that holds a js.Value into TextTrackCueList.
+func TextTrackCueListFromWrapper(input core.Wrapper) *TextTrackCueList {
+	return TextTrackCueListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2722,15 +2775,19 @@ type TextTrackList struct {
 	domcore.EventTarget
 }
 
-// TextTrackListFromJS is casting a js.Wrapper into TextTrackList.
-func TextTrackListFromJS(value js.Wrapper) *TextTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackListFromJS is casting a js.Value into TextTrackList.
+func TextTrackListFromJS(value js.Value) *TextTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackListFromJS is casting from something that holds a js.Value into TextTrackList.
+func TextTrackListFromWrapper(input core.Wrapper) *TextTrackList {
+	return TextTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2897,15 +2954,19 @@ func (_this *VideoTrack) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// VideoTrackFromJS is casting a js.Wrapper into VideoTrack.
-func VideoTrackFromJS(value js.Wrapper) *VideoTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VideoTrackFromJS is casting a js.Value into VideoTrack.
+func VideoTrackFromJS(value js.Value) *VideoTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VideoTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VideoTrackFromJS is casting from something that holds a js.Value into VideoTrack.
+func VideoTrackFromWrapper(input core.Wrapper) *VideoTrack {
+	return VideoTrackFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -2976,15 +3037,19 @@ type VideoTrackList struct {
 	domcore.EventTarget
 }
 
-// VideoTrackListFromJS is casting a js.Wrapper into VideoTrackList.
-func VideoTrackListFromJS(value js.Wrapper) *VideoTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VideoTrackListFromJS is casting a js.Value into VideoTrackList.
+func VideoTrackListFromJS(value js.Value) *VideoTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VideoTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VideoTrackListFromJS is casting from something that holds a js.Value into VideoTrackList.
+func VideoTrackListFromWrapper(input core.Wrapper) *VideoTrackList {
+	return VideoTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/html/media/media_js.go
+++ b/html/media/media_js.go
@@ -5,6 +5,7 @@ package media
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html"
 	"github.com/gowebapi/webapi/html/htmlevent"
@@ -324,15 +325,19 @@ func (_this *AudioTrack) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioTrackFromJS is casting a js.Wrapper into AudioTrack.
-func AudioTrackFromJS(value js.Wrapper) *AudioTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioTrackFromJS is casting a js.Value into AudioTrack.
+func AudioTrackFromJS(value js.Value) *AudioTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioTrackFromJS is casting from something that holds a js.Value into AudioTrack.
+func AudioTrackFromWrapper(input core.Wrapper) *AudioTrack {
+	return AudioTrackFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -403,15 +408,19 @@ type AudioTrackList struct {
 	domcore.EventTarget
 }
 
-// AudioTrackListFromJS is casting a js.Wrapper into AudioTrackList.
-func AudioTrackListFromJS(value js.Wrapper) *AudioTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioTrackListFromJS is casting a js.Value into AudioTrackList.
+func AudioTrackListFromJS(value js.Value) *AudioTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioTrackListFromJS is casting from something that holds a js.Value into AudioTrackList.
+func AudioTrackListFromWrapper(input core.Wrapper) *AudioTrackList {
+	return AudioTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -573,15 +582,19 @@ type HTMLAudioElement struct {
 	HTMLMediaElement
 }
 
-// HTMLAudioElementFromJS is casting a js.Wrapper into HTMLAudioElement.
-func HTMLAudioElementFromJS(value js.Wrapper) *HTMLAudioElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLAudioElementFromJS is casting a js.Value into HTMLAudioElement.
+func HTMLAudioElementFromJS(value js.Value) *HTMLAudioElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLAudioElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLAudioElementFromJS is casting from something that holds a js.Value into HTMLAudioElement.
+func HTMLAudioElementFromWrapper(input core.Wrapper) *HTMLAudioElement {
+	return HTMLAudioElementFromJS(input.JSValue())
 }
 
 // class: HTMLMediaElement
@@ -589,15 +602,19 @@ type HTMLMediaElement struct {
 	html.HTMLElement
 }
 
-// HTMLMediaElementFromJS is casting a js.Wrapper into HTMLMediaElement.
-func HTMLMediaElementFromJS(value js.Wrapper) *HTMLMediaElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLMediaElementFromJS is casting a js.Value into HTMLMediaElement.
+func HTMLMediaElementFromJS(value js.Value) *HTMLMediaElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLMediaElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLMediaElementFromJS is casting from something that holds a js.Value into HTMLMediaElement.
+func HTMLMediaElementFromWrapper(input core.Wrapper) *HTMLMediaElement {
+	return HTMLMediaElementFromJS(input.JSValue())
 }
 
 const (
@@ -1252,15 +1269,19 @@ type HTMLTrackElement struct {
 	html.HTMLElement
 }
 
-// HTMLTrackElementFromJS is casting a js.Wrapper into HTMLTrackElement.
-func HTMLTrackElementFromJS(value js.Wrapper) *HTMLTrackElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLTrackElementFromJS is casting a js.Value into HTMLTrackElement.
+func HTMLTrackElementFromJS(value js.Value) *HTMLTrackElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLTrackElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLTrackElementFromJS is casting from something that holds a js.Value into HTMLTrackElement.
+func HTMLTrackElementFromWrapper(input core.Wrapper) *HTMLTrackElement {
+	return HTMLTrackElementFromJS(input.JSValue())
 }
 
 const (
@@ -1373,15 +1394,19 @@ type HTMLVideoElement struct {
 	HTMLMediaElement
 }
 
-// HTMLVideoElementFromJS is casting a js.Wrapper into HTMLVideoElement.
-func HTMLVideoElementFromJS(value js.Wrapper) *HTMLVideoElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLVideoElementFromJS is casting a js.Value into HTMLVideoElement.
+func HTMLVideoElementFromJS(value js.Value) *HTMLVideoElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLVideoElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLVideoElementFromJS is casting from something that holds a js.Value into HTMLVideoElement.
+func HTMLVideoElementFromWrapper(input core.Wrapper) *HTMLVideoElement {
+	return HTMLVideoElementFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -1604,15 +1629,19 @@ func (_this *MediaError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaErrorFromJS is casting a js.Wrapper into MediaError.
-func MediaErrorFromJS(value js.Wrapper) *MediaError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaErrorFromJS is casting a js.Value into MediaError.
+func MediaErrorFromJS(value js.Value) *MediaError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaErrorFromJS is casting from something that holds a js.Value into MediaError.
+func MediaErrorFromWrapper(input core.Wrapper) *MediaError {
+	return MediaErrorFromJS(input.JSValue())
 }
 
 const (
@@ -1645,15 +1674,19 @@ type MediaSource struct {
 	domcore.EventTarget
 }
 
-// MediaSourceFromJS is casting a js.Wrapper into MediaSource.
-func MediaSourceFromJS(value js.Wrapper) *MediaSource {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSourceFromJS is casting a js.Value into MediaSource.
+func MediaSourceFromJS(value js.Value) *MediaSource {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSource{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSourceFromJS is casting from something that holds a js.Value into MediaSource.
+func MediaSourceFromWrapper(input core.Wrapper) *MediaSource {
+	return MediaSourceFromJS(input.JSValue())
 }
 
 func IsTypeSupported(_type string) (_result bool) {
@@ -1900,15 +1933,19 @@ type SourceBuffer struct {
 	domcore.EventTarget
 }
 
-// SourceBufferFromJS is casting a js.Wrapper into SourceBuffer.
-func SourceBufferFromJS(value js.Wrapper) *SourceBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SourceBufferFromJS is casting a js.Value into SourceBuffer.
+func SourceBufferFromJS(value js.Value) *SourceBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SourceBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SourceBufferFromJS is casting from something that holds a js.Value into SourceBuffer.
+func SourceBufferFromWrapper(input core.Wrapper) *SourceBuffer {
+	return SourceBufferFromJS(input.JSValue())
 }
 
 // Mode returning attribute 'mode' with
@@ -2210,15 +2247,19 @@ type SourceBufferList struct {
 	domcore.EventTarget
 }
 
-// SourceBufferListFromJS is casting a js.Wrapper into SourceBufferList.
-func SourceBufferListFromJS(value js.Wrapper) *SourceBufferList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SourceBufferListFromJS is casting a js.Value into SourceBufferList.
+func SourceBufferListFromJS(value js.Value) *SourceBufferList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SourceBufferList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SourceBufferListFromJS is casting from something that holds a js.Value into SourceBufferList.
+func SourceBufferListFromWrapper(input core.Wrapper) *SourceBufferList {
+	return SourceBufferListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2320,15 +2361,19 @@ type TextTrack struct {
 	domcore.EventTarget
 }
 
-// TextTrackFromJS is casting a js.Wrapper into TextTrack.
-func TextTrackFromJS(value js.Wrapper) *TextTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackFromJS is casting a js.Value into TextTrack.
+func TextTrackFromJS(value js.Value) *TextTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackFromJS is casting from something that holds a js.Value into TextTrack.
+func TextTrackFromWrapper(input core.Wrapper) *TextTrack {
+	return TextTrackFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -2495,15 +2540,19 @@ type TextTrackCue struct {
 	domcore.EventTarget
 }
 
-// TextTrackCueFromJS is casting a js.Wrapper into TextTrackCue.
-func TextTrackCueFromJS(value js.Wrapper) *TextTrackCue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackCueFromJS is casting a js.Value into TextTrackCue.
+func TextTrackCueFromJS(value js.Value) *TextTrackCue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackCue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackCueFromJS is casting from something that holds a js.Value into TextTrackCue.
+func TextTrackCueFromWrapper(input core.Wrapper) *TextTrackCue {
+	return TextTrackCueFromJS(input.JSValue())
 }
 
 // Track returning attribute 'track' with
@@ -2659,15 +2708,19 @@ func (_this *TextTrackCueList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TextTrackCueListFromJS is casting a js.Wrapper into TextTrackCueList.
-func TextTrackCueListFromJS(value js.Wrapper) *TextTrackCueList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackCueListFromJS is casting a js.Value into TextTrackCueList.
+func TextTrackCueListFromJS(value js.Value) *TextTrackCueList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackCueList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackCueListFromJS is casting from something that holds a js.Value into TextTrackCueList.
+func TextTrackCueListFromWrapper(input core.Wrapper) *TextTrackCueList {
+	return TextTrackCueListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2720,15 +2773,19 @@ type TextTrackList struct {
 	domcore.EventTarget
 }
 
-// TextTrackListFromJS is casting a js.Wrapper into TextTrackList.
-func TextTrackListFromJS(value js.Wrapper) *TextTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TextTrackListFromJS is casting a js.Value into TextTrackList.
+func TextTrackListFromJS(value js.Value) *TextTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TextTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TextTrackListFromJS is casting from something that holds a js.Value into TextTrackList.
+func TextTrackListFromWrapper(input core.Wrapper) *TextTrackList {
+	return TextTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -2895,15 +2952,19 @@ func (_this *VideoTrack) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// VideoTrackFromJS is casting a js.Wrapper into VideoTrack.
-func VideoTrackFromJS(value js.Wrapper) *VideoTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VideoTrackFromJS is casting a js.Value into VideoTrack.
+func VideoTrackFromJS(value js.Value) *VideoTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VideoTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VideoTrackFromJS is casting from something that holds a js.Value into VideoTrack.
+func VideoTrackFromWrapper(input core.Wrapper) *VideoTrack {
+	return VideoTrackFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -2974,15 +3035,19 @@ type VideoTrackList struct {
 	domcore.EventTarget
 }
 
-// VideoTrackListFromJS is casting a js.Wrapper into VideoTrackList.
-func VideoTrackListFromJS(value js.Wrapper) *VideoTrackList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VideoTrackListFromJS is casting a js.Value into VideoTrackList.
+func VideoTrackListFromJS(value js.Value) *VideoTrackList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VideoTrackList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VideoTrackListFromJS is casting from something that holds a js.Value into VideoTrackList.
+func VideoTrackListFromWrapper(input core.Wrapper) *VideoTrackList {
+	return VideoTrackListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with

--- a/html/selection/selection.go
+++ b/html/selection/selection.go
@@ -7,6 +7,7 @@ package selection
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 )
 
@@ -47,15 +48,19 @@ func (_this *Selection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SelectionFromJS is casting a js.Wrapper into Selection.
-func SelectionFromJS(value js.Wrapper) *Selection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SelectionFromJS is casting a js.Value into Selection.
+func SelectionFromJS(value js.Value) *Selection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Selection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SelectionFromJS is casting from something that holds a js.Value into Selection.
+func SelectionFromWrapper(input core.Wrapper) *Selection {
+	return SelectionFromJS(input.JSValue())
 }
 
 // AnchorNode returning attribute 'anchorNode' with

--- a/html/selection/selection_js.go
+++ b/html/selection/selection_js.go
@@ -5,6 +5,7 @@ package selection
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 )
 
@@ -45,15 +46,19 @@ func (_this *Selection) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SelectionFromJS is casting a js.Wrapper into Selection.
-func SelectionFromJS(value js.Wrapper) *Selection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SelectionFromJS is casting a js.Value into Selection.
+func SelectionFromJS(value js.Value) *Selection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Selection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SelectionFromJS is casting from something that holds a js.Value into Selection.
+func SelectionFromWrapper(input core.Wrapper) *Selection {
+	return SelectionFromJS(input.JSValue())
 }
 
 // AnchorNode returning attribute 'anchorNode' with

--- a/html/worker/worker.go
+++ b/html/worker/worker.go
@@ -9,6 +9,7 @@ import js "github.com/gowebapi/webapi/core/js"
 import (
 	"github.com/gowebapi/webapi/communication/netinfo"
 	"github.com/gowebapi/webapi/cookie"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto"
 	"github.com/gowebapi/webapi/device/usb"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -110,7 +111,7 @@ type WorkerOptions struct {
 	Name        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WorkerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -124,21 +125,19 @@ func (_this *WorkerOptions) JSValue() js.Value {
 }
 
 // WorkerOptionsFromJS is allocating a new
-// WorkerOptions object and copy all values from
-// input javascript object
-func WorkerOptionsFromJS(value js.Wrapper) *WorkerOptions {
-	input := value.JSValue()
+// WorkerOptions object and copy all values in the value javascript object.
+func WorkerOptionsFromJS(value js.Value) *WorkerOptions {
 	var out WorkerOptions
 	var (
 		value0 htmlcommon.WorkerType    // javascript: WorkerType {type Type _type}
 		value1 fetch.RequestCredentials // javascript: RequestCredentials {credentials Credentials credentials}
 		value2 string                   // javascript: DOMString {name Name name}
 	)
-	value0 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value0 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = fetch.RequestCredentialsFromJS(input.Get("credentials"))
+	value1 = fetch.RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value1
-	value2 = (input.Get("name")).String()
+	value2 = (value.Get("name")).String()
 	out.Name = value2
 	return &out
 }
@@ -148,15 +147,19 @@ type DedicatedWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// DedicatedWorkerGlobalScopeFromJS is casting a js.Wrapper into DedicatedWorkerGlobalScope.
-func DedicatedWorkerGlobalScopeFromJS(value js.Wrapper) *DedicatedWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DedicatedWorkerGlobalScopeFromJS is casting a js.Value into DedicatedWorkerGlobalScope.
+func DedicatedWorkerGlobalScopeFromJS(value js.Value) *DedicatedWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DedicatedWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DedicatedWorkerGlobalScopeFromJS is casting from something that holds a js.Value into DedicatedWorkerGlobalScope.
+func DedicatedWorkerGlobalScopeFromWrapper(input core.Wrapper) *DedicatedWorkerGlobalScope {
+	return DedicatedWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -322,15 +325,19 @@ type ServiceWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// ServiceWorkerGlobalScopeFromJS is casting a js.Wrapper into ServiceWorkerGlobalScope.
-func ServiceWorkerGlobalScopeFromJS(value js.Wrapper) *ServiceWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerGlobalScopeFromJS is casting a js.Value into ServiceWorkerGlobalScope.
+func ServiceWorkerGlobalScopeFromJS(value js.Value) *ServiceWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerGlobalScopeFromJS is casting from something that holds a js.Value into ServiceWorkerGlobalScope.
+func ServiceWorkerGlobalScopeFromWrapper(input core.Wrapper) *ServiceWorkerGlobalScope {
+	return ServiceWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Clients returning attribute 'clients' with
@@ -952,15 +959,19 @@ type SharedWorker struct {
 	domcore.EventTarget
 }
 
-// SharedWorkerFromJS is casting a js.Wrapper into SharedWorker.
-func SharedWorkerFromJS(value js.Wrapper) *SharedWorker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SharedWorkerFromJS is casting a js.Value into SharedWorker.
+func SharedWorkerFromJS(value js.Value) *SharedWorker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SharedWorker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SharedWorkerFromJS is casting from something that holds a js.Value into SharedWorker.
+func SharedWorkerFromWrapper(input core.Wrapper) *SharedWorker {
+	return SharedWorkerFromJS(input.JSValue())
 }
 
 func NewSharedWorker(scriptURL string, options *Union) (_result *SharedWorker) {
@@ -1041,15 +1052,19 @@ type SharedWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// SharedWorkerGlobalScopeFromJS is casting a js.Wrapper into SharedWorkerGlobalScope.
-func SharedWorkerGlobalScopeFromJS(value js.Wrapper) *SharedWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SharedWorkerGlobalScopeFromJS is casting a js.Value into SharedWorkerGlobalScope.
+func SharedWorkerGlobalScopeFromJS(value js.Value) *SharedWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SharedWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SharedWorkerGlobalScopeFromJS is casting from something that holds a js.Value into SharedWorkerGlobalScope.
+func SharedWorkerGlobalScopeFromWrapper(input core.Wrapper) *SharedWorkerGlobalScope {
+	return SharedWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1116,15 +1131,19 @@ type Worker struct {
 	domcore.EventTarget
 }
 
-// WorkerFromJS is casting a js.Wrapper into Worker.
-func WorkerFromJS(value js.Wrapper) *Worker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerFromJS is casting a js.Value into Worker.
+func WorkerFromJS(value js.Value) *Worker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Worker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerFromJS is casting from something that holds a js.Value into Worker.
+func WorkerFromWrapper(input core.Wrapper) *Worker {
+	return WorkerFromJS(input.JSValue())
 }
 
 func NewWorker(scriptURL string, options *WorkerOptions) (_result *Worker) {
@@ -1309,15 +1328,19 @@ type WorkerGlobalScope struct {
 	domcore.EventTarget
 }
 
-// WorkerGlobalScopeFromJS is casting a js.Wrapper into WorkerGlobalScope.
-func WorkerGlobalScopeFromJS(value js.Wrapper) *WorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerGlobalScopeFromJS is casting a js.Value into WorkerGlobalScope.
+func WorkerGlobalScopeFromJS(value js.Value) *WorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerGlobalScopeFromJS is casting from something that holds a js.Value into WorkerGlobalScope.
+func WorkerGlobalScopeFromWrapper(input core.Wrapper) *WorkerGlobalScope {
+	return WorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Self returning attribute 'self' with
@@ -1861,15 +1884,19 @@ func (_this *WorkerLocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkerLocationFromJS is casting a js.Wrapper into WorkerLocation.
-func WorkerLocationFromJS(value js.Wrapper) *WorkerLocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerLocationFromJS is casting a js.Value into WorkerLocation.
+func WorkerLocationFromJS(value js.Value) *WorkerLocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerLocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerLocationFromJS is casting from something that holds a js.Value into WorkerLocation.
+func WorkerLocationFromWrapper(input core.Wrapper) *WorkerLocation {
+	return WorkerLocationFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1968,15 +1995,19 @@ func (_this *WorkerNavigator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkerNavigatorFromJS is casting a js.Wrapper into WorkerNavigator.
-func WorkerNavigatorFromJS(value js.Wrapper) *WorkerNavigator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerNavigatorFromJS is casting a js.Value into WorkerNavigator.
+func WorkerNavigatorFromJS(value js.Value) *WorkerNavigator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerNavigator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerNavigatorFromJS is casting from something that holds a js.Value into WorkerNavigator.
+func WorkerNavigatorFromWrapper(input core.Wrapper) *WorkerNavigator {
+	return WorkerNavigatorFromJS(input.JSValue())
 }
 
 // MediaCapabilities returning attribute 'mediaCapabilities' with

--- a/html/worker/worker_js.go
+++ b/html/worker/worker_js.go
@@ -7,6 +7,7 @@ import "syscall/js"
 import (
 	"github.com/gowebapi/webapi/communication/netinfo"
 	"github.com/gowebapi/webapi/cookie"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto"
 	"github.com/gowebapi/webapi/device/usb"
 	"github.com/gowebapi/webapi/dom/domcore"
@@ -108,7 +109,7 @@ type WorkerOptions struct {
 	Name        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WorkerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -122,21 +123,19 @@ func (_this *WorkerOptions) JSValue() js.Value {
 }
 
 // WorkerOptionsFromJS is allocating a new
-// WorkerOptions object and copy all values from
-// input javascript object
-func WorkerOptionsFromJS(value js.Wrapper) *WorkerOptions {
-	input := value.JSValue()
+// WorkerOptions object and copy all values in the value javascript object.
+func WorkerOptionsFromJS(value js.Value) *WorkerOptions {
 	var out WorkerOptions
 	var (
 		value0 htmlcommon.WorkerType    // javascript: WorkerType {type Type _type}
 		value1 fetch.RequestCredentials // javascript: RequestCredentials {credentials Credentials credentials}
 		value2 string                   // javascript: DOMString {name Name name}
 	)
-	value0 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value0 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = fetch.RequestCredentialsFromJS(input.Get("credentials"))
+	value1 = fetch.RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value1
-	value2 = (input.Get("name")).String()
+	value2 = (value.Get("name")).String()
 	out.Name = value2
 	return &out
 }
@@ -146,15 +145,19 @@ type DedicatedWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// DedicatedWorkerGlobalScopeFromJS is casting a js.Wrapper into DedicatedWorkerGlobalScope.
-func DedicatedWorkerGlobalScopeFromJS(value js.Wrapper) *DedicatedWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DedicatedWorkerGlobalScopeFromJS is casting a js.Value into DedicatedWorkerGlobalScope.
+func DedicatedWorkerGlobalScopeFromJS(value js.Value) *DedicatedWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DedicatedWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DedicatedWorkerGlobalScopeFromJS is casting from something that holds a js.Value into DedicatedWorkerGlobalScope.
+func DedicatedWorkerGlobalScopeFromWrapper(input core.Wrapper) *DedicatedWorkerGlobalScope {
+	return DedicatedWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -320,15 +323,19 @@ type ServiceWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// ServiceWorkerGlobalScopeFromJS is casting a js.Wrapper into ServiceWorkerGlobalScope.
-func ServiceWorkerGlobalScopeFromJS(value js.Wrapper) *ServiceWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerGlobalScopeFromJS is casting a js.Value into ServiceWorkerGlobalScope.
+func ServiceWorkerGlobalScopeFromJS(value js.Value) *ServiceWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerGlobalScopeFromJS is casting from something that holds a js.Value into ServiceWorkerGlobalScope.
+func ServiceWorkerGlobalScopeFromWrapper(input core.Wrapper) *ServiceWorkerGlobalScope {
+	return ServiceWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Clients returning attribute 'clients' with
@@ -950,15 +957,19 @@ type SharedWorker struct {
 	domcore.EventTarget
 }
 
-// SharedWorkerFromJS is casting a js.Wrapper into SharedWorker.
-func SharedWorkerFromJS(value js.Wrapper) *SharedWorker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SharedWorkerFromJS is casting a js.Value into SharedWorker.
+func SharedWorkerFromJS(value js.Value) *SharedWorker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SharedWorker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SharedWorkerFromJS is casting from something that holds a js.Value into SharedWorker.
+func SharedWorkerFromWrapper(input core.Wrapper) *SharedWorker {
+	return SharedWorkerFromJS(input.JSValue())
 }
 
 func NewSharedWorker(scriptURL string, options *Union) (_result *SharedWorker) {
@@ -1039,15 +1050,19 @@ type SharedWorkerGlobalScope struct {
 	WorkerGlobalScope
 }
 
-// SharedWorkerGlobalScopeFromJS is casting a js.Wrapper into SharedWorkerGlobalScope.
-func SharedWorkerGlobalScopeFromJS(value js.Wrapper) *SharedWorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SharedWorkerGlobalScopeFromJS is casting a js.Value into SharedWorkerGlobalScope.
+func SharedWorkerGlobalScopeFromJS(value js.Value) *SharedWorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SharedWorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SharedWorkerGlobalScopeFromJS is casting from something that holds a js.Value into SharedWorkerGlobalScope.
+func SharedWorkerGlobalScopeFromWrapper(input core.Wrapper) *SharedWorkerGlobalScope {
+	return SharedWorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1114,15 +1129,19 @@ type Worker struct {
 	domcore.EventTarget
 }
 
-// WorkerFromJS is casting a js.Wrapper into Worker.
-func WorkerFromJS(value js.Wrapper) *Worker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerFromJS is casting a js.Value into Worker.
+func WorkerFromJS(value js.Value) *Worker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Worker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerFromJS is casting from something that holds a js.Value into Worker.
+func WorkerFromWrapper(input core.Wrapper) *Worker {
+	return WorkerFromJS(input.JSValue())
 }
 
 func NewWorker(scriptURL string, options *WorkerOptions) (_result *Worker) {
@@ -1307,15 +1326,19 @@ type WorkerGlobalScope struct {
 	domcore.EventTarget
 }
 
-// WorkerGlobalScopeFromJS is casting a js.Wrapper into WorkerGlobalScope.
-func WorkerGlobalScopeFromJS(value js.Wrapper) *WorkerGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerGlobalScopeFromJS is casting a js.Value into WorkerGlobalScope.
+func WorkerGlobalScopeFromJS(value js.Value) *WorkerGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerGlobalScopeFromJS is casting from something that holds a js.Value into WorkerGlobalScope.
+func WorkerGlobalScopeFromWrapper(input core.Wrapper) *WorkerGlobalScope {
+	return WorkerGlobalScopeFromJS(input.JSValue())
 }
 
 // Self returning attribute 'self' with
@@ -1859,15 +1882,19 @@ func (_this *WorkerLocation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkerLocationFromJS is casting a js.Wrapper into WorkerLocation.
-func WorkerLocationFromJS(value js.Wrapper) *WorkerLocation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerLocationFromJS is casting a js.Value into WorkerLocation.
+func WorkerLocationFromJS(value js.Value) *WorkerLocation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerLocation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerLocationFromJS is casting from something that holds a js.Value into WorkerLocation.
+func WorkerLocationFromWrapper(input core.Wrapper) *WorkerLocation {
+	return WorkerLocationFromJS(input.JSValue())
 }
 
 // Href returning attribute 'href' with
@@ -1966,15 +1993,19 @@ func (_this *WorkerNavigator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkerNavigatorFromJS is casting a js.Wrapper into WorkerNavigator.
-func WorkerNavigatorFromJS(value js.Wrapper) *WorkerNavigator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkerNavigatorFromJS is casting a js.Value into WorkerNavigator.
+func WorkerNavigatorFromJS(value js.Value) *WorkerNavigator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkerNavigator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkerNavigatorFromJS is casting from something that holds a js.Value into WorkerNavigator.
+func WorkerNavigatorFromWrapper(input core.Wrapper) *WorkerNavigator {
+	return WorkerNavigatorFromJS(input.JSValue())
 }
 
 // MediaCapabilities returning attribute 'mediaCapabilities' with

--- a/indexeddb/indexeddb.go
+++ b/indexeddb/indexeddb.go
@@ -7,6 +7,7 @@ package indexeddb
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -271,7 +272,7 @@ type IDBDatabaseInfo struct {
 	Version int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBDatabaseInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -283,18 +284,16 @@ func (_this *IDBDatabaseInfo) JSValue() js.Value {
 }
 
 // IDBDatabaseInfoFromJS is allocating a new
-// IDBDatabaseInfo object and copy all values from
-// input javascript object
-func IDBDatabaseInfoFromJS(value js.Wrapper) *IDBDatabaseInfo {
-	input := value.JSValue()
+// IDBDatabaseInfo object and copy all values in the value javascript object.
+func IDBDatabaseInfoFromJS(value js.Value) *IDBDatabaseInfo {
 	var out IDBDatabaseInfo
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned long long {version Version version}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("version")).Int()
+	value1 = (value.Get("version")).Int()
 	out.Version = value1
 	return &out
 }
@@ -305,7 +304,7 @@ type IDBIndexParameters struct {
 	MultiEntry bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBIndexParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -317,18 +316,16 @@ func (_this *IDBIndexParameters) JSValue() js.Value {
 }
 
 // IDBIndexParametersFromJS is allocating a new
-// IDBIndexParameters object and copy all values from
-// input javascript object
-func IDBIndexParametersFromJS(value js.Wrapper) *IDBIndexParameters {
-	input := value.JSValue()
+// IDBIndexParameters object and copy all values in the value javascript object.
+func IDBIndexParametersFromJS(value js.Value) *IDBIndexParameters {
 	var out IDBIndexParameters
 	var (
 		value0 bool // javascript: boolean {unique Unique unique}
 		value1 bool // javascript: boolean {multiEntry MultiEntry multiEntry}
 	)
-	value0 = (input.Get("unique")).Bool()
+	value0 = (value.Get("unique")).Bool()
 	out.Unique = value0
-	value1 = (input.Get("multiEntry")).Bool()
+	value1 = (value.Get("multiEntry")).Bool()
 	out.MultiEntry = value1
 	return &out
 }
@@ -339,7 +336,7 @@ type IDBObjectStoreParameters struct {
 	AutoIncrement bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBObjectStoreParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -351,20 +348,18 @@ func (_this *IDBObjectStoreParameters) JSValue() js.Value {
 }
 
 // IDBObjectStoreParametersFromJS is allocating a new
-// IDBObjectStoreParameters object and copy all values from
-// input javascript object
-func IDBObjectStoreParametersFromJS(value js.Wrapper) *IDBObjectStoreParameters {
-	input := value.JSValue()
+// IDBObjectStoreParameters object and copy all values in the value javascript object.
+func IDBObjectStoreParametersFromJS(value js.Value) *IDBObjectStoreParameters {
 	var out IDBObjectStoreParameters
 	var (
 		value0 *Union // javascript: Union {keyPath KeyPath keyPath}
 		value1 bool   // javascript: boolean {autoIncrement AutoIncrement autoIncrement}
 	)
-	if input.Get("keyPath").Type() != js.TypeNull && input.Get("keyPath").Type() != js.TypeUndefined {
-		value0 = UnionFromJS(input.Get("keyPath"))
+	if value.Get("keyPath").Type() != js.TypeNull && value.Get("keyPath").Type() != js.TypeUndefined {
+		value0 = UnionFromJS(value.Get("keyPath"))
 	}
 	out.KeyPath = value0
-	value1 = (input.Get("autoIncrement")).Bool()
+	value1 = (value.Get("autoIncrement")).Bool()
 	out.AutoIncrement = value1
 	return &out
 }
@@ -378,7 +373,7 @@ type IDBVersionChangeEventInit struct {
 	NewVersion *int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBVersionChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -402,10 +397,8 @@ func (_this *IDBVersionChangeEventInit) JSValue() js.Value {
 }
 
 // IDBVersionChangeEventInitFromJS is allocating a new
-// IDBVersionChangeEventInit object and copy all values from
-// input javascript object
-func IDBVersionChangeEventInitFromJS(value js.Wrapper) *IDBVersionChangeEventInit {
-	input := value.JSValue()
+// IDBVersionChangeEventInit object and copy all values in the value javascript object.
+func IDBVersionChangeEventInitFromJS(value js.Value) *IDBVersionChangeEventInit {
 	var out IDBVersionChangeEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -414,16 +407,16 @@ func IDBVersionChangeEventInitFromJS(value js.Wrapper) *IDBVersionChangeEventIni
 		value3 int  // javascript: unsigned long long {oldVersion OldVersion oldVersion}
 		value4 *int // javascript: unsigned long long {newVersion NewVersion newVersion}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("oldVersion")).Int()
+	value3 = (value.Get("oldVersion")).Int()
 	out.OldVersion = value3
-	if input.Get("newVersion").Type() != js.TypeNull && input.Get("newVersion").Type() != js.TypeUndefined {
-		__tmp := (input.Get("newVersion")).Int()
+	if value.Get("newVersion").Type() != js.TypeNull && value.Get("newVersion").Type() != js.TypeUndefined {
+		__tmp := (value.Get("newVersion")).Int()
 		value4 = &__tmp
 	}
 	out.NewVersion = value4
@@ -440,15 +433,19 @@ func (_this *IDBCursor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBCursorFromJS is casting a js.Wrapper into IDBCursor.
-func IDBCursorFromJS(value js.Wrapper) *IDBCursor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBCursorFromJS is casting a js.Value into IDBCursor.
+func IDBCursorFromJS(value js.Value) *IDBCursor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBCursor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBCursorFromJS is casting from something that holds a js.Value into IDBCursor.
+func IDBCursorFromWrapper(input core.Wrapper) *IDBCursor {
+	return IDBCursorFromJS(input.JSValue())
 }
 
 // Source returning attribute 'source' with
@@ -564,15 +561,19 @@ type IDBCursorWithValue struct {
 	IDBCursor
 }
 
-// IDBCursorWithValueFromJS is casting a js.Wrapper into IDBCursorWithValue.
-func IDBCursorWithValueFromJS(value js.Wrapper) *IDBCursorWithValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBCursorWithValueFromJS is casting a js.Value into IDBCursorWithValue.
+func IDBCursorWithValueFromJS(value js.Value) *IDBCursorWithValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBCursorWithValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBCursorWithValueFromJS is casting from something that holds a js.Value into IDBCursorWithValue.
+func IDBCursorWithValueFromWrapper(input core.Wrapper) *IDBCursorWithValue {
+	return IDBCursorWithValueFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -589,15 +590,19 @@ type IDBDatabase struct {
 	domcore.EventTarget
 }
 
-// IDBDatabaseFromJS is casting a js.Wrapper into IDBDatabase.
-func IDBDatabaseFromJS(value js.Wrapper) *IDBDatabase {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBDatabaseFromJS is casting a js.Value into IDBDatabase.
+func IDBDatabaseFromJS(value js.Value) *IDBDatabase {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBDatabase{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBDatabaseFromJS is casting from something that holds a js.Value into IDBDatabase.
+func IDBDatabaseFromWrapper(input core.Wrapper) *IDBDatabase {
+	return IDBDatabaseFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -838,15 +843,19 @@ func (_this *IDBFactory) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBFactoryFromJS is casting a js.Wrapper into IDBFactory.
-func IDBFactoryFromJS(value js.Wrapper) *IDBFactory {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBFactoryFromJS is casting a js.Value into IDBFactory.
+func IDBFactoryFromJS(value js.Value) *IDBFactory {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBFactory{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBFactoryFromJS is casting from something that holds a js.Value into IDBFactory.
+func IDBFactoryFromWrapper(input core.Wrapper) *IDBFactory {
+	return IDBFactoryFromJS(input.JSValue())
 }
 
 func (_this *IDBFactory) Open(name string, version *int) (_result *IDBOpenDBRequest) {
@@ -938,15 +947,19 @@ func (_this *IDBIndex) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBIndexFromJS is casting a js.Wrapper into IDBIndex.
-func IDBIndexFromJS(value js.Wrapper) *IDBIndex {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBIndexFromJS is casting a js.Value into IDBIndex.
+func IDBIndexFromJS(value js.Value) *IDBIndex {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBIndex{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBIndexFromJS is casting from something that holds a js.Value into IDBIndex.
+func IDBIndexFromWrapper(input core.Wrapper) *IDBIndex {
+	return IDBIndexFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1172,15 +1185,19 @@ func (_this *IDBKeyRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBKeyRangeFromJS is casting a js.Wrapper into IDBKeyRange.
-func IDBKeyRangeFromJS(value js.Wrapper) *IDBKeyRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBKeyRangeFromJS is casting a js.Value into IDBKeyRange.
+func IDBKeyRangeFromJS(value js.Value) *IDBKeyRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBKeyRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBKeyRangeFromJS is casting from something that holds a js.Value into IDBKeyRange.
+func IDBKeyRangeFromWrapper(input core.Wrapper) *IDBKeyRange {
+	return IDBKeyRangeFromJS(input.JSValue())
 }
 
 func Only(value interface{}) (_result *IDBKeyRange) {
@@ -1369,15 +1386,19 @@ func (_this *IDBObjectStore) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBObjectStoreFromJS is casting a js.Wrapper into IDBObjectStore.
-func IDBObjectStoreFromJS(value js.Wrapper) *IDBObjectStore {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBObjectStoreFromJS is casting a js.Value into IDBObjectStore.
+func IDBObjectStoreFromJS(value js.Value) *IDBObjectStore {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBObjectStore{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBObjectStoreFromJS is casting from something that holds a js.Value into IDBObjectStore.
+func IDBObjectStoreFromWrapper(input core.Wrapper) *IDBObjectStore {
+	return IDBObjectStoreFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1727,15 +1748,19 @@ type IDBOpenDBRequest struct {
 	IDBRequest
 }
 
-// IDBOpenDBRequestFromJS is casting a js.Wrapper into IDBOpenDBRequest.
-func IDBOpenDBRequestFromJS(value js.Wrapper) *IDBOpenDBRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBOpenDBRequestFromJS is casting a js.Value into IDBOpenDBRequest.
+func IDBOpenDBRequestFromJS(value js.Value) *IDBOpenDBRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBOpenDBRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBOpenDBRequestFromJS is casting from something that holds a js.Value into IDBOpenDBRequest.
+func IDBOpenDBRequestFromWrapper(input core.Wrapper) *IDBOpenDBRequest {
+	return IDBOpenDBRequestFromJS(input.JSValue())
 }
 
 // OnBlocked returning attribute 'onblocked' with
@@ -1811,15 +1836,19 @@ type IDBRequest struct {
 	domcore.EventTarget
 }
 
-// IDBRequestFromJS is casting a js.Wrapper into IDBRequest.
-func IDBRequestFromJS(value js.Wrapper) *IDBRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBRequestFromJS is casting a js.Value into IDBRequest.
+func IDBRequestFromJS(value js.Value) *IDBRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBRequestFromJS is casting from something that holds a js.Value into IDBRequest.
+func IDBRequestFromWrapper(input core.Wrapper) *IDBRequest {
+	return IDBRequestFromJS(input.JSValue())
 }
 
 // Result returning attribute 'result' with
@@ -1946,15 +1975,19 @@ type IDBTransaction struct {
 	domcore.EventTarget
 }
 
-// IDBTransactionFromJS is casting a js.Wrapper into IDBTransaction.
-func IDBTransactionFromJS(value js.Wrapper) *IDBTransaction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBTransactionFromJS is casting a js.Value into IDBTransaction.
+func IDBTransactionFromJS(value js.Value) *IDBTransaction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBTransaction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBTransactionFromJS is casting from something that holds a js.Value into IDBTransaction.
+func IDBTransactionFromWrapper(input core.Wrapper) *IDBTransaction {
+	return IDBTransactionFromJS(input.JSValue())
 }
 
 // ObjectStoreNames returning attribute 'objectStoreNames' with
@@ -2128,15 +2161,19 @@ type IDBVersionChangeEvent struct {
 	domcore.Event
 }
 
-// IDBVersionChangeEventFromJS is casting a js.Wrapper into IDBVersionChangeEvent.
-func IDBVersionChangeEventFromJS(value js.Wrapper) *IDBVersionChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBVersionChangeEventFromJS is casting a js.Value into IDBVersionChangeEvent.
+func IDBVersionChangeEventFromJS(value js.Value) *IDBVersionChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBVersionChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBVersionChangeEventFromJS is casting from something that holds a js.Value into IDBVersionChangeEvent.
+func IDBVersionChangeEventFromWrapper(input core.Wrapper) *IDBVersionChangeEvent {
+	return IDBVersionChangeEventFromJS(input.JSValue())
 }
 
 func NewIDBVersionChangeEvent(_type string, eventInitDict *IDBVersionChangeEventInit) (_result *IDBVersionChangeEvent) {
@@ -2193,15 +2230,19 @@ func (_this *PromiseSequenceIDBDatabaseInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceIDBDatabaseInfoFromJS is casting a js.Wrapper into PromiseSequenceIDBDatabaseInfo.
-func PromiseSequenceIDBDatabaseInfoFromJS(value js.Wrapper) *PromiseSequenceIDBDatabaseInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceIDBDatabaseInfoFromJS is casting a js.Value into PromiseSequenceIDBDatabaseInfo.
+func PromiseSequenceIDBDatabaseInfoFromJS(value js.Value) *PromiseSequenceIDBDatabaseInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceIDBDatabaseInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceIDBDatabaseInfoFromJS is casting from something that holds a js.Value into PromiseSequenceIDBDatabaseInfo.
+func PromiseSequenceIDBDatabaseInfoFromWrapper(input core.Wrapper) *PromiseSequenceIDBDatabaseInfo {
+	return PromiseSequenceIDBDatabaseInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceIDBDatabaseInfo) Then(onFulfilled *PromiseSequenceIDBDatabaseInfoOnFulfilled, onRejected *PromiseSequenceIDBDatabaseInfoOnRejected) (_result *PromiseSequenceIDBDatabaseInfo) {

--- a/indexeddb/indexeddb_js.go
+++ b/indexeddb/indexeddb_js.go
@@ -5,6 +5,7 @@ package indexeddb
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -269,7 +270,7 @@ type IDBDatabaseInfo struct {
 	Version int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBDatabaseInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -281,18 +282,16 @@ func (_this *IDBDatabaseInfo) JSValue() js.Value {
 }
 
 // IDBDatabaseInfoFromJS is allocating a new
-// IDBDatabaseInfo object and copy all values from
-// input javascript object
-func IDBDatabaseInfoFromJS(value js.Wrapper) *IDBDatabaseInfo {
-	input := value.JSValue()
+// IDBDatabaseInfo object and copy all values in the value javascript object.
+func IDBDatabaseInfoFromJS(value js.Value) *IDBDatabaseInfo {
 	var out IDBDatabaseInfo
 	var (
 		value0 string // javascript: DOMString {name Name name}
 		value1 int    // javascript: unsigned long long {version Version version}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (input.Get("version")).Int()
+	value1 = (value.Get("version")).Int()
 	out.Version = value1
 	return &out
 }
@@ -303,7 +302,7 @@ type IDBIndexParameters struct {
 	MultiEntry bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBIndexParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -315,18 +314,16 @@ func (_this *IDBIndexParameters) JSValue() js.Value {
 }
 
 // IDBIndexParametersFromJS is allocating a new
-// IDBIndexParameters object and copy all values from
-// input javascript object
-func IDBIndexParametersFromJS(value js.Wrapper) *IDBIndexParameters {
-	input := value.JSValue()
+// IDBIndexParameters object and copy all values in the value javascript object.
+func IDBIndexParametersFromJS(value js.Value) *IDBIndexParameters {
 	var out IDBIndexParameters
 	var (
 		value0 bool // javascript: boolean {unique Unique unique}
 		value1 bool // javascript: boolean {multiEntry MultiEntry multiEntry}
 	)
-	value0 = (input.Get("unique")).Bool()
+	value0 = (value.Get("unique")).Bool()
 	out.Unique = value0
-	value1 = (input.Get("multiEntry")).Bool()
+	value1 = (value.Get("multiEntry")).Bool()
 	out.MultiEntry = value1
 	return &out
 }
@@ -337,7 +334,7 @@ type IDBObjectStoreParameters struct {
 	AutoIncrement bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBObjectStoreParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -349,20 +346,18 @@ func (_this *IDBObjectStoreParameters) JSValue() js.Value {
 }
 
 // IDBObjectStoreParametersFromJS is allocating a new
-// IDBObjectStoreParameters object and copy all values from
-// input javascript object
-func IDBObjectStoreParametersFromJS(value js.Wrapper) *IDBObjectStoreParameters {
-	input := value.JSValue()
+// IDBObjectStoreParameters object and copy all values in the value javascript object.
+func IDBObjectStoreParametersFromJS(value js.Value) *IDBObjectStoreParameters {
 	var out IDBObjectStoreParameters
 	var (
 		value0 *Union // javascript: Union {keyPath KeyPath keyPath}
 		value1 bool   // javascript: boolean {autoIncrement AutoIncrement autoIncrement}
 	)
-	if input.Get("keyPath").Type() != js.TypeNull && input.Get("keyPath").Type() != js.TypeUndefined {
-		value0 = UnionFromJS(input.Get("keyPath"))
+	if value.Get("keyPath").Type() != js.TypeNull && value.Get("keyPath").Type() != js.TypeUndefined {
+		value0 = UnionFromJS(value.Get("keyPath"))
 	}
 	out.KeyPath = value0
-	value1 = (input.Get("autoIncrement")).Bool()
+	value1 = (value.Get("autoIncrement")).Bool()
 	out.AutoIncrement = value1
 	return &out
 }
@@ -376,7 +371,7 @@ type IDBVersionChangeEventInit struct {
 	NewVersion *int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IDBVersionChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -400,10 +395,8 @@ func (_this *IDBVersionChangeEventInit) JSValue() js.Value {
 }
 
 // IDBVersionChangeEventInitFromJS is allocating a new
-// IDBVersionChangeEventInit object and copy all values from
-// input javascript object
-func IDBVersionChangeEventInitFromJS(value js.Wrapper) *IDBVersionChangeEventInit {
-	input := value.JSValue()
+// IDBVersionChangeEventInit object and copy all values in the value javascript object.
+func IDBVersionChangeEventInitFromJS(value js.Value) *IDBVersionChangeEventInit {
 	var out IDBVersionChangeEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
@@ -412,16 +405,16 @@ func IDBVersionChangeEventInitFromJS(value js.Wrapper) *IDBVersionChangeEventIni
 		value3 int  // javascript: unsigned long long {oldVersion OldVersion oldVersion}
 		value4 *int // javascript: unsigned long long {newVersion NewVersion newVersion}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("oldVersion")).Int()
+	value3 = (value.Get("oldVersion")).Int()
 	out.OldVersion = value3
-	if input.Get("newVersion").Type() != js.TypeNull && input.Get("newVersion").Type() != js.TypeUndefined {
-		__tmp := (input.Get("newVersion")).Int()
+	if value.Get("newVersion").Type() != js.TypeNull && value.Get("newVersion").Type() != js.TypeUndefined {
+		__tmp := (value.Get("newVersion")).Int()
 		value4 = &__tmp
 	}
 	out.NewVersion = value4
@@ -438,15 +431,19 @@ func (_this *IDBCursor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBCursorFromJS is casting a js.Wrapper into IDBCursor.
-func IDBCursorFromJS(value js.Wrapper) *IDBCursor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBCursorFromJS is casting a js.Value into IDBCursor.
+func IDBCursorFromJS(value js.Value) *IDBCursor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBCursor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBCursorFromJS is casting from something that holds a js.Value into IDBCursor.
+func IDBCursorFromWrapper(input core.Wrapper) *IDBCursor {
+	return IDBCursorFromJS(input.JSValue())
 }
 
 // Source returning attribute 'source' with
@@ -562,15 +559,19 @@ type IDBCursorWithValue struct {
 	IDBCursor
 }
 
-// IDBCursorWithValueFromJS is casting a js.Wrapper into IDBCursorWithValue.
-func IDBCursorWithValueFromJS(value js.Wrapper) *IDBCursorWithValue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBCursorWithValueFromJS is casting a js.Value into IDBCursorWithValue.
+func IDBCursorWithValueFromJS(value js.Value) *IDBCursorWithValue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBCursorWithValue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBCursorWithValueFromJS is casting from something that holds a js.Value into IDBCursorWithValue.
+func IDBCursorWithValueFromWrapper(input core.Wrapper) *IDBCursorWithValue {
+	return IDBCursorWithValueFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -587,15 +588,19 @@ type IDBDatabase struct {
 	domcore.EventTarget
 }
 
-// IDBDatabaseFromJS is casting a js.Wrapper into IDBDatabase.
-func IDBDatabaseFromJS(value js.Wrapper) *IDBDatabase {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBDatabaseFromJS is casting a js.Value into IDBDatabase.
+func IDBDatabaseFromJS(value js.Value) *IDBDatabase {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBDatabase{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBDatabaseFromJS is casting from something that holds a js.Value into IDBDatabase.
+func IDBDatabaseFromWrapper(input core.Wrapper) *IDBDatabase {
+	return IDBDatabaseFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -836,15 +841,19 @@ func (_this *IDBFactory) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBFactoryFromJS is casting a js.Wrapper into IDBFactory.
-func IDBFactoryFromJS(value js.Wrapper) *IDBFactory {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBFactoryFromJS is casting a js.Value into IDBFactory.
+func IDBFactoryFromJS(value js.Value) *IDBFactory {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBFactory{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBFactoryFromJS is casting from something that holds a js.Value into IDBFactory.
+func IDBFactoryFromWrapper(input core.Wrapper) *IDBFactory {
+	return IDBFactoryFromJS(input.JSValue())
 }
 
 func (_this *IDBFactory) Open(name string, version *int) (_result *IDBOpenDBRequest) {
@@ -936,15 +945,19 @@ func (_this *IDBIndex) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBIndexFromJS is casting a js.Wrapper into IDBIndex.
-func IDBIndexFromJS(value js.Wrapper) *IDBIndex {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBIndexFromJS is casting a js.Value into IDBIndex.
+func IDBIndexFromJS(value js.Value) *IDBIndex {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBIndex{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBIndexFromJS is casting from something that holds a js.Value into IDBIndex.
+func IDBIndexFromWrapper(input core.Wrapper) *IDBIndex {
+	return IDBIndexFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1170,15 +1183,19 @@ func (_this *IDBKeyRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBKeyRangeFromJS is casting a js.Wrapper into IDBKeyRange.
-func IDBKeyRangeFromJS(value js.Wrapper) *IDBKeyRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBKeyRangeFromJS is casting a js.Value into IDBKeyRange.
+func IDBKeyRangeFromJS(value js.Value) *IDBKeyRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBKeyRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBKeyRangeFromJS is casting from something that holds a js.Value into IDBKeyRange.
+func IDBKeyRangeFromWrapper(input core.Wrapper) *IDBKeyRange {
+	return IDBKeyRangeFromJS(input.JSValue())
 }
 
 func Only(value interface{}) (_result *IDBKeyRange) {
@@ -1367,15 +1384,19 @@ func (_this *IDBObjectStore) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IDBObjectStoreFromJS is casting a js.Wrapper into IDBObjectStore.
-func IDBObjectStoreFromJS(value js.Wrapper) *IDBObjectStore {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBObjectStoreFromJS is casting a js.Value into IDBObjectStore.
+func IDBObjectStoreFromJS(value js.Value) *IDBObjectStore {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBObjectStore{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBObjectStoreFromJS is casting from something that holds a js.Value into IDBObjectStore.
+func IDBObjectStoreFromWrapper(input core.Wrapper) *IDBObjectStore {
+	return IDBObjectStoreFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1725,15 +1746,19 @@ type IDBOpenDBRequest struct {
 	IDBRequest
 }
 
-// IDBOpenDBRequestFromJS is casting a js.Wrapper into IDBOpenDBRequest.
-func IDBOpenDBRequestFromJS(value js.Wrapper) *IDBOpenDBRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBOpenDBRequestFromJS is casting a js.Value into IDBOpenDBRequest.
+func IDBOpenDBRequestFromJS(value js.Value) *IDBOpenDBRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBOpenDBRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBOpenDBRequestFromJS is casting from something that holds a js.Value into IDBOpenDBRequest.
+func IDBOpenDBRequestFromWrapper(input core.Wrapper) *IDBOpenDBRequest {
+	return IDBOpenDBRequestFromJS(input.JSValue())
 }
 
 // OnBlocked returning attribute 'onblocked' with
@@ -1809,15 +1834,19 @@ type IDBRequest struct {
 	domcore.EventTarget
 }
 
-// IDBRequestFromJS is casting a js.Wrapper into IDBRequest.
-func IDBRequestFromJS(value js.Wrapper) *IDBRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBRequestFromJS is casting a js.Value into IDBRequest.
+func IDBRequestFromJS(value js.Value) *IDBRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBRequestFromJS is casting from something that holds a js.Value into IDBRequest.
+func IDBRequestFromWrapper(input core.Wrapper) *IDBRequest {
+	return IDBRequestFromJS(input.JSValue())
 }
 
 // Result returning attribute 'result' with
@@ -1944,15 +1973,19 @@ type IDBTransaction struct {
 	domcore.EventTarget
 }
 
-// IDBTransactionFromJS is casting a js.Wrapper into IDBTransaction.
-func IDBTransactionFromJS(value js.Wrapper) *IDBTransaction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBTransactionFromJS is casting a js.Value into IDBTransaction.
+func IDBTransactionFromJS(value js.Value) *IDBTransaction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBTransaction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBTransactionFromJS is casting from something that holds a js.Value into IDBTransaction.
+func IDBTransactionFromWrapper(input core.Wrapper) *IDBTransaction {
+	return IDBTransactionFromJS(input.JSValue())
 }
 
 // ObjectStoreNames returning attribute 'objectStoreNames' with
@@ -2126,15 +2159,19 @@ type IDBVersionChangeEvent struct {
 	domcore.Event
 }
 
-// IDBVersionChangeEventFromJS is casting a js.Wrapper into IDBVersionChangeEvent.
-func IDBVersionChangeEventFromJS(value js.Wrapper) *IDBVersionChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IDBVersionChangeEventFromJS is casting a js.Value into IDBVersionChangeEvent.
+func IDBVersionChangeEventFromJS(value js.Value) *IDBVersionChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IDBVersionChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IDBVersionChangeEventFromJS is casting from something that holds a js.Value into IDBVersionChangeEvent.
+func IDBVersionChangeEventFromWrapper(input core.Wrapper) *IDBVersionChangeEvent {
+	return IDBVersionChangeEventFromJS(input.JSValue())
 }
 
 func NewIDBVersionChangeEvent(_type string, eventInitDict *IDBVersionChangeEventInit) (_result *IDBVersionChangeEvent) {
@@ -2191,15 +2228,19 @@ func (_this *PromiseSequenceIDBDatabaseInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceIDBDatabaseInfoFromJS is casting a js.Wrapper into PromiseSequenceIDBDatabaseInfo.
-func PromiseSequenceIDBDatabaseInfoFromJS(value js.Wrapper) *PromiseSequenceIDBDatabaseInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceIDBDatabaseInfoFromJS is casting a js.Value into PromiseSequenceIDBDatabaseInfo.
+func PromiseSequenceIDBDatabaseInfoFromJS(value js.Value) *PromiseSequenceIDBDatabaseInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceIDBDatabaseInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceIDBDatabaseInfoFromJS is casting from something that holds a js.Value into PromiseSequenceIDBDatabaseInfo.
+func PromiseSequenceIDBDatabaseInfoFromWrapper(input core.Wrapper) *PromiseSequenceIDBDatabaseInfo {
+	return PromiseSequenceIDBDatabaseInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceIDBDatabaseInfo) Then(onFulfilled *PromiseSequenceIDBDatabaseInfoOnFulfilled, onRejected *PromiseSequenceIDBDatabaseInfoOnRejected) (_result *PromiseSequenceIDBDatabaseInfo) {

--- a/javascript/javascript.go
+++ b/javascript/javascript.go
@@ -6,6 +6,10 @@ package javascript
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -1163,7 +1167,7 @@ type ArrayEntryValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayEntryValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1179,26 +1183,24 @@ func (_this *ArrayEntryValue) JSValue() js.Value {
 }
 
 // ArrayEntryValueFromJS is allocating a new
-// ArrayEntryValue object and copy all values from
-// input javascript object
-func ArrayEntryValueFromJS(value js.Wrapper) *ArrayEntryValue {
-	input := value.JSValue()
+// ArrayEntryValue object and copy all values in the value javascript object.
+func ArrayEntryValueFromJS(value js.Value) *ArrayEntryValue {
 	var out ArrayEntryValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1209,7 +1211,7 @@ type ArrayKeyValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayKeyValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1221,18 +1223,16 @@ func (_this *ArrayKeyValue) JSValue() js.Value {
 }
 
 // ArrayKeyValueFromJS is allocating a new
-// ArrayKeyValue object and copy all values from
-// input javascript object
-func ArrayKeyValueFromJS(value js.Wrapper) *ArrayKeyValue {
-	input := value.JSValue()
+// ArrayKeyValue object and copy all values in the value javascript object.
+func ArrayKeyValueFromJS(value js.Value) *ArrayKeyValue {
 	var out ArrayKeyValue
 	var (
 		value0 int  // javascript: long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).Int()
+	value0 = (value.Get("value")).Int()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1243,7 +1243,7 @@ type ArrayValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1255,18 +1255,16 @@ func (_this *ArrayValueIteratorValue) JSValue() js.Value {
 }
 
 // ArrayValueIteratorValueFromJS is allocating a new
-// ArrayValueIteratorValue object and copy all values from
-// input javascript object
-func ArrayValueIteratorValueFromJS(value js.Wrapper) *ArrayValueIteratorValue {
-	input := value.JSValue()
+// ArrayValueIteratorValue object and copy all values in the value javascript object.
+func ArrayValueIteratorValueFromJS(value js.Value) *ArrayValueIteratorValue {
 	var out ArrayValueIteratorValue
 	var (
 		value0 js.Value // javascript: any {value Value value}
 		value1 bool     // javascript: boolean {done Done done}
 	)
-	value0 = input.Get("value")
+	value0 = value.Get("value")
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1281,15 +1279,19 @@ func (_this *Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayFromJS is casting a js.Wrapper into Array.
-func ArrayFromJS(value js.Wrapper) *Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayFromJS is casting a js.Value into Array.
+func ArrayFromJS(value js.Value) *Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayFromJS is casting from something that holds a js.Value into Array.
+func ArrayFromWrapper(input core.Wrapper) *Array {
+	return ArrayFromJS(input.JSValue())
 }
 
 func From(arrayLike interface{}, mapFn *ArrayMapFn, thisArg interface{}) (_result *Array) {
@@ -2166,15 +2168,19 @@ func (_this *ArrayBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayBufferFromJS is casting a js.Wrapper into ArrayBuffer.
-func ArrayBufferFromJS(value js.Wrapper) *ArrayBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayBufferFromJS is casting a js.Value into ArrayBuffer.
+func ArrayBufferFromJS(value js.Value) *ArrayBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayBufferFromJS is casting from something that holds a js.Value into ArrayBuffer.
+func ArrayBufferFromWrapper(input core.Wrapper) *ArrayBuffer {
+	return ArrayBufferFromJS(input.JSValue())
 }
 
 // class: ArrayEntryIterator
@@ -2187,15 +2193,19 @@ func (_this *ArrayEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayEntryIteratorFromJS is casting a js.Wrapper into ArrayEntryIterator.
-func ArrayEntryIteratorFromJS(value js.Wrapper) *ArrayEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayEntryIteratorFromJS is casting a js.Value into ArrayEntryIterator.
+func ArrayEntryIteratorFromJS(value js.Value) *ArrayEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayEntryIteratorFromJS is casting from something that holds a js.Value into ArrayEntryIterator.
+func ArrayEntryIteratorFromWrapper(input core.Wrapper) *ArrayEntryIterator {
+	return ArrayEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayEntryIterator) Next() (_result *ArrayEntryValue) {
@@ -2222,15 +2232,19 @@ func (_this *ArrayKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayKeyIteratorFromJS is casting a js.Wrapper into ArrayKeyIterator.
-func ArrayKeyIteratorFromJS(value js.Wrapper) *ArrayKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayKeyIteratorFromJS is casting a js.Value into ArrayKeyIterator.
+func ArrayKeyIteratorFromJS(value js.Value) *ArrayKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayKeyIteratorFromJS is casting from something that holds a js.Value into ArrayKeyIterator.
+func ArrayKeyIteratorFromWrapper(input core.Wrapper) *ArrayKeyIterator {
+	return ArrayKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayKeyIterator) Next() (_result *ArrayKeyValue) {
@@ -2257,15 +2271,19 @@ func (_this *ArrayValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayValueIteratorFromJS is casting a js.Wrapper into ArrayValueIterator.
-func ArrayValueIteratorFromJS(value js.Wrapper) *ArrayValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayValueIteratorFromJS is casting a js.Value into ArrayValueIterator.
+func ArrayValueIteratorFromJS(value js.Value) *ArrayValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayValueIteratorFromJS is casting from something that holds a js.Value into ArrayValueIterator.
+func ArrayValueIteratorFromWrapper(input core.Wrapper) *ArrayValueIterator {
+	return ArrayValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayValueIterator) Next() (_result *ArrayValueIteratorValue) {
@@ -2292,15 +2310,19 @@ func (_this *DataView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataViewFromJS is casting a js.Wrapper into DataView.
-func DataViewFromJS(value js.Wrapper) *DataView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataViewFromJS is casting a js.Value into DataView.
+func DataViewFromJS(value js.Value) *DataView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataViewFromJS is casting from something that holds a js.Value into DataView.
+func DataViewFromWrapper(input core.Wrapper) *DataView {
+	return DataViewFromJS(input.JSValue())
 }
 
 // class: Float32Array
@@ -2313,15 +2335,19 @@ func (_this *Float32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Float32ArrayFromJS is casting a js.Wrapper into Float32Array.
-func Float32ArrayFromJS(value js.Wrapper) *Float32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Float32ArrayFromJS is casting a js.Value into Float32Array.
+func Float32ArrayFromJS(value js.Value) *Float32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Float32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Float32ArrayFromJS is casting from something that holds a js.Value into Float32Array.
+func Float32ArrayFromWrapper(input core.Wrapper) *Float32Array {
+	return Float32ArrayFromJS(input.JSValue())
 }
 
 // class: Float64Array
@@ -2334,15 +2360,19 @@ func (_this *Float64Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Float64ArrayFromJS is casting a js.Wrapper into Float64Array.
-func Float64ArrayFromJS(value js.Wrapper) *Float64Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Float64ArrayFromJS is casting a js.Value into Float64Array.
+func Float64ArrayFromJS(value js.Value) *Float64Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Float64Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Float64ArrayFromJS is casting from something that holds a js.Value into Float64Array.
+func Float64ArrayFromWrapper(input core.Wrapper) *Float64Array {
+	return Float64ArrayFromJS(input.JSValue())
 }
 
 // class: FrozenArray
@@ -2355,15 +2385,19 @@ func (_this *FrozenArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FrozenArrayFromJS is casting a js.Wrapper into FrozenArray.
-func FrozenArrayFromJS(value js.Wrapper) *FrozenArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FrozenArrayFromJS is casting a js.Value into FrozenArray.
+func FrozenArrayFromJS(value js.Value) *FrozenArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FrozenArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FrozenArrayFromJS is casting from something that holds a js.Value into FrozenArray.
+func FrozenArrayFromWrapper(input core.Wrapper) *FrozenArray {
+	return FrozenArrayFromJS(input.JSValue())
 }
 
 // class: Int16Array
@@ -2376,15 +2410,19 @@ func (_this *Int16Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int16ArrayFromJS is casting a js.Wrapper into Int16Array.
-func Int16ArrayFromJS(value js.Wrapper) *Int16Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int16ArrayFromJS is casting a js.Value into Int16Array.
+func Int16ArrayFromJS(value js.Value) *Int16Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int16Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int16ArrayFromJS is casting from something that holds a js.Value into Int16Array.
+func Int16ArrayFromWrapper(input core.Wrapper) *Int16Array {
+	return Int16ArrayFromJS(input.JSValue())
 }
 
 // class: Int32Array
@@ -2397,15 +2435,19 @@ func (_this *Int32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int32ArrayFromJS is casting a js.Wrapper into Int32Array.
-func Int32ArrayFromJS(value js.Wrapper) *Int32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int32ArrayFromJS is casting a js.Value into Int32Array.
+func Int32ArrayFromJS(value js.Value) *Int32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int32ArrayFromJS is casting from something that holds a js.Value into Int32Array.
+func Int32ArrayFromWrapper(input core.Wrapper) *Int32Array {
+	return Int32ArrayFromJS(input.JSValue())
 }
 
 // class: Int8Array
@@ -2418,15 +2460,19 @@ func (_this *Int8Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int8ArrayFromJS is casting a js.Wrapper into Int8Array.
-func Int8ArrayFromJS(value js.Wrapper) *Int8Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int8ArrayFromJS is casting a js.Value into Int8Array.
+func Int8ArrayFromJS(value js.Value) *Int8Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int8Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int8ArrayFromJS is casting from something that holds a js.Value into Int8Array.
+func Int8ArrayFromWrapper(input core.Wrapper) *Int8Array {
+	return Int8ArrayFromJS(input.JSValue())
 }
 
 // class: JavaScriptFunction
@@ -2439,15 +2485,19 @@ func (_this *JavaScriptFunction) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// JavaScriptFunctionFromJS is casting a js.Wrapper into JavaScriptFunction.
-func JavaScriptFunctionFromJS(value js.Wrapper) *JavaScriptFunction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// JavaScriptFunctionFromJS is casting a js.Value into JavaScriptFunction.
+func JavaScriptFunctionFromJS(value js.Value) *JavaScriptFunction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &JavaScriptFunction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// JavaScriptFunctionFromJS is casting from something that holds a js.Value into JavaScriptFunction.
+func JavaScriptFunctionFromWrapper(input core.Wrapper) *JavaScriptFunction {
+	return JavaScriptFunctionFromJS(input.JSValue())
 }
 
 func NewJavaScriptFunction(argumentAndFunctionBody ...string) (_result *JavaScriptFunction) {
@@ -2682,15 +2732,19 @@ func (_this *Object) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObjectFromJS is casting a js.Wrapper into Object.
-func ObjectFromJS(value js.Wrapper) *Object {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObjectFromJS is casting a js.Value into Object.
+func ObjectFromJS(value js.Value) *Object {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Object{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObjectFromJS is casting from something that holds a js.Value into Object.
+func ObjectFromWrapper(input core.Wrapper) *Object {
+	return ObjectFromJS(input.JSValue())
 }
 
 // class: Promise
@@ -2703,15 +2757,19 @@ func (_this *Promise) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFromJS is casting a js.Wrapper into Promise.
-func PromiseFromJS(value js.Wrapper) *Promise {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFromJS is casting a js.Value into Promise.
+func PromiseFromJS(value js.Value) *Promise {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Promise{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFromJS is casting from something that holds a js.Value into Promise.
+func PromiseFromWrapper(input core.Wrapper) *Promise {
+	return PromiseFromJS(input.JSValue())
 }
 
 func (_this *Promise) Then(onFulfilled *PromiseOnFulfilled, onRejected *PromiseOnRejected) (_result *Promise) {
@@ -2808,15 +2866,19 @@ func (_this *PromiseArrayBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseArrayBufferFromJS is casting a js.Wrapper into PromiseArrayBuffer.
-func PromiseArrayBufferFromJS(value js.Wrapper) *PromiseArrayBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseArrayBufferFromJS is casting a js.Value into PromiseArrayBuffer.
+func PromiseArrayBufferFromJS(value js.Value) *PromiseArrayBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseArrayBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseArrayBufferFromJS is casting from something that holds a js.Value into PromiseArrayBuffer.
+func PromiseArrayBufferFromWrapper(input core.Wrapper) *PromiseArrayBuffer {
+	return PromiseArrayBufferFromJS(input.JSValue())
 }
 
 func (_this *PromiseArrayBuffer) Then(onFulfilled *PromiseArrayBufferOnFulfilled, onRejected *PromiseArrayBufferOnRejected) (_result *PromiseArrayBuffer) {
@@ -2913,15 +2975,19 @@ func (_this *PromiseBool) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBoolFromJS is casting a js.Wrapper into PromiseBool.
-func PromiseBoolFromJS(value js.Wrapper) *PromiseBool {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBoolFromJS is casting a js.Value into PromiseBool.
+func PromiseBoolFromJS(value js.Value) *PromiseBool {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBool{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBoolFromJS is casting from something that holds a js.Value into PromiseBool.
+func PromiseBoolFromWrapper(input core.Wrapper) *PromiseBool {
+	return PromiseBoolFromJS(input.JSValue())
 }
 
 func (_this *PromiseBool) Then(onFulfilled *PromiseBoolOnFulfilled, onRejected *PromiseBoolOnRejected) (_result *PromiseBool) {
@@ -3018,15 +3084,19 @@ func (_this *PromiseDataView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDataViewFromJS is casting a js.Wrapper into PromiseDataView.
-func PromiseDataViewFromJS(value js.Wrapper) *PromiseDataView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDataViewFromJS is casting a js.Value into PromiseDataView.
+func PromiseDataViewFromJS(value js.Value) *PromiseDataView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDataView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDataViewFromJS is casting from something that holds a js.Value into PromiseDataView.
+func PromiseDataViewFromWrapper(input core.Wrapper) *PromiseDataView {
+	return PromiseDataViewFromJS(input.JSValue())
 }
 
 func (_this *PromiseDataView) Then(onFulfilled *PromiseDataViewOnFulfilled, onRejected *PromiseDataViewOnRejected) (_result *PromiseDataView) {
@@ -3123,15 +3193,19 @@ func (_this *PromiseFrozenArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFrozenArrayFromJS is casting a js.Wrapper into PromiseFrozenArray.
-func PromiseFrozenArrayFromJS(value js.Wrapper) *PromiseFrozenArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFrozenArrayFromJS is casting a js.Value into PromiseFrozenArray.
+func PromiseFrozenArrayFromJS(value js.Value) *PromiseFrozenArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFrozenArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFrozenArrayFromJS is casting from something that holds a js.Value into PromiseFrozenArray.
+func PromiseFrozenArrayFromWrapper(input core.Wrapper) *PromiseFrozenArray {
+	return PromiseFrozenArrayFromJS(input.JSValue())
 }
 
 func (_this *PromiseFrozenArray) Then(onFulfilled *PromiseFrozenArrayOnFulfilled, onRejected *PromiseFrozenArrayOnRejected) (_result *PromiseFrozenArray) {
@@ -3228,15 +3302,19 @@ func (_this *PromiseInt) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseIntFromJS is casting a js.Wrapper into PromiseInt.
-func PromiseIntFromJS(value js.Wrapper) *PromiseInt {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseIntFromJS is casting a js.Value into PromiseInt.
+func PromiseIntFromJS(value js.Value) *PromiseInt {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseInt{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseIntFromJS is casting from something that holds a js.Value into PromiseInt.
+func PromiseIntFromWrapper(input core.Wrapper) *PromiseInt {
+	return PromiseIntFromJS(input.JSValue())
 }
 
 func (_this *PromiseInt) Then(onFulfilled *PromiseIntOnFulfilled, onRejected *PromiseIntOnRejected) (_result *PromiseInt) {
@@ -3333,15 +3411,19 @@ func (_this *PromiseSequenceString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceStringFromJS is casting a js.Wrapper into PromiseSequenceString.
-func PromiseSequenceStringFromJS(value js.Wrapper) *PromiseSequenceString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceStringFromJS is casting a js.Value into PromiseSequenceString.
+func PromiseSequenceStringFromJS(value js.Value) *PromiseSequenceString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceStringFromJS is casting from something that holds a js.Value into PromiseSequenceString.
+func PromiseSequenceStringFromWrapper(input core.Wrapper) *PromiseSequenceString {
+	return PromiseSequenceStringFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceString) Then(onFulfilled *PromiseSequenceStringOnFulfilled, onRejected *PromiseSequenceStringOnRejected) (_result *PromiseSequenceString) {
@@ -3438,15 +3520,19 @@ func (_this *PromiseString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStringFromJS is casting a js.Wrapper into PromiseString.
-func PromiseStringFromJS(value js.Wrapper) *PromiseString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStringFromJS is casting a js.Value into PromiseString.
+func PromiseStringFromJS(value js.Value) *PromiseString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStringFromJS is casting from something that holds a js.Value into PromiseString.
+func PromiseStringFromWrapper(input core.Wrapper) *PromiseString {
+	return PromiseStringFromJS(input.JSValue())
 }
 
 func (_this *PromiseString) Then(onFulfilled *PromiseStringOnFulfilled, onRejected *PromiseStringOnRejected) (_result *PromiseString) {
@@ -3543,15 +3629,19 @@ func (_this *PromiseVoid) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseVoidFromJS is casting a js.Wrapper into PromiseVoid.
-func PromiseVoidFromJS(value js.Wrapper) *PromiseVoid {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseVoidFromJS is casting a js.Value into PromiseVoid.
+func PromiseVoidFromJS(value js.Value) *PromiseVoid {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseVoid{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseVoidFromJS is casting from something that holds a js.Value into PromiseVoid.
+func PromiseVoidFromWrapper(input core.Wrapper) *PromiseVoid {
+	return PromiseVoidFromJS(input.JSValue())
 }
 
 func (_this *PromiseVoid) Then(onFulfilled *PromiseVoidOnFulfilled, onRejected *PromiseVoidOnRejected) (_result *PromiseVoid) {
@@ -3648,15 +3738,19 @@ func (_this *Uint16Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint16ArrayFromJS is casting a js.Wrapper into Uint16Array.
-func Uint16ArrayFromJS(value js.Wrapper) *Uint16Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint16ArrayFromJS is casting a js.Value into Uint16Array.
+func Uint16ArrayFromJS(value js.Value) *Uint16Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint16Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint16ArrayFromJS is casting from something that holds a js.Value into Uint16Array.
+func Uint16ArrayFromWrapper(input core.Wrapper) *Uint16Array {
+	return Uint16ArrayFromJS(input.JSValue())
 }
 
 // class: Uint32Array
@@ -3669,15 +3763,19 @@ func (_this *Uint32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint32ArrayFromJS is casting a js.Wrapper into Uint32Array.
-func Uint32ArrayFromJS(value js.Wrapper) *Uint32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint32ArrayFromJS is casting a js.Value into Uint32Array.
+func Uint32ArrayFromJS(value js.Value) *Uint32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint32ArrayFromJS is casting from something that holds a js.Value into Uint32Array.
+func Uint32ArrayFromWrapper(input core.Wrapper) *Uint32Array {
+	return Uint32ArrayFromJS(input.JSValue())
 }
 
 // class: Uint8Array
@@ -3690,13 +3788,17 @@ func (_this *Uint8Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint8ArrayFromJS is casting a js.Wrapper into Uint8Array.
-func Uint8ArrayFromJS(value js.Wrapper) *Uint8Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint8ArrayFromJS is casting a js.Value into Uint8Array.
+func Uint8ArrayFromJS(value js.Value) *Uint8Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint8Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint8ArrayFromJS is casting from something that holds a js.Value into Uint8Array.
+func Uint8ArrayFromWrapper(input core.Wrapper) *Uint8Array {
+	return Uint8ArrayFromJS(input.JSValue())
 }

--- a/javascript/javascript_js.go
+++ b/javascript/javascript_js.go
@@ -4,6 +4,10 @@ package javascript
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -1161,7 +1165,7 @@ type ArrayEntryValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayEntryValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1177,26 +1181,24 @@ func (_this *ArrayEntryValue) JSValue() js.Value {
 }
 
 // ArrayEntryValueFromJS is allocating a new
-// ArrayEntryValue object and copy all values from
-// input javascript object
-func ArrayEntryValueFromJS(value js.Wrapper) *ArrayEntryValue {
-	input := value.JSValue()
+// ArrayEntryValue object and copy all values in the value javascript object.
+func ArrayEntryValueFromJS(value js.Value) *ArrayEntryValue {
 	var out ArrayEntryValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1207,7 +1209,7 @@ type ArrayKeyValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayKeyValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1219,18 +1221,16 @@ func (_this *ArrayKeyValue) JSValue() js.Value {
 }
 
 // ArrayKeyValueFromJS is allocating a new
-// ArrayKeyValue object and copy all values from
-// input javascript object
-func ArrayKeyValueFromJS(value js.Wrapper) *ArrayKeyValue {
-	input := value.JSValue()
+// ArrayKeyValue object and copy all values in the value javascript object.
+func ArrayKeyValueFromJS(value js.Value) *ArrayKeyValue {
 	var out ArrayKeyValue
 	var (
 		value0 int  // javascript: long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).Int()
+	value0 = (value.Get("value")).Int()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1241,7 +1241,7 @@ type ArrayValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ArrayValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1253,18 +1253,16 @@ func (_this *ArrayValueIteratorValue) JSValue() js.Value {
 }
 
 // ArrayValueIteratorValueFromJS is allocating a new
-// ArrayValueIteratorValue object and copy all values from
-// input javascript object
-func ArrayValueIteratorValueFromJS(value js.Wrapper) *ArrayValueIteratorValue {
-	input := value.JSValue()
+// ArrayValueIteratorValue object and copy all values in the value javascript object.
+func ArrayValueIteratorValueFromJS(value js.Value) *ArrayValueIteratorValue {
 	var out ArrayValueIteratorValue
 	var (
 		value0 js.Value // javascript: any {value Value value}
 		value1 bool     // javascript: boolean {done Done done}
 	)
-	value0 = input.Get("value")
+	value0 = value.Get("value")
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1279,15 +1277,19 @@ func (_this *Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayFromJS is casting a js.Wrapper into Array.
-func ArrayFromJS(value js.Wrapper) *Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayFromJS is casting a js.Value into Array.
+func ArrayFromJS(value js.Value) *Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayFromJS is casting from something that holds a js.Value into Array.
+func ArrayFromWrapper(input core.Wrapper) *Array {
+	return ArrayFromJS(input.JSValue())
 }
 
 func From(arrayLike interface{}, mapFn *ArrayMapFn, thisArg interface{}) (_result *Array) {
@@ -2164,15 +2166,19 @@ func (_this *ArrayBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayBufferFromJS is casting a js.Wrapper into ArrayBuffer.
-func ArrayBufferFromJS(value js.Wrapper) *ArrayBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayBufferFromJS is casting a js.Value into ArrayBuffer.
+func ArrayBufferFromJS(value js.Value) *ArrayBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayBufferFromJS is casting from something that holds a js.Value into ArrayBuffer.
+func ArrayBufferFromWrapper(input core.Wrapper) *ArrayBuffer {
+	return ArrayBufferFromJS(input.JSValue())
 }
 
 // class: ArrayEntryIterator
@@ -2185,15 +2191,19 @@ func (_this *ArrayEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayEntryIteratorFromJS is casting a js.Wrapper into ArrayEntryIterator.
-func ArrayEntryIteratorFromJS(value js.Wrapper) *ArrayEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayEntryIteratorFromJS is casting a js.Value into ArrayEntryIterator.
+func ArrayEntryIteratorFromJS(value js.Value) *ArrayEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayEntryIteratorFromJS is casting from something that holds a js.Value into ArrayEntryIterator.
+func ArrayEntryIteratorFromWrapper(input core.Wrapper) *ArrayEntryIterator {
+	return ArrayEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayEntryIterator) Next() (_result *ArrayEntryValue) {
@@ -2220,15 +2230,19 @@ func (_this *ArrayKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayKeyIteratorFromJS is casting a js.Wrapper into ArrayKeyIterator.
-func ArrayKeyIteratorFromJS(value js.Wrapper) *ArrayKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayKeyIteratorFromJS is casting a js.Value into ArrayKeyIterator.
+func ArrayKeyIteratorFromJS(value js.Value) *ArrayKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayKeyIteratorFromJS is casting from something that holds a js.Value into ArrayKeyIterator.
+func ArrayKeyIteratorFromWrapper(input core.Wrapper) *ArrayKeyIterator {
+	return ArrayKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayKeyIterator) Next() (_result *ArrayKeyValue) {
@@ -2255,15 +2269,19 @@ func (_this *ArrayValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ArrayValueIteratorFromJS is casting a js.Wrapper into ArrayValueIterator.
-func ArrayValueIteratorFromJS(value js.Wrapper) *ArrayValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ArrayValueIteratorFromJS is casting a js.Value into ArrayValueIterator.
+func ArrayValueIteratorFromJS(value js.Value) *ArrayValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ArrayValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ArrayValueIteratorFromJS is casting from something that holds a js.Value into ArrayValueIterator.
+func ArrayValueIteratorFromWrapper(input core.Wrapper) *ArrayValueIterator {
+	return ArrayValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *ArrayValueIterator) Next() (_result *ArrayValueIteratorValue) {
@@ -2290,15 +2308,19 @@ func (_this *DataView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DataViewFromJS is casting a js.Wrapper into DataView.
-func DataViewFromJS(value js.Wrapper) *DataView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataViewFromJS is casting a js.Value into DataView.
+func DataViewFromJS(value js.Value) *DataView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataViewFromJS is casting from something that holds a js.Value into DataView.
+func DataViewFromWrapper(input core.Wrapper) *DataView {
+	return DataViewFromJS(input.JSValue())
 }
 
 // class: Float32Array
@@ -2311,15 +2333,19 @@ func (_this *Float32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Float32ArrayFromJS is casting a js.Wrapper into Float32Array.
-func Float32ArrayFromJS(value js.Wrapper) *Float32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Float32ArrayFromJS is casting a js.Value into Float32Array.
+func Float32ArrayFromJS(value js.Value) *Float32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Float32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Float32ArrayFromJS is casting from something that holds a js.Value into Float32Array.
+func Float32ArrayFromWrapper(input core.Wrapper) *Float32Array {
+	return Float32ArrayFromJS(input.JSValue())
 }
 
 // class: Float64Array
@@ -2332,15 +2358,19 @@ func (_this *Float64Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Float64ArrayFromJS is casting a js.Wrapper into Float64Array.
-func Float64ArrayFromJS(value js.Wrapper) *Float64Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Float64ArrayFromJS is casting a js.Value into Float64Array.
+func Float64ArrayFromJS(value js.Value) *Float64Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Float64Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Float64ArrayFromJS is casting from something that holds a js.Value into Float64Array.
+func Float64ArrayFromWrapper(input core.Wrapper) *Float64Array {
+	return Float64ArrayFromJS(input.JSValue())
 }
 
 // class: FrozenArray
@@ -2353,15 +2383,19 @@ func (_this *FrozenArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// FrozenArrayFromJS is casting a js.Wrapper into FrozenArray.
-func FrozenArrayFromJS(value js.Wrapper) *FrozenArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FrozenArrayFromJS is casting a js.Value into FrozenArray.
+func FrozenArrayFromJS(value js.Value) *FrozenArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FrozenArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FrozenArrayFromJS is casting from something that holds a js.Value into FrozenArray.
+func FrozenArrayFromWrapper(input core.Wrapper) *FrozenArray {
+	return FrozenArrayFromJS(input.JSValue())
 }
 
 // class: Int16Array
@@ -2374,15 +2408,19 @@ func (_this *Int16Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int16ArrayFromJS is casting a js.Wrapper into Int16Array.
-func Int16ArrayFromJS(value js.Wrapper) *Int16Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int16ArrayFromJS is casting a js.Value into Int16Array.
+func Int16ArrayFromJS(value js.Value) *Int16Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int16Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int16ArrayFromJS is casting from something that holds a js.Value into Int16Array.
+func Int16ArrayFromWrapper(input core.Wrapper) *Int16Array {
+	return Int16ArrayFromJS(input.JSValue())
 }
 
 // class: Int32Array
@@ -2395,15 +2433,19 @@ func (_this *Int32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int32ArrayFromJS is casting a js.Wrapper into Int32Array.
-func Int32ArrayFromJS(value js.Wrapper) *Int32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int32ArrayFromJS is casting a js.Value into Int32Array.
+func Int32ArrayFromJS(value js.Value) *Int32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int32ArrayFromJS is casting from something that holds a js.Value into Int32Array.
+func Int32ArrayFromWrapper(input core.Wrapper) *Int32Array {
+	return Int32ArrayFromJS(input.JSValue())
 }
 
 // class: Int8Array
@@ -2416,15 +2458,19 @@ func (_this *Int8Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Int8ArrayFromJS is casting a js.Wrapper into Int8Array.
-func Int8ArrayFromJS(value js.Wrapper) *Int8Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Int8ArrayFromJS is casting a js.Value into Int8Array.
+func Int8ArrayFromJS(value js.Value) *Int8Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Int8Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Int8ArrayFromJS is casting from something that holds a js.Value into Int8Array.
+func Int8ArrayFromWrapper(input core.Wrapper) *Int8Array {
+	return Int8ArrayFromJS(input.JSValue())
 }
 
 // class: JavaScriptFunction
@@ -2437,15 +2483,19 @@ func (_this *JavaScriptFunction) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// JavaScriptFunctionFromJS is casting a js.Wrapper into JavaScriptFunction.
-func JavaScriptFunctionFromJS(value js.Wrapper) *JavaScriptFunction {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// JavaScriptFunctionFromJS is casting a js.Value into JavaScriptFunction.
+func JavaScriptFunctionFromJS(value js.Value) *JavaScriptFunction {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &JavaScriptFunction{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// JavaScriptFunctionFromJS is casting from something that holds a js.Value into JavaScriptFunction.
+func JavaScriptFunctionFromWrapper(input core.Wrapper) *JavaScriptFunction {
+	return JavaScriptFunctionFromJS(input.JSValue())
 }
 
 func NewJavaScriptFunction(argumentAndFunctionBody ...string) (_result *JavaScriptFunction) {
@@ -2680,15 +2730,19 @@ func (_this *Object) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObjectFromJS is casting a js.Wrapper into Object.
-func ObjectFromJS(value js.Wrapper) *Object {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObjectFromJS is casting a js.Value into Object.
+func ObjectFromJS(value js.Value) *Object {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Object{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObjectFromJS is casting from something that holds a js.Value into Object.
+func ObjectFromWrapper(input core.Wrapper) *Object {
+	return ObjectFromJS(input.JSValue())
 }
 
 // class: Promise
@@ -2701,15 +2755,19 @@ func (_this *Promise) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFromJS is casting a js.Wrapper into Promise.
-func PromiseFromJS(value js.Wrapper) *Promise {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFromJS is casting a js.Value into Promise.
+func PromiseFromJS(value js.Value) *Promise {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Promise{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFromJS is casting from something that holds a js.Value into Promise.
+func PromiseFromWrapper(input core.Wrapper) *Promise {
+	return PromiseFromJS(input.JSValue())
 }
 
 func (_this *Promise) Then(onFulfilled *PromiseOnFulfilled, onRejected *PromiseOnRejected) (_result *Promise) {
@@ -2806,15 +2864,19 @@ func (_this *PromiseArrayBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseArrayBufferFromJS is casting a js.Wrapper into PromiseArrayBuffer.
-func PromiseArrayBufferFromJS(value js.Wrapper) *PromiseArrayBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseArrayBufferFromJS is casting a js.Value into PromiseArrayBuffer.
+func PromiseArrayBufferFromJS(value js.Value) *PromiseArrayBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseArrayBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseArrayBufferFromJS is casting from something that holds a js.Value into PromiseArrayBuffer.
+func PromiseArrayBufferFromWrapper(input core.Wrapper) *PromiseArrayBuffer {
+	return PromiseArrayBufferFromJS(input.JSValue())
 }
 
 func (_this *PromiseArrayBuffer) Then(onFulfilled *PromiseArrayBufferOnFulfilled, onRejected *PromiseArrayBufferOnRejected) (_result *PromiseArrayBuffer) {
@@ -2911,15 +2973,19 @@ func (_this *PromiseBool) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBoolFromJS is casting a js.Wrapper into PromiseBool.
-func PromiseBoolFromJS(value js.Wrapper) *PromiseBool {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBoolFromJS is casting a js.Value into PromiseBool.
+func PromiseBoolFromJS(value js.Value) *PromiseBool {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBool{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBoolFromJS is casting from something that holds a js.Value into PromiseBool.
+func PromiseBoolFromWrapper(input core.Wrapper) *PromiseBool {
+	return PromiseBoolFromJS(input.JSValue())
 }
 
 func (_this *PromiseBool) Then(onFulfilled *PromiseBoolOnFulfilled, onRejected *PromiseBoolOnRejected) (_result *PromiseBool) {
@@ -3016,15 +3082,19 @@ func (_this *PromiseDataView) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseDataViewFromJS is casting a js.Wrapper into PromiseDataView.
-func PromiseDataViewFromJS(value js.Wrapper) *PromiseDataView {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseDataViewFromJS is casting a js.Value into PromiseDataView.
+func PromiseDataViewFromJS(value js.Value) *PromiseDataView {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseDataView{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseDataViewFromJS is casting from something that holds a js.Value into PromiseDataView.
+func PromiseDataViewFromWrapper(input core.Wrapper) *PromiseDataView {
+	return PromiseDataViewFromJS(input.JSValue())
 }
 
 func (_this *PromiseDataView) Then(onFulfilled *PromiseDataViewOnFulfilled, onRejected *PromiseDataViewOnRejected) (_result *PromiseDataView) {
@@ -3121,15 +3191,19 @@ func (_this *PromiseFrozenArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseFrozenArrayFromJS is casting a js.Wrapper into PromiseFrozenArray.
-func PromiseFrozenArrayFromJS(value js.Wrapper) *PromiseFrozenArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseFrozenArrayFromJS is casting a js.Value into PromiseFrozenArray.
+func PromiseFrozenArrayFromJS(value js.Value) *PromiseFrozenArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseFrozenArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseFrozenArrayFromJS is casting from something that holds a js.Value into PromiseFrozenArray.
+func PromiseFrozenArrayFromWrapper(input core.Wrapper) *PromiseFrozenArray {
+	return PromiseFrozenArrayFromJS(input.JSValue())
 }
 
 func (_this *PromiseFrozenArray) Then(onFulfilled *PromiseFrozenArrayOnFulfilled, onRejected *PromiseFrozenArrayOnRejected) (_result *PromiseFrozenArray) {
@@ -3226,15 +3300,19 @@ func (_this *PromiseInt) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseIntFromJS is casting a js.Wrapper into PromiseInt.
-func PromiseIntFromJS(value js.Wrapper) *PromiseInt {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseIntFromJS is casting a js.Value into PromiseInt.
+func PromiseIntFromJS(value js.Value) *PromiseInt {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseInt{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseIntFromJS is casting from something that holds a js.Value into PromiseInt.
+func PromiseIntFromWrapper(input core.Wrapper) *PromiseInt {
+	return PromiseIntFromJS(input.JSValue())
 }
 
 func (_this *PromiseInt) Then(onFulfilled *PromiseIntOnFulfilled, onRejected *PromiseIntOnRejected) (_result *PromiseInt) {
@@ -3331,15 +3409,19 @@ func (_this *PromiseSequenceString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceStringFromJS is casting a js.Wrapper into PromiseSequenceString.
-func PromiseSequenceStringFromJS(value js.Wrapper) *PromiseSequenceString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceStringFromJS is casting a js.Value into PromiseSequenceString.
+func PromiseSequenceStringFromJS(value js.Value) *PromiseSequenceString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceStringFromJS is casting from something that holds a js.Value into PromiseSequenceString.
+func PromiseSequenceStringFromWrapper(input core.Wrapper) *PromiseSequenceString {
+	return PromiseSequenceStringFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceString) Then(onFulfilled *PromiseSequenceStringOnFulfilled, onRejected *PromiseSequenceStringOnRejected) (_result *PromiseSequenceString) {
@@ -3436,15 +3518,19 @@ func (_this *PromiseString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStringFromJS is casting a js.Wrapper into PromiseString.
-func PromiseStringFromJS(value js.Wrapper) *PromiseString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStringFromJS is casting a js.Value into PromiseString.
+func PromiseStringFromJS(value js.Value) *PromiseString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStringFromJS is casting from something that holds a js.Value into PromiseString.
+func PromiseStringFromWrapper(input core.Wrapper) *PromiseString {
+	return PromiseStringFromJS(input.JSValue())
 }
 
 func (_this *PromiseString) Then(onFulfilled *PromiseStringOnFulfilled, onRejected *PromiseStringOnRejected) (_result *PromiseString) {
@@ -3541,15 +3627,19 @@ func (_this *PromiseVoid) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseVoidFromJS is casting a js.Wrapper into PromiseVoid.
-func PromiseVoidFromJS(value js.Wrapper) *PromiseVoid {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseVoidFromJS is casting a js.Value into PromiseVoid.
+func PromiseVoidFromJS(value js.Value) *PromiseVoid {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseVoid{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseVoidFromJS is casting from something that holds a js.Value into PromiseVoid.
+func PromiseVoidFromWrapper(input core.Wrapper) *PromiseVoid {
+	return PromiseVoidFromJS(input.JSValue())
 }
 
 func (_this *PromiseVoid) Then(onFulfilled *PromiseVoidOnFulfilled, onRejected *PromiseVoidOnRejected) (_result *PromiseVoid) {
@@ -3646,15 +3736,19 @@ func (_this *Uint16Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint16ArrayFromJS is casting a js.Wrapper into Uint16Array.
-func Uint16ArrayFromJS(value js.Wrapper) *Uint16Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint16ArrayFromJS is casting a js.Value into Uint16Array.
+func Uint16ArrayFromJS(value js.Value) *Uint16Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint16Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint16ArrayFromJS is casting from something that holds a js.Value into Uint16Array.
+func Uint16ArrayFromWrapper(input core.Wrapper) *Uint16Array {
+	return Uint16ArrayFromJS(input.JSValue())
 }
 
 // class: Uint32Array
@@ -3667,15 +3761,19 @@ func (_this *Uint32Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint32ArrayFromJS is casting a js.Wrapper into Uint32Array.
-func Uint32ArrayFromJS(value js.Wrapper) *Uint32Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint32ArrayFromJS is casting a js.Value into Uint32Array.
+func Uint32ArrayFromJS(value js.Value) *Uint32Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint32Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint32ArrayFromJS is casting from something that holds a js.Value into Uint32Array.
+func Uint32ArrayFromWrapper(input core.Wrapper) *Uint32Array {
+	return Uint32ArrayFromJS(input.JSValue())
 }
 
 // class: Uint8Array
@@ -3688,13 +3786,17 @@ func (_this *Uint8Array) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint8ArrayFromJS is casting a js.Wrapper into Uint8Array.
-func Uint8ArrayFromJS(value js.Wrapper) *Uint8Array {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint8ArrayFromJS is casting a js.Value into Uint8Array.
+func Uint8ArrayFromJS(value js.Value) *Uint8Array {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint8Array{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint8ArrayFromJS is casting from something that holds a js.Value into Uint8Array.
+func Uint8ArrayFromWrapper(input core.Wrapper) *Uint8Array {
+	return Uint8ArrayFromJS(input.JSValue())
 }

--- a/javascript/missingtypes/missingtypes.go
+++ b/javascript/missingtypes/missingtypes.go
@@ -6,6 +6,10 @@ package missingtypes
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -41,15 +45,19 @@ func (_this *Date) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DateFromJS is casting a js.Wrapper into Date.
-func DateFromJS(value js.Wrapper) *Date {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DateFromJS is casting a js.Value into Date.
+func DateFromJS(value js.Value) *Date {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Date{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DateFromJS is casting from something that holds a js.Value into Date.
+func DateFromWrapper(input core.Wrapper) *Date {
+	return DateFromJS(input.JSValue())
 }
 
 // class: Dictionary
@@ -62,15 +70,19 @@ func (_this *Dictionary) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DictionaryFromJS is casting a js.Wrapper into Dictionary.
-func DictionaryFromJS(value js.Wrapper) *Dictionary {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DictionaryFromJS is casting a js.Value into Dictionary.
+func DictionaryFromJS(value js.Value) *Dictionary {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Dictionary{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DictionaryFromJS is casting from something that holds a js.Value into Dictionary.
+func DictionaryFromWrapper(input core.Wrapper) *Dictionary {
+	return DictionaryFromJS(input.JSValue())
 }
 
 // class: WritableStream
@@ -83,13 +95,17 @@ func (_this *WritableStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WritableStreamFromJS is casting a js.Wrapper into WritableStream.
-func WritableStreamFromJS(value js.Wrapper) *WritableStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WritableStreamFromJS is casting a js.Value into WritableStream.
+func WritableStreamFromJS(value js.Value) *WritableStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WritableStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WritableStreamFromJS is casting from something that holds a js.Value into WritableStream.
+func WritableStreamFromWrapper(input core.Wrapper) *WritableStream {
+	return WritableStreamFromJS(input.JSValue())
 }

--- a/javascript/missingtypes/missingtypes_js.go
+++ b/javascript/missingtypes/missingtypes_js.go
@@ -4,6 +4,10 @@ package missingtypes
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -39,15 +43,19 @@ func (_this *Date) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DateFromJS is casting a js.Wrapper into Date.
-func DateFromJS(value js.Wrapper) *Date {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DateFromJS is casting a js.Value into Date.
+func DateFromJS(value js.Value) *Date {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Date{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DateFromJS is casting from something that holds a js.Value into Date.
+func DateFromWrapper(input core.Wrapper) *Date {
+	return DateFromJS(input.JSValue())
 }
 
 // class: Dictionary
@@ -60,15 +68,19 @@ func (_this *Dictionary) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DictionaryFromJS is casting a js.Wrapper into Dictionary.
-func DictionaryFromJS(value js.Wrapper) *Dictionary {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DictionaryFromJS is casting a js.Value into Dictionary.
+func DictionaryFromJS(value js.Value) *Dictionary {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Dictionary{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DictionaryFromJS is casting from something that holds a js.Value into Dictionary.
+func DictionaryFromWrapper(input core.Wrapper) *Dictionary {
+	return DictionaryFromJS(input.JSValue())
 }
 
 // class: WritableStream
@@ -81,13 +93,17 @@ func (_this *WritableStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WritableStreamFromJS is casting a js.Wrapper into WritableStream.
-func WritableStreamFromJS(value js.Wrapper) *WritableStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WritableStreamFromJS is casting a js.Value into WritableStream.
+func WritableStreamFromJS(value js.Value) *WritableStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WritableStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WritableStreamFromJS is casting from something that holds a js.Value into WritableStream.
+func WritableStreamFromWrapper(input core.Wrapper) *WritableStream {
+	return WritableStreamFromJS(input.JSValue())
 }

--- a/media/audio/audio.go
+++ b/media/audio/audio.go
@@ -7,6 +7,7 @@ package audio
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/channel"
@@ -718,7 +719,7 @@ type AnalyserOptions struct {
 	SmoothingTimeConstant float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnalyserOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -740,10 +741,8 @@ func (_this *AnalyserOptions) JSValue() js.Value {
 }
 
 // AnalyserOptionsFromJS is allocating a new
-// AnalyserOptions object and copy all values from
-// input javascript object
-func AnalyserOptionsFromJS(value js.Wrapper) *AnalyserOptions {
-	input := value.JSValue()
+// AnalyserOptions object and copy all values in the value javascript object.
+func AnalyserOptionsFromJS(value js.Value) *AnalyserOptions {
 	var out AnalyserOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -754,19 +753,19 @@ func AnalyserOptionsFromJS(value js.Wrapper) *AnalyserOptions {
 		value5 float64               // javascript: double {minDecibels MinDecibels minDecibels}
 		value6 float64               // javascript: double {smoothingTimeConstant SmoothingTimeConstant smoothingTimeConstant}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("fftSize")).Int())
+	value3 = (uint)((value.Get("fftSize")).Int())
 	out.FftSize = value3
-	value4 = (input.Get("maxDecibels")).Float()
+	value4 = (value.Get("maxDecibels")).Float()
 	out.MaxDecibels = value4
-	value5 = (input.Get("minDecibels")).Float()
+	value5 = (value.Get("minDecibels")).Float()
 	out.MinDecibels = value5
-	value6 = (input.Get("smoothingTimeConstant")).Float()
+	value6 = (value.Get("smoothingTimeConstant")).Float()
 	out.SmoothingTimeConstant = value6
 	return &out
 }
@@ -778,7 +777,7 @@ type AudioBufferOptions struct {
 	SampleRate       float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioBufferOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -792,21 +791,19 @@ func (_this *AudioBufferOptions) JSValue() js.Value {
 }
 
 // AudioBufferOptionsFromJS is allocating a new
-// AudioBufferOptions object and copy all values from
-// input javascript object
-func AudioBufferOptionsFromJS(value js.Wrapper) *AudioBufferOptions {
-	input := value.JSValue()
+// AudioBufferOptions object and copy all values in the value javascript object.
+func AudioBufferOptionsFromJS(value js.Value) *AudioBufferOptions {
 	var out AudioBufferOptions
 	var (
 		value0 uint    // javascript: unsigned long {numberOfChannels NumberOfChannels numberOfChannels}
 		value1 uint    // javascript: unsigned long {length Length length}
 		value2 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = (uint)((input.Get("numberOfChannels")).Int())
+	value0 = (uint)((value.Get("numberOfChannels")).Int())
 	out.NumberOfChannels = value0
-	value1 = (uint)((input.Get("length")).Int())
+	value1 = (uint)((value.Get("length")).Int())
 	out.Length = value1
-	value2 = (float32)((input.Get("sampleRate")).Float())
+	value2 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value2
 	return &out
 }
@@ -821,7 +818,7 @@ type AudioBufferSourceOptions struct {
 	PlaybackRate float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioBufferSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -841,10 +838,8 @@ func (_this *AudioBufferSourceOptions) JSValue() js.Value {
 }
 
 // AudioBufferSourceOptionsFromJS is allocating a new
-// AudioBufferSourceOptions object and copy all values from
-// input javascript object
-func AudioBufferSourceOptionsFromJS(value js.Wrapper) *AudioBufferSourceOptions {
-	input := value.JSValue()
+// AudioBufferSourceOptions object and copy all values in the value javascript object.
+func AudioBufferSourceOptionsFromJS(value js.Value) *AudioBufferSourceOptions {
 	var out AudioBufferSourceOptions
 	var (
 		value0 *AudioBuffer // javascript: AudioBuffer {buffer Buffer buffer}
@@ -854,19 +849,19 @@ func AudioBufferSourceOptionsFromJS(value js.Wrapper) *AudioBufferSourceOptions 
 		value4 float64      // javascript: double {loopStart LoopStart loopStart}
 		value5 float32      // javascript: float {playbackRate PlaybackRate playbackRate}
 	)
-	if input.Get("buffer").Type() != js.TypeNull && input.Get("buffer").Type() != js.TypeUndefined {
-		value0 = AudioBufferFromJS(input.Get("buffer"))
+	if value.Get("buffer").Type() != js.TypeNull && value.Get("buffer").Type() != js.TypeUndefined {
+		value0 = AudioBufferFromJS(value.Get("buffer"))
 	}
 	out.Buffer = value0
-	value1 = (float32)((input.Get("detune")).Float())
+	value1 = (float32)((value.Get("detune")).Float())
 	out.Detune = value1
-	value2 = (input.Get("loop")).Bool()
+	value2 = (value.Get("loop")).Bool()
 	out.Loop = value2
-	value3 = (input.Get("loopEnd")).Float()
+	value3 = (value.Get("loopEnd")).Float()
 	out.LoopEnd = value3
-	value4 = (input.Get("loopStart")).Float()
+	value4 = (value.Get("loopStart")).Float()
 	out.LoopStart = value4
-	value5 = (float32)((input.Get("playbackRate")).Float())
+	value5 = (float32)((value.Get("playbackRate")).Float())
 	out.PlaybackRate = value5
 	return &out
 }
@@ -877,7 +872,7 @@ type AudioContextOptions struct {
 	SampleRate  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioContextOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -889,18 +884,16 @@ func (_this *AudioContextOptions) JSValue() js.Value {
 }
 
 // AudioContextOptionsFromJS is allocating a new
-// AudioContextOptions object and copy all values from
-// input javascript object
-func AudioContextOptionsFromJS(value js.Wrapper) *AudioContextOptions {
-	input := value.JSValue()
+// AudioContextOptions object and copy all values in the value javascript object.
+func AudioContextOptionsFromJS(value js.Value) *AudioContextOptions {
 	var out AudioContextOptions
 	var (
 		value0 *Union  // javascript: Union {latencyHint LatencyHint latencyHint}
 		value1 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = UnionFromJS(input.Get("latencyHint"))
+	value0 = UnionFromJS(value.Get("latencyHint"))
 	out.LatencyHint = value0
-	value1 = (float32)((input.Get("sampleRate")).Float())
+	value1 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value1
 	return &out
 }
@@ -912,7 +905,7 @@ type AudioNodeOptions struct {
 	ChannelInterpretation ChannelInterpretation
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -926,21 +919,19 @@ func (_this *AudioNodeOptions) JSValue() js.Value {
 }
 
 // AudioNodeOptionsFromJS is allocating a new
-// AudioNodeOptions object and copy all values from
-// input javascript object
-func AudioNodeOptionsFromJS(value js.Wrapper) *AudioNodeOptions {
-	input := value.JSValue()
+// AudioNodeOptions object and copy all values in the value javascript object.
+func AudioNodeOptionsFromJS(value js.Value) *AudioNodeOptions {
 	var out AudioNodeOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
 		value1 ChannelCountMode      // javascript: ChannelCountMode {channelCountMode ChannelCountMode channelCountMode}
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
 	return &out
 }
@@ -954,7 +945,7 @@ type AudioParamDescriptor struct {
 	AutomationRate AutomationRate
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -972,10 +963,8 @@ func (_this *AudioParamDescriptor) JSValue() js.Value {
 }
 
 // AudioParamDescriptorFromJS is allocating a new
-// AudioParamDescriptor object and copy all values from
-// input javascript object
-func AudioParamDescriptorFromJS(value js.Wrapper) *AudioParamDescriptor {
-	input := value.JSValue()
+// AudioParamDescriptor object and copy all values in the value javascript object.
+func AudioParamDescriptorFromJS(value js.Value) *AudioParamDescriptor {
 	var out AudioParamDescriptor
 	var (
 		value0 string         // javascript: DOMString {name Name name}
@@ -984,15 +973,15 @@ func AudioParamDescriptorFromJS(value js.Wrapper) *AudioParamDescriptor {
 		value3 float32        // javascript: float {maxValue MaxValue maxValue}
 		value4 AutomationRate // javascript: AutomationRate {automationRate AutomationRate automationRate}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (float32)((input.Get("defaultValue")).Float())
+	value1 = (float32)((value.Get("defaultValue")).Float())
 	out.DefaultValue = value1
-	value2 = (float32)((input.Get("minValue")).Float())
+	value2 = (float32)((value.Get("minValue")).Float())
 	out.MinValue = value2
-	value3 = (float32)((input.Get("maxValue")).Float())
+	value3 = (float32)((value.Get("maxValue")).Float())
 	out.MaxValue = value3
-	value4 = AutomationRateFromJS(input.Get("automationRate"))
+	value4 = AutomationRateFromJS(value.Get("automationRate"))
 	out.AutomationRate = value4
 	return &out
 }
@@ -1003,7 +992,7 @@ type AudioParamMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1019,26 +1008,24 @@ func (_this *AudioParamMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapEntryIteratorValueFromJS is allocating a new
-// AudioParamMapEntryIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapEntryIteratorValueFromJS(value js.Wrapper) *AudioParamMapEntryIteratorValue {
-	input := value.JSValue()
+// AudioParamMapEntryIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapEntryIteratorValueFromJS(value js.Value) *AudioParamMapEntryIteratorValue {
 	var out AudioParamMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1049,7 +1036,7 @@ type AudioParamMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1061,18 +1048,16 @@ func (_this *AudioParamMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapKeyIteratorValueFromJS is allocating a new
-// AudioParamMapKeyIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapKeyIteratorValueFromJS(value js.Wrapper) *AudioParamMapKeyIteratorValue {
-	input := value.JSValue()
+// AudioParamMapKeyIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapKeyIteratorValueFromJS(value js.Value) *AudioParamMapKeyIteratorValue {
 	var out AudioParamMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1083,7 +1068,7 @@ type AudioParamMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1095,18 +1080,16 @@ func (_this *AudioParamMapValueIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapValueIteratorValueFromJS is allocating a new
-// AudioParamMapValueIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapValueIteratorValueFromJS(value js.Wrapper) *AudioParamMapValueIteratorValue {
-	input := value.JSValue()
+// AudioParamMapValueIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapValueIteratorValueFromJS(value js.Value) *AudioParamMapValueIteratorValue {
 	var out AudioParamMapValueIteratorValue
 	var (
 		value0 *AudioParam // javascript: AudioParam {value Value value}
 		value1 bool        // javascript: boolean {done Done done}
 	)
-	value0 = AudioParamFromJS(input.Get("value"))
+	value0 = AudioParamFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1121,7 +1104,7 @@ type AudioProcessingEventInit struct {
 	OutputBuffer *AudioBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioProcessingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1141,10 +1124,8 @@ func (_this *AudioProcessingEventInit) JSValue() js.Value {
 }
 
 // AudioProcessingEventInitFromJS is allocating a new
-// AudioProcessingEventInit object and copy all values from
-// input javascript object
-func AudioProcessingEventInitFromJS(value js.Wrapper) *AudioProcessingEventInit {
-	input := value.JSValue()
+// AudioProcessingEventInit object and copy all values in the value javascript object.
+func AudioProcessingEventInitFromJS(value js.Value) *AudioProcessingEventInit {
 	var out AudioProcessingEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1154,17 +1135,17 @@ func AudioProcessingEventInitFromJS(value js.Wrapper) *AudioProcessingEventInit 
 		value4 *AudioBuffer // javascript: AudioBuffer {inputBuffer InputBuffer inputBuffer}
 		value5 *AudioBuffer // javascript: AudioBuffer {outputBuffer OutputBuffer outputBuffer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("playbackTime")).Float()
+	value3 = (value.Get("playbackTime")).Float()
 	out.PlaybackTime = value3
-	value4 = AudioBufferFromJS(input.Get("inputBuffer"))
+	value4 = AudioBufferFromJS(value.Get("inputBuffer"))
 	out.InputBuffer = value4
-	value5 = AudioBufferFromJS(input.Get("outputBuffer"))
+	value5 = AudioBufferFromJS(value.Get("outputBuffer"))
 	out.OutputBuffer = value5
 	return &out
 }
@@ -1175,7 +1156,7 @@ type AudioTimestamp struct {
 	PerformanceTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioTimestamp) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1187,18 +1168,16 @@ func (_this *AudioTimestamp) JSValue() js.Value {
 }
 
 // AudioTimestampFromJS is allocating a new
-// AudioTimestamp object and copy all values from
-// input javascript object
-func AudioTimestampFromJS(value js.Wrapper) *AudioTimestamp {
-	input := value.JSValue()
+// AudioTimestamp object and copy all values in the value javascript object.
+func AudioTimestampFromJS(value js.Value) *AudioTimestamp {
 	var out AudioTimestamp
 	var (
 		value0 float64 // javascript: double {contextTime ContextTime contextTime}
 		value1 float64 // javascript: double {performanceTime PerformanceTime performanceTime}
 	)
-	value0 = (input.Get("contextTime")).Float()
+	value0 = (value.Get("contextTime")).Float()
 	out.ContextTime = value0
-	value1 = (input.Get("performanceTime")).Float()
+	value1 = (value.Get("performanceTime")).Float()
 	out.PerformanceTime = value1
 	return &out
 }
@@ -1214,7 +1193,7 @@ type AudioWorkletNodeOptions struct {
 	ProcessorOptions      *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioWorkletNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1240,10 +1219,8 @@ func (_this *AudioWorkletNodeOptions) JSValue() js.Value {
 }
 
 // AudioWorkletNodeOptionsFromJS is allocating a new
-// AudioWorkletNodeOptions object and copy all values from
-// input javascript object
-func AudioWorkletNodeOptionsFromJS(value js.Wrapper) *AudioWorkletNodeOptions {
-	input := value.JSValue()
+// AudioWorkletNodeOptions object and copy all values in the value javascript object.
+func AudioWorkletNodeOptionsFromJS(value js.Value) *AudioWorkletNodeOptions {
 	var out AudioWorkletNodeOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1254,28 +1231,28 @@ func AudioWorkletNodeOptionsFromJS(value js.Wrapper) *AudioWorkletNodeOptions {
 		value5 []uint                // javascript: sequence<unsigned long> {outputChannelCount OutputChannelCount outputChannelCount}
 		value6 *javascript.Object    // javascript: object {processorOptions ProcessorOptions processorOptions}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfInputs")).Int())
+	value3 = (uint)((value.Get("numberOfInputs")).Int())
 	out.NumberOfInputs = value3
-	value4 = (uint)((input.Get("numberOfOutputs")).Int())
+	value4 = (uint)((value.Get("numberOfOutputs")).Int())
 	out.NumberOfOutputs = value4
-	__length5 := input.Get("outputChannelCount").Length()
+	__length5 := value.Get("outputChannelCount").Length()
 	__array5 := make([]uint, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 uint
-		__seq_in5 := input.Get("outputChannelCount").Index(__idx5)
+		__seq_in5 := value.Get("outputChannelCount").Index(__idx5)
 		__seq_out5 = (uint)((__seq_in5).Int())
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.OutputChannelCount = value5
-	if input.Get("processorOptions").Type() != js.TypeNull && input.Get("processorOptions").Type() != js.TypeUndefined {
-		value6 = javascript.ObjectFromJS(input.Get("processorOptions"))
+	if value.Get("processorOptions").Type() != js.TypeNull && value.Get("processorOptions").Type() != js.TypeUndefined {
+		value6 = javascript.ObjectFromJS(value.Get("processorOptions"))
 	}
 	out.ProcessorOptions = value6
 	return &out
@@ -1293,7 +1270,7 @@ type BiquadFilterOptions struct {
 	Gain                  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BiquadFilterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1317,10 +1294,8 @@ func (_this *BiquadFilterOptions) JSValue() js.Value {
 }
 
 // BiquadFilterOptionsFromJS is allocating a new
-// BiquadFilterOptions object and copy all values from
-// input javascript object
-func BiquadFilterOptionsFromJS(value js.Wrapper) *BiquadFilterOptions {
-	input := value.JSValue()
+// BiquadFilterOptions object and copy all values in the value javascript object.
+func BiquadFilterOptionsFromJS(value js.Value) *BiquadFilterOptions {
 	var out BiquadFilterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1332,21 +1307,21 @@ func BiquadFilterOptionsFromJS(value js.Wrapper) *BiquadFilterOptions {
 		value6 float32               // javascript: float {frequency Frequency frequency}
 		value7 float32               // javascript: float {gain Gain gain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = BiquadFilterTypeFromJS(input.Get("type"))
+	value3 = BiquadFilterTypeFromJS(value.Get("type"))
 	out.Type = value3
-	value4 = (float32)((input.Get("Q")).Float())
+	value4 = (float32)((value.Get("Q")).Float())
 	out.Q = value4
-	value5 = (float32)((input.Get("detune")).Float())
+	value5 = (float32)((value.Get("detune")).Float())
 	out.Detune = value5
-	value6 = (float32)((input.Get("frequency")).Float())
+	value6 = (float32)((value.Get("frequency")).Float())
 	out.Frequency = value6
-	value7 = (float32)((input.Get("gain")).Float())
+	value7 = (float32)((value.Get("gain")).Float())
 	out.Gain = value7
 	return &out
 }
@@ -1359,7 +1334,7 @@ type ChannelMergerOptions struct {
 	NumberOfInputs        uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ChannelMergerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1375,10 +1350,8 @@ func (_this *ChannelMergerOptions) JSValue() js.Value {
 }
 
 // ChannelMergerOptionsFromJS is allocating a new
-// ChannelMergerOptions object and copy all values from
-// input javascript object
-func ChannelMergerOptionsFromJS(value js.Wrapper) *ChannelMergerOptions {
-	input := value.JSValue()
+// ChannelMergerOptions object and copy all values in the value javascript object.
+func ChannelMergerOptionsFromJS(value js.Value) *ChannelMergerOptions {
 	var out ChannelMergerOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1386,13 +1359,13 @@ func ChannelMergerOptionsFromJS(value js.Wrapper) *ChannelMergerOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 uint                  // javascript: unsigned long {numberOfInputs NumberOfInputs numberOfInputs}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfInputs")).Int())
+	value3 = (uint)((value.Get("numberOfInputs")).Int())
 	out.NumberOfInputs = value3
 	return &out
 }
@@ -1405,7 +1378,7 @@ type ChannelSplitterOptions struct {
 	NumberOfOutputs       uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ChannelSplitterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1421,10 +1394,8 @@ func (_this *ChannelSplitterOptions) JSValue() js.Value {
 }
 
 // ChannelSplitterOptionsFromJS is allocating a new
-// ChannelSplitterOptions object and copy all values from
-// input javascript object
-func ChannelSplitterOptionsFromJS(value js.Wrapper) *ChannelSplitterOptions {
-	input := value.JSValue()
+// ChannelSplitterOptions object and copy all values in the value javascript object.
+func ChannelSplitterOptionsFromJS(value js.Value) *ChannelSplitterOptions {
 	var out ChannelSplitterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1432,13 +1403,13 @@ func ChannelSplitterOptionsFromJS(value js.Wrapper) *ChannelSplitterOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 uint                  // javascript: unsigned long {numberOfOutputs NumberOfOutputs numberOfOutputs}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfOutputs")).Int())
+	value3 = (uint)((value.Get("numberOfOutputs")).Int())
 	out.NumberOfOutputs = value3
 	return &out
 }
@@ -1448,7 +1419,7 @@ type ConstantSourceOptions struct {
 	Offset float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstantSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1458,15 +1429,13 @@ func (_this *ConstantSourceOptions) JSValue() js.Value {
 }
 
 // ConstantSourceOptionsFromJS is allocating a new
-// ConstantSourceOptions object and copy all values from
-// input javascript object
-func ConstantSourceOptionsFromJS(value js.Wrapper) *ConstantSourceOptions {
-	input := value.JSValue()
+// ConstantSourceOptions object and copy all values in the value javascript object.
+func ConstantSourceOptionsFromJS(value js.Value) *ConstantSourceOptions {
 	var out ConstantSourceOptions
 	var (
 		value0 float32 // javascript: float {offset Offset offset}
 	)
-	value0 = (float32)((input.Get("offset")).Float())
+	value0 = (float32)((value.Get("offset")).Float())
 	out.Offset = value0
 	return &out
 }
@@ -1480,7 +1449,7 @@ type ConvolverOptions struct {
 	DisableNormalization  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConvolverOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1498,10 +1467,8 @@ func (_this *ConvolverOptions) JSValue() js.Value {
 }
 
 // ConvolverOptionsFromJS is allocating a new
-// ConvolverOptions object and copy all values from
-// input javascript object
-func ConvolverOptionsFromJS(value js.Wrapper) *ConvolverOptions {
-	input := value.JSValue()
+// ConvolverOptions object and copy all values in the value javascript object.
+func ConvolverOptionsFromJS(value js.Value) *ConvolverOptions {
 	var out ConvolverOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1510,17 +1477,17 @@ func ConvolverOptionsFromJS(value js.Wrapper) *ConvolverOptions {
 		value3 *AudioBuffer          // javascript: AudioBuffer {buffer Buffer buffer}
 		value4 bool                  // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	if input.Get("buffer").Type() != js.TypeNull && input.Get("buffer").Type() != js.TypeUndefined {
-		value3 = AudioBufferFromJS(input.Get("buffer"))
+	if value.Get("buffer").Type() != js.TypeNull && value.Get("buffer").Type() != js.TypeUndefined {
+		value3 = AudioBufferFromJS(value.Get("buffer"))
 	}
 	out.Buffer = value3
-	value4 = (input.Get("disableNormalization")).Bool()
+	value4 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value4
 	return &out
 }
@@ -1534,7 +1501,7 @@ type DelayOptions struct {
 	DelayTime             float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DelayOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1552,10 +1519,8 @@ func (_this *DelayOptions) JSValue() js.Value {
 }
 
 // DelayOptionsFromJS is allocating a new
-// DelayOptions object and copy all values from
-// input javascript object
-func DelayOptionsFromJS(value js.Wrapper) *DelayOptions {
-	input := value.JSValue()
+// DelayOptions object and copy all values in the value javascript object.
+func DelayOptionsFromJS(value js.Value) *DelayOptions {
 	var out DelayOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1564,15 +1529,15 @@ func DelayOptionsFromJS(value js.Wrapper) *DelayOptions {
 		value3 float64               // javascript: double {maxDelayTime MaxDelayTime maxDelayTime}
 		value4 float64               // javascript: double {delayTime DelayTime delayTime}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (input.Get("maxDelayTime")).Float()
+	value3 = (value.Get("maxDelayTime")).Float()
 	out.MaxDelayTime = value3
-	value4 = (input.Get("delayTime")).Float()
+	value4 = (value.Get("delayTime")).Float()
 	out.DelayTime = value4
 	return &out
 }
@@ -1589,7 +1554,7 @@ type DynamicsCompressorOptions struct {
 	Threshold             float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DynamicsCompressorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1613,10 +1578,8 @@ func (_this *DynamicsCompressorOptions) JSValue() js.Value {
 }
 
 // DynamicsCompressorOptionsFromJS is allocating a new
-// DynamicsCompressorOptions object and copy all values from
-// input javascript object
-func DynamicsCompressorOptionsFromJS(value js.Wrapper) *DynamicsCompressorOptions {
-	input := value.JSValue()
+// DynamicsCompressorOptions object and copy all values in the value javascript object.
+func DynamicsCompressorOptionsFromJS(value js.Value) *DynamicsCompressorOptions {
 	var out DynamicsCompressorOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1628,21 +1591,21 @@ func DynamicsCompressorOptionsFromJS(value js.Wrapper) *DynamicsCompressorOption
 		value6 float32               // javascript: float {release Release release}
 		value7 float32               // javascript: float {threshold Threshold threshold}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("attack")).Float())
+	value3 = (float32)((value.Get("attack")).Float())
 	out.Attack = value3
-	value4 = (float32)((input.Get("knee")).Float())
+	value4 = (float32)((value.Get("knee")).Float())
 	out.Knee = value4
-	value5 = (float32)((input.Get("ratio")).Float())
+	value5 = (float32)((value.Get("ratio")).Float())
 	out.Ratio = value5
-	value6 = (float32)((input.Get("release")).Float())
+	value6 = (float32)((value.Get("release")).Float())
 	out.Release = value6
-	value7 = (float32)((input.Get("threshold")).Float())
+	value7 = (float32)((value.Get("threshold")).Float())
 	out.Threshold = value7
 	return &out
 }
@@ -1655,7 +1618,7 @@ type GainOptions struct {
 	Gain                  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GainOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1671,10 +1634,8 @@ func (_this *GainOptions) JSValue() js.Value {
 }
 
 // GainOptionsFromJS is allocating a new
-// GainOptions object and copy all values from
-// input javascript object
-func GainOptionsFromJS(value js.Wrapper) *GainOptions {
-	input := value.JSValue()
+// GainOptions object and copy all values in the value javascript object.
+func GainOptionsFromJS(value js.Value) *GainOptions {
 	var out GainOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1682,13 +1643,13 @@ func GainOptionsFromJS(value js.Wrapper) *GainOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 float32               // javascript: float {gain Gain gain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("gain")).Float())
+	value3 = (float32)((value.Get("gain")).Float())
 	out.Gain = value3
 	return &out
 }
@@ -1702,7 +1663,7 @@ type IIRFilterOptions struct {
 	Feedback              []float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IIRFilterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1720,10 +1681,8 @@ func (_this *IIRFilterOptions) JSValue() js.Value {
 }
 
 // IIRFilterOptionsFromJS is allocating a new
-// IIRFilterOptions object and copy all values from
-// input javascript object
-func IIRFilterOptionsFromJS(value js.Wrapper) *IIRFilterOptions {
-	input := value.JSValue()
+// IIRFilterOptions object and copy all values in the value javascript object.
+func IIRFilterOptionsFromJS(value js.Value) *IIRFilterOptions {
 	var out IIRFilterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1732,15 +1691,15 @@ func IIRFilterOptionsFromJS(value js.Wrapper) *IIRFilterOptions {
 		value3 []float64             // javascript: typed-array {feedforward Feedforward feedforward}
 		value4 []float64             // javascript: typed-array {feedback Feedback feedback}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = jsarray.Float64ToGo(input.Get("feedforward"))
+	value3 = jsarray.Float64ToGo(value.Get("feedforward"))
 	out.Feedforward = value3
-	value4 = jsarray.Float64ToGo(input.Get("feedback"))
+	value4 = jsarray.Float64ToGo(value.Get("feedback"))
 	out.Feedback = value4
 	return &out
 }
@@ -1750,7 +1709,7 @@ type MediaElementAudioSourceOptions struct {
 	MediaElement *media.HTMLMediaElement
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaElementAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1760,15 +1719,13 @@ func (_this *MediaElementAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaElementAudioSourceOptionsFromJS is allocating a new
-// MediaElementAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaElementAudioSourceOptionsFromJS(value js.Wrapper) *MediaElementAudioSourceOptions {
-	input := value.JSValue()
+// MediaElementAudioSourceOptions object and copy all values in the value javascript object.
+func MediaElementAudioSourceOptionsFromJS(value js.Value) *MediaElementAudioSourceOptions {
 	var out MediaElementAudioSourceOptions
 	var (
 		value0 *media.HTMLMediaElement // javascript: HTMLMediaElement {mediaElement MediaElement mediaElement}
 	)
-	value0 = media.HTMLMediaElementFromJS(input.Get("mediaElement"))
+	value0 = media.HTMLMediaElementFromJS(value.Get("mediaElement"))
 	out.MediaElement = value0
 	return &out
 }
@@ -1778,7 +1735,7 @@ type MediaStreamAudioSourceOptions struct {
 	MediaStream *local.MediaStream
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1788,15 +1745,13 @@ func (_this *MediaStreamAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaStreamAudioSourceOptionsFromJS is allocating a new
-// MediaStreamAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaStreamAudioSourceOptionsFromJS(value js.Wrapper) *MediaStreamAudioSourceOptions {
-	input := value.JSValue()
+// MediaStreamAudioSourceOptions object and copy all values in the value javascript object.
+func MediaStreamAudioSourceOptionsFromJS(value js.Value) *MediaStreamAudioSourceOptions {
 	var out MediaStreamAudioSourceOptions
 	var (
 		value0 *local.MediaStream // javascript: MediaStream {mediaStream MediaStream mediaStream}
 	)
-	value0 = local.MediaStreamFromJS(input.Get("mediaStream"))
+	value0 = local.MediaStreamFromJS(value.Get("mediaStream"))
 	out.MediaStream = value0
 	return &out
 }
@@ -1806,7 +1761,7 @@ type MediaStreamTrackAudioSourceOptions struct {
 	MediaStreamTrack *local.MediaStreamTrack
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamTrackAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1816,15 +1771,13 @@ func (_this *MediaStreamTrackAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaStreamTrackAudioSourceOptionsFromJS is allocating a new
-// MediaStreamTrackAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaStreamTrackAudioSourceOptionsFromJS(value js.Wrapper) *MediaStreamTrackAudioSourceOptions {
-	input := value.JSValue()
+// MediaStreamTrackAudioSourceOptions object and copy all values in the value javascript object.
+func MediaStreamTrackAudioSourceOptionsFromJS(value js.Value) *MediaStreamTrackAudioSourceOptions {
 	var out MediaStreamTrackAudioSourceOptions
 	var (
 		value0 *local.MediaStreamTrack // javascript: MediaStreamTrack {mediaStreamTrack MediaStreamTrack mediaStreamTrack}
 	)
-	value0 = local.MediaStreamTrackFromJS(input.Get("mediaStreamTrack"))
+	value0 = local.MediaStreamTrackFromJS(value.Get("mediaStreamTrack"))
 	out.MediaStreamTrack = value0
 	return &out
 }
@@ -1837,7 +1790,7 @@ type OfflineAudioCompletionEventInit struct {
 	RenderedBuffer *AudioBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfflineAudioCompletionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1853,10 +1806,8 @@ func (_this *OfflineAudioCompletionEventInit) JSValue() js.Value {
 }
 
 // OfflineAudioCompletionEventInitFromJS is allocating a new
-// OfflineAudioCompletionEventInit object and copy all values from
-// input javascript object
-func OfflineAudioCompletionEventInitFromJS(value js.Wrapper) *OfflineAudioCompletionEventInit {
-	input := value.JSValue()
+// OfflineAudioCompletionEventInit object and copy all values in the value javascript object.
+func OfflineAudioCompletionEventInitFromJS(value js.Value) *OfflineAudioCompletionEventInit {
 	var out OfflineAudioCompletionEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1864,13 +1815,13 @@ func OfflineAudioCompletionEventInitFromJS(value js.Wrapper) *OfflineAudioComple
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *AudioBuffer // javascript: AudioBuffer {renderedBuffer RenderedBuffer renderedBuffer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = AudioBufferFromJS(input.Get("renderedBuffer"))
+	value3 = AudioBufferFromJS(value.Get("renderedBuffer"))
 	out.RenderedBuffer = value3
 	return &out
 }
@@ -1882,7 +1833,7 @@ type OfflineAudioContextOptions struct {
 	SampleRate       float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfflineAudioContextOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1896,21 +1847,19 @@ func (_this *OfflineAudioContextOptions) JSValue() js.Value {
 }
 
 // OfflineAudioContextOptionsFromJS is allocating a new
-// OfflineAudioContextOptions object and copy all values from
-// input javascript object
-func OfflineAudioContextOptionsFromJS(value js.Wrapper) *OfflineAudioContextOptions {
-	input := value.JSValue()
+// OfflineAudioContextOptions object and copy all values in the value javascript object.
+func OfflineAudioContextOptionsFromJS(value js.Value) *OfflineAudioContextOptions {
 	var out OfflineAudioContextOptions
 	var (
 		value0 uint    // javascript: unsigned long {numberOfChannels NumberOfChannels numberOfChannels}
 		value1 uint    // javascript: unsigned long {length Length length}
 		value2 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = (uint)((input.Get("numberOfChannels")).Int())
+	value0 = (uint)((value.Get("numberOfChannels")).Int())
 	out.NumberOfChannels = value0
-	value1 = (uint)((input.Get("length")).Int())
+	value1 = (uint)((value.Get("length")).Int())
 	out.Length = value1
-	value2 = (float32)((input.Get("sampleRate")).Float())
+	value2 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value2
 	return &out
 }
@@ -1926,7 +1875,7 @@ type OscillatorOptions struct {
 	PeriodicWave          *PeriodicWave
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OscillatorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1948,10 +1897,8 @@ func (_this *OscillatorOptions) JSValue() js.Value {
 }
 
 // OscillatorOptionsFromJS is allocating a new
-// OscillatorOptions object and copy all values from
-// input javascript object
-func OscillatorOptionsFromJS(value js.Wrapper) *OscillatorOptions {
-	input := value.JSValue()
+// OscillatorOptions object and copy all values in the value javascript object.
+func OscillatorOptionsFromJS(value js.Value) *OscillatorOptions {
 	var out OscillatorOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1962,19 +1909,19 @@ func OscillatorOptionsFromJS(value js.Wrapper) *OscillatorOptions {
 		value5 float32               // javascript: float {detune Detune detune}
 		value6 *PeriodicWave         // javascript: PeriodicWave {periodicWave PeriodicWave periodicWave}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = OscillatorTypeFromJS(input.Get("type"))
+	value3 = OscillatorTypeFromJS(value.Get("type"))
 	out.Type = value3
-	value4 = (float32)((input.Get("frequency")).Float())
+	value4 = (float32)((value.Get("frequency")).Float())
 	out.Frequency = value4
-	value5 = (float32)((input.Get("detune")).Float())
+	value5 = (float32)((value.Get("detune")).Float())
 	out.Detune = value5
-	value6 = PeriodicWaveFromJS(input.Get("periodicWave"))
+	value6 = PeriodicWaveFromJS(value.Get("periodicWave"))
 	out.PeriodicWave = value6
 	return &out
 }
@@ -2000,7 +1947,7 @@ type PannerOptions struct {
 	ConeOuterGain         float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PannerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2042,10 +1989,8 @@ func (_this *PannerOptions) JSValue() js.Value {
 }
 
 // PannerOptionsFromJS is allocating a new
-// PannerOptions object and copy all values from
-// input javascript object
-func PannerOptionsFromJS(value js.Wrapper) *PannerOptions {
-	input := value.JSValue()
+// PannerOptions object and copy all values in the value javascript object.
+func PannerOptionsFromJS(value js.Value) *PannerOptions {
 	var out PannerOptions
 	var (
 		value0  uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2066,39 +2011,39 @@ func PannerOptionsFromJS(value js.Wrapper) *PannerOptions {
 		value15 float64               // javascript: double {coneOuterAngle ConeOuterAngle coneOuterAngle}
 		value16 float64               // javascript: double {coneOuterGain ConeOuterGain coneOuterGain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = PanningModelTypeFromJS(input.Get("panningModel"))
+	value3 = PanningModelTypeFromJS(value.Get("panningModel"))
 	out.PanningModel = value3
-	value4 = DistanceModelTypeFromJS(input.Get("distanceModel"))
+	value4 = DistanceModelTypeFromJS(value.Get("distanceModel"))
 	out.DistanceModel = value4
-	value5 = (float32)((input.Get("positionX")).Float())
+	value5 = (float32)((value.Get("positionX")).Float())
 	out.PositionX = value5
-	value6 = (float32)((input.Get("positionY")).Float())
+	value6 = (float32)((value.Get("positionY")).Float())
 	out.PositionY = value6
-	value7 = (float32)((input.Get("positionZ")).Float())
+	value7 = (float32)((value.Get("positionZ")).Float())
 	out.PositionZ = value7
-	value8 = (float32)((input.Get("orientationX")).Float())
+	value8 = (float32)((value.Get("orientationX")).Float())
 	out.OrientationX = value8
-	value9 = (float32)((input.Get("orientationY")).Float())
+	value9 = (float32)((value.Get("orientationY")).Float())
 	out.OrientationY = value9
-	value10 = (float32)((input.Get("orientationZ")).Float())
+	value10 = (float32)((value.Get("orientationZ")).Float())
 	out.OrientationZ = value10
-	value11 = (input.Get("refDistance")).Float()
+	value11 = (value.Get("refDistance")).Float()
 	out.RefDistance = value11
-	value12 = (input.Get("maxDistance")).Float()
+	value12 = (value.Get("maxDistance")).Float()
 	out.MaxDistance = value12
-	value13 = (input.Get("rolloffFactor")).Float()
+	value13 = (value.Get("rolloffFactor")).Float()
 	out.RolloffFactor = value13
-	value14 = (input.Get("coneInnerAngle")).Float()
+	value14 = (value.Get("coneInnerAngle")).Float()
 	out.ConeInnerAngle = value14
-	value15 = (input.Get("coneOuterAngle")).Float()
+	value15 = (value.Get("coneOuterAngle")).Float()
 	out.ConeOuterAngle = value15
-	value16 = (input.Get("coneOuterGain")).Float()
+	value16 = (value.Get("coneOuterGain")).Float()
 	out.ConeOuterGain = value16
 	return &out
 }
@@ -2108,7 +2053,7 @@ type PeriodicWaveConstraints struct {
 	DisableNormalization bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeriodicWaveConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2118,15 +2063,13 @@ func (_this *PeriodicWaveConstraints) JSValue() js.Value {
 }
 
 // PeriodicWaveConstraintsFromJS is allocating a new
-// PeriodicWaveConstraints object and copy all values from
-// input javascript object
-func PeriodicWaveConstraintsFromJS(value js.Wrapper) *PeriodicWaveConstraints {
-	input := value.JSValue()
+// PeriodicWaveConstraints object and copy all values in the value javascript object.
+func PeriodicWaveConstraintsFromJS(value js.Value) *PeriodicWaveConstraints {
 	var out PeriodicWaveConstraints
 	var (
 		value0 bool // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 	)
-	value0 = (input.Get("disableNormalization")).Bool()
+	value0 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value0
 	return &out
 }
@@ -2138,7 +2081,7 @@ type PeriodicWaveOptions struct {
 	Imag                 []float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeriodicWaveOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2152,21 +2095,19 @@ func (_this *PeriodicWaveOptions) JSValue() js.Value {
 }
 
 // PeriodicWaveOptionsFromJS is allocating a new
-// PeriodicWaveOptions object and copy all values from
-// input javascript object
-func PeriodicWaveOptionsFromJS(value js.Wrapper) *PeriodicWaveOptions {
-	input := value.JSValue()
+// PeriodicWaveOptions object and copy all values in the value javascript object.
+func PeriodicWaveOptionsFromJS(value js.Value) *PeriodicWaveOptions {
 	var out PeriodicWaveOptions
 	var (
 		value0 bool      // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 		value1 []float32 // javascript: typed-array {real Real real}
 		value2 []float32 // javascript: typed-array {imag Imag imag}
 	)
-	value0 = (input.Get("disableNormalization")).Bool()
+	value0 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value0
-	value1 = jsarray.Float32ToGo(input.Get("real"))
+	value1 = jsarray.Float32ToGo(value.Get("real"))
 	out.Real = value1
-	value2 = jsarray.Float32ToGo(input.Get("imag"))
+	value2 = jsarray.Float32ToGo(value.Get("imag"))
 	out.Imag = value2
 	return &out
 }
@@ -2179,7 +2120,7 @@ type StereoPannerOptions struct {
 	Pan                   float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StereoPannerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2195,10 +2136,8 @@ func (_this *StereoPannerOptions) JSValue() js.Value {
 }
 
 // StereoPannerOptionsFromJS is allocating a new
-// StereoPannerOptions object and copy all values from
-// input javascript object
-func StereoPannerOptionsFromJS(value js.Wrapper) *StereoPannerOptions {
-	input := value.JSValue()
+// StereoPannerOptions object and copy all values in the value javascript object.
+func StereoPannerOptionsFromJS(value js.Value) *StereoPannerOptions {
 	var out StereoPannerOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2206,13 +2145,13 @@ func StereoPannerOptionsFromJS(value js.Wrapper) *StereoPannerOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 float32               // javascript: float {pan Pan pan}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("pan")).Float())
+	value3 = (float32)((value.Get("pan")).Float())
 	out.Pan = value3
 	return &out
 }
@@ -2226,7 +2165,7 @@ type WaveShaperOptions struct {
 	Oversample            OverSampleType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WaveShaperOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2244,10 +2183,8 @@ func (_this *WaveShaperOptions) JSValue() js.Value {
 }
 
 // WaveShaperOptionsFromJS is allocating a new
-// WaveShaperOptions object and copy all values from
-// input javascript object
-func WaveShaperOptionsFromJS(value js.Wrapper) *WaveShaperOptions {
-	input := value.JSValue()
+// WaveShaperOptions object and copy all values in the value javascript object.
+func WaveShaperOptionsFromJS(value js.Value) *WaveShaperOptions {
 	var out WaveShaperOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2256,15 +2193,15 @@ func WaveShaperOptionsFromJS(value js.Wrapper) *WaveShaperOptions {
 		value3 []float32             // javascript: typed-array {curve Curve curve}
 		value4 OverSampleType        // javascript: OverSampleType {oversample Oversample oversample}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = jsarray.Float32ToGo(input.Get("curve"))
+	value3 = jsarray.Float32ToGo(value.Get("curve"))
 	out.Curve = value3
-	value4 = OverSampleTypeFromJS(input.Get("oversample"))
+	value4 = OverSampleTypeFromJS(value.Get("oversample"))
 	out.Oversample = value4
 	return &out
 }
@@ -2274,15 +2211,19 @@ type AnalyserNode struct {
 	AudioNode
 }
 
-// AnalyserNodeFromJS is casting a js.Wrapper into AnalyserNode.
-func AnalyserNodeFromJS(value js.Wrapper) *AnalyserNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnalyserNodeFromJS is casting a js.Value into AnalyserNode.
+func AnalyserNodeFromJS(value js.Value) *AnalyserNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnalyserNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnalyserNodeFromJS is casting from something that holds a js.Value into AnalyserNode.
+func AnalyserNodeFromWrapper(input core.Wrapper) *AnalyserNode {
+	return AnalyserNodeFromJS(input.JSValue())
 }
 
 func NewAnalyserNode(context *BaseAudioContext, options *AnalyserOptions) (_result *AnalyserNode) {
@@ -2439,15 +2380,19 @@ func (_this *AudioBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioBufferFromJS is casting a js.Wrapper into AudioBuffer.
-func AudioBufferFromJS(value js.Wrapper) *AudioBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioBufferFromJS is casting a js.Value into AudioBuffer.
+func AudioBufferFromJS(value js.Value) *AudioBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioBufferFromJS is casting from something that holds a js.Value into AudioBuffer.
+func AudioBufferFromWrapper(input core.Wrapper) *AudioBuffer {
+	return AudioBufferFromJS(input.JSValue())
 }
 
 func NewAudioBuffer(options *AudioBufferOptions) (_result *AudioBuffer) {
@@ -2578,15 +2523,19 @@ type AudioBufferSourceNode struct {
 	AudioScheduledSourceNode
 }
 
-// AudioBufferSourceNodeFromJS is casting a js.Wrapper into AudioBufferSourceNode.
-func AudioBufferSourceNodeFromJS(value js.Wrapper) *AudioBufferSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioBufferSourceNodeFromJS is casting a js.Value into AudioBufferSourceNode.
+func AudioBufferSourceNodeFromJS(value js.Value) *AudioBufferSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioBufferSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioBufferSourceNodeFromJS is casting from something that holds a js.Value into AudioBufferSourceNode.
+func AudioBufferSourceNodeFromWrapper(input core.Wrapper) *AudioBufferSourceNode {
+	return AudioBufferSourceNodeFromJS(input.JSValue())
 }
 
 func NewAudioBufferSourceNode(context *BaseAudioContext, options *AudioBufferSourceOptions) (_result *AudioBufferSourceNode) {
@@ -2743,15 +2692,19 @@ type AudioContext struct {
 	BaseAudioContext
 }
 
-// AudioContextFromJS is casting a js.Wrapper into AudioContext.
-func AudioContextFromJS(value js.Wrapper) *AudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioContextFromJS is casting a js.Value into AudioContext.
+func AudioContextFromJS(value js.Value) *AudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioContextFromJS is casting from something that holds a js.Value into AudioContext.
+func AudioContextFromWrapper(input core.Wrapper) *AudioContext {
+	return AudioContextFromJS(input.JSValue())
 }
 
 func NewAudioContext(contextOptions *AudioContextOptions) (_result *AudioContext) {
@@ -2918,15 +2871,19 @@ type AudioDestinationNode struct {
 	AudioNode
 }
 
-// AudioDestinationNodeFromJS is casting a js.Wrapper into AudioDestinationNode.
-func AudioDestinationNodeFromJS(value js.Wrapper) *AudioDestinationNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioDestinationNodeFromJS is casting a js.Value into AudioDestinationNode.
+func AudioDestinationNodeFromJS(value js.Value) *AudioDestinationNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioDestinationNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioDestinationNodeFromJS is casting from something that holds a js.Value into AudioDestinationNode.
+func AudioDestinationNodeFromWrapper(input core.Wrapper) *AudioDestinationNode {
+	return AudioDestinationNodeFromJS(input.JSValue())
 }
 
 // MaxChannelCount returning attribute 'maxChannelCount' with
@@ -2948,15 +2905,19 @@ func (_this *AudioListener) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioListenerFromJS is casting a js.Wrapper into AudioListener.
-func AudioListenerFromJS(value js.Wrapper) *AudioListener {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioListenerFromJS is casting a js.Value into AudioListener.
+func AudioListenerFromJS(value js.Value) *AudioListener {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioListener{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioListenerFromJS is casting from something that holds a js.Value into AudioListener.
+func AudioListenerFromWrapper(input core.Wrapper) *AudioListener {
+	return AudioListenerFromJS(input.JSValue())
 }
 
 // PositionX returning attribute 'positionX' with
@@ -3090,15 +3051,19 @@ type AudioNode struct {
 	domcore.EventTarget
 }
 
-// AudioNodeFromJS is casting a js.Wrapper into AudioNode.
-func AudioNodeFromJS(value js.Wrapper) *AudioNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioNodeFromJS is casting a js.Value into AudioNode.
+func AudioNodeFromJS(value js.Value) *AudioNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioNodeFromJS is casting from something that holds a js.Value into AudioNode.
+func AudioNodeFromWrapper(input core.Wrapper) *AudioNode {
+	return AudioNodeFromJS(input.JSValue())
 }
 
 // Context returning attribute 'context' with
@@ -3341,15 +3306,19 @@ func (_this *AudioParam) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamFromJS is casting a js.Wrapper into AudioParam.
-func AudioParamFromJS(value js.Wrapper) *AudioParam {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamFromJS is casting a js.Value into AudioParam.
+func AudioParamFromJS(value js.Value) *AudioParam {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParam{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamFromJS is casting from something that holds a js.Value into AudioParam.
+func AudioParamFromWrapper(input core.Wrapper) *AudioParam {
+	return AudioParamFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -3561,15 +3530,19 @@ func (_this *AudioParamMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapFromJS is casting a js.Wrapper into AudioParamMap.
-func AudioParamMapFromJS(value js.Wrapper) *AudioParamMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapFromJS is casting a js.Value into AudioParamMap.
+func AudioParamMapFromJS(value js.Value) *AudioParamMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapFromJS is casting from something that holds a js.Value into AudioParamMap.
+func AudioParamMapFromWrapper(input core.Wrapper) *AudioParamMap {
+	return AudioParamMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -3693,15 +3666,19 @@ func (_this *AudioParamMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapEntryIteratorFromJS is casting a js.Wrapper into AudioParamMapEntryIterator.
-func AudioParamMapEntryIteratorFromJS(value js.Wrapper) *AudioParamMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapEntryIteratorFromJS is casting a js.Value into AudioParamMapEntryIterator.
+func AudioParamMapEntryIteratorFromJS(value js.Value) *AudioParamMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapEntryIteratorFromJS is casting from something that holds a js.Value into AudioParamMapEntryIterator.
+func AudioParamMapEntryIteratorFromWrapper(input core.Wrapper) *AudioParamMapEntryIterator {
+	return AudioParamMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapEntryIterator) Next() (_result *AudioParamMapEntryIteratorValue) {
@@ -3728,15 +3705,19 @@ func (_this *AudioParamMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapKeyIteratorFromJS is casting a js.Wrapper into AudioParamMapKeyIterator.
-func AudioParamMapKeyIteratorFromJS(value js.Wrapper) *AudioParamMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapKeyIteratorFromJS is casting a js.Value into AudioParamMapKeyIterator.
+func AudioParamMapKeyIteratorFromJS(value js.Value) *AudioParamMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapKeyIteratorFromJS is casting from something that holds a js.Value into AudioParamMapKeyIterator.
+func AudioParamMapKeyIteratorFromWrapper(input core.Wrapper) *AudioParamMapKeyIterator {
+	return AudioParamMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapKeyIterator) Next() (_result *AudioParamMapKeyIteratorValue) {
@@ -3763,15 +3744,19 @@ func (_this *AudioParamMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapValueIteratorFromJS is casting a js.Wrapper into AudioParamMapValueIterator.
-func AudioParamMapValueIteratorFromJS(value js.Wrapper) *AudioParamMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapValueIteratorFromJS is casting a js.Value into AudioParamMapValueIterator.
+func AudioParamMapValueIteratorFromJS(value js.Value) *AudioParamMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapValueIteratorFromJS is casting from something that holds a js.Value into AudioParamMapValueIterator.
+func AudioParamMapValueIteratorFromWrapper(input core.Wrapper) *AudioParamMapValueIterator {
+	return AudioParamMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapValueIterator) Next() (_result *AudioParamMapValueIteratorValue) {
@@ -3793,15 +3778,19 @@ type AudioProcessingEvent struct {
 	domcore.Event
 }
 
-// AudioProcessingEventFromJS is casting a js.Wrapper into AudioProcessingEvent.
-func AudioProcessingEventFromJS(value js.Wrapper) *AudioProcessingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioProcessingEventFromJS is casting a js.Value into AudioProcessingEvent.
+func AudioProcessingEventFromJS(value js.Value) *AudioProcessingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioProcessingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioProcessingEventFromJS is casting from something that holds a js.Value into AudioProcessingEvent.
+func AudioProcessingEventFromWrapper(input core.Wrapper) *AudioProcessingEvent {
+	return AudioProcessingEventFromJS(input.JSValue())
 }
 
 func NewAudioProcessingEvent(_type string, eventInitDict *AudioProcessingEventInit) (_result *AudioProcessingEvent) {
@@ -3857,15 +3846,19 @@ type AudioScheduledSourceNode struct {
 	AudioNode
 }
 
-// AudioScheduledSourceNodeFromJS is casting a js.Wrapper into AudioScheduledSourceNode.
-func AudioScheduledSourceNodeFromJS(value js.Wrapper) *AudioScheduledSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioScheduledSourceNodeFromJS is casting a js.Value into AudioScheduledSourceNode.
+func AudioScheduledSourceNodeFromJS(value js.Value) *AudioScheduledSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioScheduledSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioScheduledSourceNodeFromJS is casting from something that holds a js.Value into AudioScheduledSourceNode.
+func AudioScheduledSourceNodeFromWrapper(input core.Wrapper) *AudioScheduledSourceNode {
+	return AudioScheduledSourceNodeFromJS(input.JSValue())
 }
 
 // OnEnded returning attribute 'onended' with
@@ -3954,15 +3947,19 @@ type AudioWorklet struct {
 	worklets.Worklet
 }
 
-// AudioWorkletFromJS is casting a js.Wrapper into AudioWorklet.
-func AudioWorkletFromJS(value js.Wrapper) *AudioWorklet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletFromJS is casting a js.Value into AudioWorklet.
+func AudioWorkletFromJS(value js.Value) *AudioWorklet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorklet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletFromJS is casting from something that holds a js.Value into AudioWorklet.
+func AudioWorkletFromWrapper(input core.Wrapper) *AudioWorklet {
+	return AudioWorkletFromJS(input.JSValue())
 }
 
 // class: AudioWorkletGlobalScope
@@ -3970,15 +3967,19 @@ type AudioWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// AudioWorkletGlobalScopeFromJS is casting a js.Wrapper into AudioWorkletGlobalScope.
-func AudioWorkletGlobalScopeFromJS(value js.Wrapper) *AudioWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletGlobalScopeFromJS is casting a js.Value into AudioWorkletGlobalScope.
+func AudioWorkletGlobalScopeFromJS(value js.Value) *AudioWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletGlobalScopeFromJS is casting from something that holds a js.Value into AudioWorkletGlobalScope.
+func AudioWorkletGlobalScopeFromWrapper(input core.Wrapper) *AudioWorkletGlobalScope {
+	return AudioWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 // CurrentFrame returning attribute 'currentFrame' with
@@ -4035,15 +4036,19 @@ type AudioWorkletNode struct {
 	AudioNode
 }
 
-// AudioWorkletNodeFromJS is casting a js.Wrapper into AudioWorkletNode.
-func AudioWorkletNodeFromJS(value js.Wrapper) *AudioWorkletNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletNodeFromJS is casting a js.Value into AudioWorkletNode.
+func AudioWorkletNodeFromJS(value js.Value) *AudioWorkletNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletNodeFromJS is casting from something that holds a js.Value into AudioWorkletNode.
+func AudioWorkletNodeFromWrapper(input core.Wrapper) *AudioWorkletNode {
+	return AudioWorkletNodeFromJS(input.JSValue())
 }
 
 func NewAudioWorkletNode(context *BaseAudioContext, name string, options *AudioWorkletNodeOptions) (_result *AudioWorkletNode) {
@@ -4141,15 +4146,19 @@ func (_this *AudioWorkletProcessor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioWorkletProcessorFromJS is casting a js.Wrapper into AudioWorkletProcessor.
-func AudioWorkletProcessorFromJS(value js.Wrapper) *AudioWorkletProcessor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletProcessorFromJS is casting a js.Value into AudioWorkletProcessor.
+func AudioWorkletProcessorFromJS(value js.Value) *AudioWorkletProcessor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletProcessor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletProcessorFromJS is casting from something that holds a js.Value into AudioWorkletProcessor.
+func AudioWorkletProcessorFromWrapper(input core.Wrapper) *AudioWorkletProcessor {
+	return AudioWorkletProcessorFromJS(input.JSValue())
 }
 
 func NewAudioWorkletProcessor(options *AudioWorkletNodeOptions) (_result *AudioWorkletProcessor) {
@@ -4186,15 +4195,19 @@ type BaseAudioContext struct {
 	domcore.EventTarget
 }
 
-// BaseAudioContextFromJS is casting a js.Wrapper into BaseAudioContext.
-func BaseAudioContextFromJS(value js.Wrapper) *BaseAudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BaseAudioContextFromJS is casting a js.Value into BaseAudioContext.
+func BaseAudioContextFromJS(value js.Value) *BaseAudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BaseAudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BaseAudioContextFromJS is casting from something that holds a js.Value into BaseAudioContext.
+func BaseAudioContextFromWrapper(input core.Wrapper) *BaseAudioContext {
+	return BaseAudioContextFromJS(input.JSValue())
 }
 
 // Destination returning attribute 'destination' with
@@ -4682,15 +4695,19 @@ type BiquadFilterNode struct {
 	AudioNode
 }
 
-// BiquadFilterNodeFromJS is casting a js.Wrapper into BiquadFilterNode.
-func BiquadFilterNodeFromJS(value js.Wrapper) *BiquadFilterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BiquadFilterNodeFromJS is casting a js.Value into BiquadFilterNode.
+func BiquadFilterNodeFromJS(value js.Value) *BiquadFilterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BiquadFilterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BiquadFilterNodeFromJS is casting from something that holds a js.Value into BiquadFilterNode.
+func BiquadFilterNodeFromWrapper(input core.Wrapper) *BiquadFilterNode {
+	return BiquadFilterNodeFromJS(input.JSValue())
 }
 
 func NewBiquadFilterNode(context *BaseAudioContext, options *BiquadFilterOptions) (_result *BiquadFilterNode) {
@@ -4791,15 +4808,19 @@ type ChannelMergerNode struct {
 	AudioNode
 }
 
-// ChannelMergerNodeFromJS is casting a js.Wrapper into ChannelMergerNode.
-func ChannelMergerNodeFromJS(value js.Wrapper) *ChannelMergerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChannelMergerNodeFromJS is casting a js.Value into ChannelMergerNode.
+func ChannelMergerNodeFromJS(value js.Value) *ChannelMergerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChannelMergerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChannelMergerNodeFromJS is casting from something that holds a js.Value into ChannelMergerNode.
+func ChannelMergerNodeFromWrapper(input core.Wrapper) *ChannelMergerNode {
+	return ChannelMergerNodeFromJS(input.JSValue())
 }
 
 func NewChannelMergerNode(context *BaseAudioContext, options *ChannelMergerOptions) (_result *ChannelMergerNode) {
@@ -4830,15 +4851,19 @@ type ChannelSplitterNode struct {
 	AudioNode
 }
 
-// ChannelSplitterNodeFromJS is casting a js.Wrapper into ChannelSplitterNode.
-func ChannelSplitterNodeFromJS(value js.Wrapper) *ChannelSplitterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChannelSplitterNodeFromJS is casting a js.Value into ChannelSplitterNode.
+func ChannelSplitterNodeFromJS(value js.Value) *ChannelSplitterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChannelSplitterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChannelSplitterNodeFromJS is casting from something that holds a js.Value into ChannelSplitterNode.
+func ChannelSplitterNodeFromWrapper(input core.Wrapper) *ChannelSplitterNode {
+	return ChannelSplitterNodeFromJS(input.JSValue())
 }
 
 func NewChannelSplitterNode(context *BaseAudioContext, options *ChannelSplitterOptions) (_result *ChannelSplitterNode) {
@@ -4869,15 +4894,19 @@ type ConstantSourceNode struct {
 	AudioScheduledSourceNode
 }
 
-// ConstantSourceNodeFromJS is casting a js.Wrapper into ConstantSourceNode.
-func ConstantSourceNodeFromJS(value js.Wrapper) *ConstantSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConstantSourceNodeFromJS is casting a js.Value into ConstantSourceNode.
+func ConstantSourceNodeFromJS(value js.Value) *ConstantSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConstantSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConstantSourceNodeFromJS is casting from something that holds a js.Value into ConstantSourceNode.
+func ConstantSourceNodeFromWrapper(input core.Wrapper) *ConstantSourceNode {
+	return ConstantSourceNodeFromJS(input.JSValue())
 }
 
 func NewConstantSourceNode(context *BaseAudioContext, options *ConstantSourceOptions) (_result *ConstantSourceNode) {
@@ -4917,15 +4946,19 @@ type ConvolverNode struct {
 	AudioNode
 }
 
-// ConvolverNodeFromJS is casting a js.Wrapper into ConvolverNode.
-func ConvolverNodeFromJS(value js.Wrapper) *ConvolverNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConvolverNodeFromJS is casting a js.Value into ConvolverNode.
+func ConvolverNodeFromJS(value js.Value) *ConvolverNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConvolverNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConvolverNodeFromJS is casting from something that holds a js.Value into ConvolverNode.
+func ConvolverNodeFromWrapper(input core.Wrapper) *ConvolverNode {
+	return ConvolverNodeFromJS(input.JSValue())
 }
 
 func NewConvolverNode(context *BaseAudioContext, options *ConvolverOptions) (_result *ConvolverNode) {
@@ -4990,15 +5023,19 @@ type DelayNode struct {
 	AudioNode
 }
 
-// DelayNodeFromJS is casting a js.Wrapper into DelayNode.
-func DelayNodeFromJS(value js.Wrapper) *DelayNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DelayNodeFromJS is casting a js.Value into DelayNode.
+func DelayNodeFromJS(value js.Value) *DelayNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DelayNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DelayNodeFromJS is casting from something that holds a js.Value into DelayNode.
+func DelayNodeFromWrapper(input core.Wrapper) *DelayNode {
+	return DelayNodeFromJS(input.JSValue())
 }
 
 func NewDelayNode(context *BaseAudioContext, options *DelayOptions) (_result *DelayNode) {
@@ -5038,15 +5075,19 @@ type DynamicsCompressorNode struct {
 	AudioNode
 }
 
-// DynamicsCompressorNodeFromJS is casting a js.Wrapper into DynamicsCompressorNode.
-func DynamicsCompressorNodeFromJS(value js.Wrapper) *DynamicsCompressorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DynamicsCompressorNodeFromJS is casting a js.Value into DynamicsCompressorNode.
+func DynamicsCompressorNodeFromJS(value js.Value) *DynamicsCompressorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DynamicsCompressorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DynamicsCompressorNodeFromJS is casting from something that holds a js.Value into DynamicsCompressorNode.
+func DynamicsCompressorNodeFromWrapper(input core.Wrapper) *DynamicsCompressorNode {
+	return DynamicsCompressorNodeFromJS(input.JSValue())
 }
 
 func NewDynamicsCompressorNode(context *BaseAudioContext, options *DynamicsCompressorOptions) (_result *DynamicsCompressorNode) {
@@ -5131,15 +5172,19 @@ type GainNode struct {
 	AudioNode
 }
 
-// GainNodeFromJS is casting a js.Wrapper into GainNode.
-func GainNodeFromJS(value js.Wrapper) *GainNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GainNodeFromJS is casting a js.Value into GainNode.
+func GainNodeFromJS(value js.Value) *GainNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GainNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GainNodeFromJS is casting from something that holds a js.Value into GainNode.
+func GainNodeFromWrapper(input core.Wrapper) *GainNode {
+	return GainNodeFromJS(input.JSValue())
 }
 
 func NewGainNode(context *BaseAudioContext, options *GainOptions) (_result *GainNode) {
@@ -5179,15 +5224,19 @@ type IIRFilterNode struct {
 	AudioNode
 }
 
-// IIRFilterNodeFromJS is casting a js.Wrapper into IIRFilterNode.
-func IIRFilterNodeFromJS(value js.Wrapper) *IIRFilterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IIRFilterNodeFromJS is casting a js.Value into IIRFilterNode.
+func IIRFilterNodeFromJS(value js.Value) *IIRFilterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IIRFilterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IIRFilterNodeFromJS is casting from something that holds a js.Value into IIRFilterNode.
+func IIRFilterNodeFromWrapper(input core.Wrapper) *IIRFilterNode {
+	return IIRFilterNodeFromJS(input.JSValue())
 }
 
 func NewIIRFilterNode(context *BaseAudioContext, options *IIRFilterOptions) (_result *IIRFilterNode) {
@@ -5234,15 +5283,19 @@ type MediaElementAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaElementAudioSourceNodeFromJS is casting a js.Wrapper into MediaElementAudioSourceNode.
-func MediaElementAudioSourceNodeFromJS(value js.Wrapper) *MediaElementAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaElementAudioSourceNodeFromJS is casting a js.Value into MediaElementAudioSourceNode.
+func MediaElementAudioSourceNodeFromJS(value js.Value) *MediaElementAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaElementAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaElementAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaElementAudioSourceNode.
+func MediaElementAudioSourceNodeFromWrapper(input core.Wrapper) *MediaElementAudioSourceNode {
+	return MediaElementAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaElementAudioSourceNode(context *AudioContext, options *MediaElementAudioSourceOptions) (_result *MediaElementAudioSourceNode) {
@@ -5280,15 +5333,19 @@ type MediaStreamAudioDestinationNode struct {
 	AudioNode
 }
 
-// MediaStreamAudioDestinationNodeFromJS is casting a js.Wrapper into MediaStreamAudioDestinationNode.
-func MediaStreamAudioDestinationNodeFromJS(value js.Wrapper) *MediaStreamAudioDestinationNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamAudioDestinationNodeFromJS is casting a js.Value into MediaStreamAudioDestinationNode.
+func MediaStreamAudioDestinationNodeFromJS(value js.Value) *MediaStreamAudioDestinationNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamAudioDestinationNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamAudioDestinationNodeFromJS is casting from something that holds a js.Value into MediaStreamAudioDestinationNode.
+func MediaStreamAudioDestinationNodeFromWrapper(input core.Wrapper) *MediaStreamAudioDestinationNode {
+	return MediaStreamAudioDestinationNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamAudioDestinationNode(context *AudioContext, options *AudioNodeOptions) (_result *MediaStreamAudioDestinationNode) {
@@ -5328,15 +5385,19 @@ type MediaStreamAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaStreamAudioSourceNodeFromJS is casting a js.Wrapper into MediaStreamAudioSourceNode.
-func MediaStreamAudioSourceNodeFromJS(value js.Wrapper) *MediaStreamAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamAudioSourceNodeFromJS is casting a js.Value into MediaStreamAudioSourceNode.
+func MediaStreamAudioSourceNodeFromJS(value js.Value) *MediaStreamAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaStreamAudioSourceNode.
+func MediaStreamAudioSourceNodeFromWrapper(input core.Wrapper) *MediaStreamAudioSourceNode {
+	return MediaStreamAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamAudioSourceNode(context *AudioContext, options *MediaStreamAudioSourceOptions) (_result *MediaStreamAudioSourceNode) {
@@ -5374,15 +5435,19 @@ type MediaStreamTrackAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaStreamTrackAudioSourceNodeFromJS is casting a js.Wrapper into MediaStreamTrackAudioSourceNode.
-func MediaStreamTrackAudioSourceNodeFromJS(value js.Wrapper) *MediaStreamTrackAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackAudioSourceNodeFromJS is casting a js.Value into MediaStreamTrackAudioSourceNode.
+func MediaStreamTrackAudioSourceNodeFromJS(value js.Value) *MediaStreamTrackAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrackAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaStreamTrackAudioSourceNode.
+func MediaStreamTrackAudioSourceNodeFromWrapper(input core.Wrapper) *MediaStreamTrackAudioSourceNode {
+	return MediaStreamTrackAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamTrackAudioSourceNode(context *AudioContext, options *MediaStreamTrackAudioSourceOptions) (_result *MediaStreamTrackAudioSourceNode) {
@@ -5411,15 +5476,19 @@ type OfflineAudioCompletionEvent struct {
 	domcore.Event
 }
 
-// OfflineAudioCompletionEventFromJS is casting a js.Wrapper into OfflineAudioCompletionEvent.
-func OfflineAudioCompletionEventFromJS(value js.Wrapper) *OfflineAudioCompletionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OfflineAudioCompletionEventFromJS is casting a js.Value into OfflineAudioCompletionEvent.
+func OfflineAudioCompletionEventFromJS(value js.Value) *OfflineAudioCompletionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OfflineAudioCompletionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OfflineAudioCompletionEventFromJS is casting from something that holds a js.Value into OfflineAudioCompletionEvent.
+func OfflineAudioCompletionEventFromWrapper(input core.Wrapper) *OfflineAudioCompletionEvent {
+	return OfflineAudioCompletionEventFromJS(input.JSValue())
 }
 
 func NewOfflineAudioCompletionEvent(_type string, eventInitDict *OfflineAudioCompletionEventInit) (_result *OfflineAudioCompletionEvent) {
@@ -5457,15 +5526,19 @@ type OfflineAudioContext struct {
 	BaseAudioContext
 }
 
-// OfflineAudioContextFromJS is casting a js.Wrapper into OfflineAudioContext.
-func OfflineAudioContextFromJS(value js.Wrapper) *OfflineAudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OfflineAudioContextFromJS is casting a js.Value into OfflineAudioContext.
+func OfflineAudioContextFromJS(value js.Value) *OfflineAudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OfflineAudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OfflineAudioContextFromJS is casting from something that holds a js.Value into OfflineAudioContext.
+func OfflineAudioContextFromWrapper(input core.Wrapper) *OfflineAudioContext {
+	return OfflineAudioContextFromJS(input.JSValue())
 }
 
 func NewOfflineAudioContext(numberOfChannels uint, length uint, sampleRate float32) (_result *OfflineAudioContext) {
@@ -5592,15 +5665,19 @@ type OscillatorNode struct {
 	AudioScheduledSourceNode
 }
 
-// OscillatorNodeFromJS is casting a js.Wrapper into OscillatorNode.
-func OscillatorNodeFromJS(value js.Wrapper) *OscillatorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OscillatorNodeFromJS is casting a js.Value into OscillatorNode.
+func OscillatorNodeFromJS(value js.Value) *OscillatorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OscillatorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OscillatorNodeFromJS is casting from something that holds a js.Value into OscillatorNode.
+func OscillatorNodeFromWrapper(input core.Wrapper) *OscillatorNode {
+	return OscillatorNodeFromJS(input.JSValue())
 }
 
 func NewOscillatorNode(context *BaseAudioContext, options *OscillatorOptions) (_result *OscillatorNode) {
@@ -5677,15 +5754,19 @@ type PannerNode struct {
 	AudioNode
 }
 
-// PannerNodeFromJS is casting a js.Wrapper into PannerNode.
-func PannerNodeFromJS(value js.Wrapper) *PannerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PannerNodeFromJS is casting a js.Value into PannerNode.
+func PannerNodeFromJS(value js.Value) *PannerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PannerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PannerNodeFromJS is casting from something that holds a js.Value into PannerNode.
+func PannerNodeFromWrapper(input core.Wrapper) *PannerNode {
+	return PannerNodeFromJS(input.JSValue())
 }
 
 func NewPannerNode(context *BaseAudioContext, options *PannerOptions) (_result *PannerNode) {
@@ -5939,15 +6020,19 @@ func (_this *PeriodicWave) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PeriodicWaveFromJS is casting a js.Wrapper into PeriodicWave.
-func PeriodicWaveFromJS(value js.Wrapper) *PeriodicWave {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeriodicWaveFromJS is casting a js.Value into PeriodicWave.
+func PeriodicWaveFromJS(value js.Value) *PeriodicWave {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeriodicWave{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeriodicWaveFromJS is casting from something that holds a js.Value into PeriodicWave.
+func PeriodicWaveFromWrapper(input core.Wrapper) *PeriodicWave {
+	return PeriodicWaveFromJS(input.JSValue())
 }
 
 func NewPeriodicWave(context *BaseAudioContext, options *PeriodicWaveOptions) (_result *PeriodicWave) {
@@ -5983,15 +6068,19 @@ func (_this *PromiseAudioBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAudioBufferFromJS is casting a js.Wrapper into PromiseAudioBuffer.
-func PromiseAudioBufferFromJS(value js.Wrapper) *PromiseAudioBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAudioBufferFromJS is casting a js.Value into PromiseAudioBuffer.
+func PromiseAudioBufferFromJS(value js.Value) *PromiseAudioBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAudioBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAudioBufferFromJS is casting from something that holds a js.Value into PromiseAudioBuffer.
+func PromiseAudioBufferFromWrapper(input core.Wrapper) *PromiseAudioBuffer {
+	return PromiseAudioBufferFromJS(input.JSValue())
 }
 
 func (_this *PromiseAudioBuffer) Then(onFulfilled *PromiseAudioBufferOnFulfilled, onRejected *PromiseAudioBufferOnRejected) (_result *PromiseAudioBuffer) {
@@ -6083,15 +6172,19 @@ type ScriptProcessorNode struct {
 	AudioNode
 }
 
-// ScriptProcessorNodeFromJS is casting a js.Wrapper into ScriptProcessorNode.
-func ScriptProcessorNodeFromJS(value js.Wrapper) *ScriptProcessorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScriptProcessorNodeFromJS is casting a js.Value into ScriptProcessorNode.
+func ScriptProcessorNodeFromJS(value js.Value) *ScriptProcessorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScriptProcessorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScriptProcessorNodeFromJS is casting from something that holds a js.Value into ScriptProcessorNode.
+func ScriptProcessorNodeFromWrapper(input core.Wrapper) *ScriptProcessorNode {
+	return ScriptProcessorNodeFromJS(input.JSValue())
 }
 
 // OnAudioProcess returning attribute 'onaudioprocess' with
@@ -6149,15 +6242,19 @@ type StereoPannerNode struct {
 	AudioNode
 }
 
-// StereoPannerNodeFromJS is casting a js.Wrapper into StereoPannerNode.
-func StereoPannerNodeFromJS(value js.Wrapper) *StereoPannerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StereoPannerNodeFromJS is casting a js.Value into StereoPannerNode.
+func StereoPannerNodeFromJS(value js.Value) *StereoPannerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StereoPannerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StereoPannerNodeFromJS is casting from something that holds a js.Value into StereoPannerNode.
+func StereoPannerNodeFromWrapper(input core.Wrapper) *StereoPannerNode {
+	return StereoPannerNodeFromJS(input.JSValue())
 }
 
 func NewStereoPannerNode(context *BaseAudioContext, options *StereoPannerOptions) (_result *StereoPannerNode) {
@@ -6197,15 +6294,19 @@ type WaveShaperNode struct {
 	AudioNode
 }
 
-// WaveShaperNodeFromJS is casting a js.Wrapper into WaveShaperNode.
-func WaveShaperNodeFromJS(value js.Wrapper) *WaveShaperNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WaveShaperNodeFromJS is casting a js.Value into WaveShaperNode.
+func WaveShaperNodeFromJS(value js.Value) *WaveShaperNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WaveShaperNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WaveShaperNodeFromJS is casting from something that holds a js.Value into WaveShaperNode.
+func WaveShaperNodeFromWrapper(input core.Wrapper) *WaveShaperNode {
+	return WaveShaperNodeFromJS(input.JSValue())
 }
 
 func NewWaveShaperNode(context *BaseAudioContext, options *WaveShaperOptions) (_result *WaveShaperNode) {

--- a/media/audio/audio_js.go
+++ b/media/audio/audio_js.go
@@ -5,6 +5,7 @@ package audio
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/core/jsarray"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/html/channel"
@@ -716,7 +717,7 @@ type AnalyserOptions struct {
 	SmoothingTimeConstant float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnalyserOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -738,10 +739,8 @@ func (_this *AnalyserOptions) JSValue() js.Value {
 }
 
 // AnalyserOptionsFromJS is allocating a new
-// AnalyserOptions object and copy all values from
-// input javascript object
-func AnalyserOptionsFromJS(value js.Wrapper) *AnalyserOptions {
-	input := value.JSValue()
+// AnalyserOptions object and copy all values in the value javascript object.
+func AnalyserOptionsFromJS(value js.Value) *AnalyserOptions {
 	var out AnalyserOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -752,19 +751,19 @@ func AnalyserOptionsFromJS(value js.Wrapper) *AnalyserOptions {
 		value5 float64               // javascript: double {minDecibels MinDecibels minDecibels}
 		value6 float64               // javascript: double {smoothingTimeConstant SmoothingTimeConstant smoothingTimeConstant}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("fftSize")).Int())
+	value3 = (uint)((value.Get("fftSize")).Int())
 	out.FftSize = value3
-	value4 = (input.Get("maxDecibels")).Float()
+	value4 = (value.Get("maxDecibels")).Float()
 	out.MaxDecibels = value4
-	value5 = (input.Get("minDecibels")).Float()
+	value5 = (value.Get("minDecibels")).Float()
 	out.MinDecibels = value5
-	value6 = (input.Get("smoothingTimeConstant")).Float()
+	value6 = (value.Get("smoothingTimeConstant")).Float()
 	out.SmoothingTimeConstant = value6
 	return &out
 }
@@ -776,7 +775,7 @@ type AudioBufferOptions struct {
 	SampleRate       float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioBufferOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -790,21 +789,19 @@ func (_this *AudioBufferOptions) JSValue() js.Value {
 }
 
 // AudioBufferOptionsFromJS is allocating a new
-// AudioBufferOptions object and copy all values from
-// input javascript object
-func AudioBufferOptionsFromJS(value js.Wrapper) *AudioBufferOptions {
-	input := value.JSValue()
+// AudioBufferOptions object and copy all values in the value javascript object.
+func AudioBufferOptionsFromJS(value js.Value) *AudioBufferOptions {
 	var out AudioBufferOptions
 	var (
 		value0 uint    // javascript: unsigned long {numberOfChannels NumberOfChannels numberOfChannels}
 		value1 uint    // javascript: unsigned long {length Length length}
 		value2 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = (uint)((input.Get("numberOfChannels")).Int())
+	value0 = (uint)((value.Get("numberOfChannels")).Int())
 	out.NumberOfChannels = value0
-	value1 = (uint)((input.Get("length")).Int())
+	value1 = (uint)((value.Get("length")).Int())
 	out.Length = value1
-	value2 = (float32)((input.Get("sampleRate")).Float())
+	value2 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value2
 	return &out
 }
@@ -819,7 +816,7 @@ type AudioBufferSourceOptions struct {
 	PlaybackRate float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioBufferSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -839,10 +836,8 @@ func (_this *AudioBufferSourceOptions) JSValue() js.Value {
 }
 
 // AudioBufferSourceOptionsFromJS is allocating a new
-// AudioBufferSourceOptions object and copy all values from
-// input javascript object
-func AudioBufferSourceOptionsFromJS(value js.Wrapper) *AudioBufferSourceOptions {
-	input := value.JSValue()
+// AudioBufferSourceOptions object and copy all values in the value javascript object.
+func AudioBufferSourceOptionsFromJS(value js.Value) *AudioBufferSourceOptions {
 	var out AudioBufferSourceOptions
 	var (
 		value0 *AudioBuffer // javascript: AudioBuffer {buffer Buffer buffer}
@@ -852,19 +847,19 @@ func AudioBufferSourceOptionsFromJS(value js.Wrapper) *AudioBufferSourceOptions 
 		value4 float64      // javascript: double {loopStart LoopStart loopStart}
 		value5 float32      // javascript: float {playbackRate PlaybackRate playbackRate}
 	)
-	if input.Get("buffer").Type() != js.TypeNull && input.Get("buffer").Type() != js.TypeUndefined {
-		value0 = AudioBufferFromJS(input.Get("buffer"))
+	if value.Get("buffer").Type() != js.TypeNull && value.Get("buffer").Type() != js.TypeUndefined {
+		value0 = AudioBufferFromJS(value.Get("buffer"))
 	}
 	out.Buffer = value0
-	value1 = (float32)((input.Get("detune")).Float())
+	value1 = (float32)((value.Get("detune")).Float())
 	out.Detune = value1
-	value2 = (input.Get("loop")).Bool()
+	value2 = (value.Get("loop")).Bool()
 	out.Loop = value2
-	value3 = (input.Get("loopEnd")).Float()
+	value3 = (value.Get("loopEnd")).Float()
 	out.LoopEnd = value3
-	value4 = (input.Get("loopStart")).Float()
+	value4 = (value.Get("loopStart")).Float()
 	out.LoopStart = value4
-	value5 = (float32)((input.Get("playbackRate")).Float())
+	value5 = (float32)((value.Get("playbackRate")).Float())
 	out.PlaybackRate = value5
 	return &out
 }
@@ -875,7 +870,7 @@ type AudioContextOptions struct {
 	SampleRate  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioContextOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -887,18 +882,16 @@ func (_this *AudioContextOptions) JSValue() js.Value {
 }
 
 // AudioContextOptionsFromJS is allocating a new
-// AudioContextOptions object and copy all values from
-// input javascript object
-func AudioContextOptionsFromJS(value js.Wrapper) *AudioContextOptions {
-	input := value.JSValue()
+// AudioContextOptions object and copy all values in the value javascript object.
+func AudioContextOptionsFromJS(value js.Value) *AudioContextOptions {
 	var out AudioContextOptions
 	var (
 		value0 *Union  // javascript: Union {latencyHint LatencyHint latencyHint}
 		value1 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = UnionFromJS(input.Get("latencyHint"))
+	value0 = UnionFromJS(value.Get("latencyHint"))
 	out.LatencyHint = value0
-	value1 = (float32)((input.Get("sampleRate")).Float())
+	value1 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value1
 	return &out
 }
@@ -910,7 +903,7 @@ type AudioNodeOptions struct {
 	ChannelInterpretation ChannelInterpretation
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -924,21 +917,19 @@ func (_this *AudioNodeOptions) JSValue() js.Value {
 }
 
 // AudioNodeOptionsFromJS is allocating a new
-// AudioNodeOptions object and copy all values from
-// input javascript object
-func AudioNodeOptionsFromJS(value js.Wrapper) *AudioNodeOptions {
-	input := value.JSValue()
+// AudioNodeOptions object and copy all values in the value javascript object.
+func AudioNodeOptionsFromJS(value js.Value) *AudioNodeOptions {
 	var out AudioNodeOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
 		value1 ChannelCountMode      // javascript: ChannelCountMode {channelCountMode ChannelCountMode channelCountMode}
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
 	return &out
 }
@@ -952,7 +943,7 @@ type AudioParamDescriptor struct {
 	AutomationRate AutomationRate
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamDescriptor) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -970,10 +961,8 @@ func (_this *AudioParamDescriptor) JSValue() js.Value {
 }
 
 // AudioParamDescriptorFromJS is allocating a new
-// AudioParamDescriptor object and copy all values from
-// input javascript object
-func AudioParamDescriptorFromJS(value js.Wrapper) *AudioParamDescriptor {
-	input := value.JSValue()
+// AudioParamDescriptor object and copy all values in the value javascript object.
+func AudioParamDescriptorFromJS(value js.Value) *AudioParamDescriptor {
 	var out AudioParamDescriptor
 	var (
 		value0 string         // javascript: DOMString {name Name name}
@@ -982,15 +971,15 @@ func AudioParamDescriptorFromJS(value js.Wrapper) *AudioParamDescriptor {
 		value3 float32        // javascript: float {maxValue MaxValue maxValue}
 		value4 AutomationRate // javascript: AutomationRate {automationRate AutomationRate automationRate}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	value1 = (float32)((input.Get("defaultValue")).Float())
+	value1 = (float32)((value.Get("defaultValue")).Float())
 	out.DefaultValue = value1
-	value2 = (float32)((input.Get("minValue")).Float())
+	value2 = (float32)((value.Get("minValue")).Float())
 	out.MinValue = value2
-	value3 = (float32)((input.Get("maxValue")).Float())
+	value3 = (float32)((value.Get("maxValue")).Float())
 	out.MaxValue = value3
-	value4 = AutomationRateFromJS(input.Get("automationRate"))
+	value4 = AutomationRateFromJS(value.Get("automationRate"))
 	out.AutomationRate = value4
 	return &out
 }
@@ -1001,7 +990,7 @@ type AudioParamMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1017,26 +1006,24 @@ func (_this *AudioParamMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapEntryIteratorValueFromJS is allocating a new
-// AudioParamMapEntryIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapEntryIteratorValueFromJS(value js.Wrapper) *AudioParamMapEntryIteratorValue {
-	input := value.JSValue()
+// AudioParamMapEntryIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapEntryIteratorValueFromJS(value js.Value) *AudioParamMapEntryIteratorValue {
 	var out AudioParamMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1047,7 +1034,7 @@ type AudioParamMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1059,18 +1046,16 @@ func (_this *AudioParamMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapKeyIteratorValueFromJS is allocating a new
-// AudioParamMapKeyIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapKeyIteratorValueFromJS(value js.Wrapper) *AudioParamMapKeyIteratorValue {
-	input := value.JSValue()
+// AudioParamMapKeyIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapKeyIteratorValueFromJS(value js.Value) *AudioParamMapKeyIteratorValue {
 	var out AudioParamMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1081,7 +1066,7 @@ type AudioParamMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioParamMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1093,18 +1078,16 @@ func (_this *AudioParamMapValueIteratorValue) JSValue() js.Value {
 }
 
 // AudioParamMapValueIteratorValueFromJS is allocating a new
-// AudioParamMapValueIteratorValue object and copy all values from
-// input javascript object
-func AudioParamMapValueIteratorValueFromJS(value js.Wrapper) *AudioParamMapValueIteratorValue {
-	input := value.JSValue()
+// AudioParamMapValueIteratorValue object and copy all values in the value javascript object.
+func AudioParamMapValueIteratorValueFromJS(value js.Value) *AudioParamMapValueIteratorValue {
 	var out AudioParamMapValueIteratorValue
 	var (
 		value0 *AudioParam // javascript: AudioParam {value Value value}
 		value1 bool        // javascript: boolean {done Done done}
 	)
-	value0 = AudioParamFromJS(input.Get("value"))
+	value0 = AudioParamFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -1119,7 +1102,7 @@ type AudioProcessingEventInit struct {
 	OutputBuffer *AudioBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioProcessingEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1139,10 +1122,8 @@ func (_this *AudioProcessingEventInit) JSValue() js.Value {
 }
 
 // AudioProcessingEventInitFromJS is allocating a new
-// AudioProcessingEventInit object and copy all values from
-// input javascript object
-func AudioProcessingEventInitFromJS(value js.Wrapper) *AudioProcessingEventInit {
-	input := value.JSValue()
+// AudioProcessingEventInit object and copy all values in the value javascript object.
+func AudioProcessingEventInitFromJS(value js.Value) *AudioProcessingEventInit {
 	var out AudioProcessingEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1152,17 +1133,17 @@ func AudioProcessingEventInitFromJS(value js.Wrapper) *AudioProcessingEventInit 
 		value4 *AudioBuffer // javascript: AudioBuffer {inputBuffer InputBuffer inputBuffer}
 		value5 *AudioBuffer // javascript: AudioBuffer {outputBuffer OutputBuffer outputBuffer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("playbackTime")).Float()
+	value3 = (value.Get("playbackTime")).Float()
 	out.PlaybackTime = value3
-	value4 = AudioBufferFromJS(input.Get("inputBuffer"))
+	value4 = AudioBufferFromJS(value.Get("inputBuffer"))
 	out.InputBuffer = value4
-	value5 = AudioBufferFromJS(input.Get("outputBuffer"))
+	value5 = AudioBufferFromJS(value.Get("outputBuffer"))
 	out.OutputBuffer = value5
 	return &out
 }
@@ -1173,7 +1154,7 @@ type AudioTimestamp struct {
 	PerformanceTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioTimestamp) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1185,18 +1166,16 @@ func (_this *AudioTimestamp) JSValue() js.Value {
 }
 
 // AudioTimestampFromJS is allocating a new
-// AudioTimestamp object and copy all values from
-// input javascript object
-func AudioTimestampFromJS(value js.Wrapper) *AudioTimestamp {
-	input := value.JSValue()
+// AudioTimestamp object and copy all values in the value javascript object.
+func AudioTimestampFromJS(value js.Value) *AudioTimestamp {
 	var out AudioTimestamp
 	var (
 		value0 float64 // javascript: double {contextTime ContextTime contextTime}
 		value1 float64 // javascript: double {performanceTime PerformanceTime performanceTime}
 	)
-	value0 = (input.Get("contextTime")).Float()
+	value0 = (value.Get("contextTime")).Float()
 	out.ContextTime = value0
-	value1 = (input.Get("performanceTime")).Float()
+	value1 = (value.Get("performanceTime")).Float()
 	out.PerformanceTime = value1
 	return &out
 }
@@ -1212,7 +1191,7 @@ type AudioWorkletNodeOptions struct {
 	ProcessorOptions      *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioWorkletNodeOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1238,10 +1217,8 @@ func (_this *AudioWorkletNodeOptions) JSValue() js.Value {
 }
 
 // AudioWorkletNodeOptionsFromJS is allocating a new
-// AudioWorkletNodeOptions object and copy all values from
-// input javascript object
-func AudioWorkletNodeOptionsFromJS(value js.Wrapper) *AudioWorkletNodeOptions {
-	input := value.JSValue()
+// AudioWorkletNodeOptions object and copy all values in the value javascript object.
+func AudioWorkletNodeOptionsFromJS(value js.Value) *AudioWorkletNodeOptions {
 	var out AudioWorkletNodeOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1252,28 +1229,28 @@ func AudioWorkletNodeOptionsFromJS(value js.Wrapper) *AudioWorkletNodeOptions {
 		value5 []uint                // javascript: sequence<unsigned long> {outputChannelCount OutputChannelCount outputChannelCount}
 		value6 *javascript.Object    // javascript: object {processorOptions ProcessorOptions processorOptions}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfInputs")).Int())
+	value3 = (uint)((value.Get("numberOfInputs")).Int())
 	out.NumberOfInputs = value3
-	value4 = (uint)((input.Get("numberOfOutputs")).Int())
+	value4 = (uint)((value.Get("numberOfOutputs")).Int())
 	out.NumberOfOutputs = value4
-	__length5 := input.Get("outputChannelCount").Length()
+	__length5 := value.Get("outputChannelCount").Length()
 	__array5 := make([]uint, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 uint
-		__seq_in5 := input.Get("outputChannelCount").Index(__idx5)
+		__seq_in5 := value.Get("outputChannelCount").Index(__idx5)
 		__seq_out5 = (uint)((__seq_in5).Int())
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.OutputChannelCount = value5
-	if input.Get("processorOptions").Type() != js.TypeNull && input.Get("processorOptions").Type() != js.TypeUndefined {
-		value6 = javascript.ObjectFromJS(input.Get("processorOptions"))
+	if value.Get("processorOptions").Type() != js.TypeNull && value.Get("processorOptions").Type() != js.TypeUndefined {
+		value6 = javascript.ObjectFromJS(value.Get("processorOptions"))
 	}
 	out.ProcessorOptions = value6
 	return &out
@@ -1291,7 +1268,7 @@ type BiquadFilterOptions struct {
 	Gain                  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BiquadFilterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1315,10 +1292,8 @@ func (_this *BiquadFilterOptions) JSValue() js.Value {
 }
 
 // BiquadFilterOptionsFromJS is allocating a new
-// BiquadFilterOptions object and copy all values from
-// input javascript object
-func BiquadFilterOptionsFromJS(value js.Wrapper) *BiquadFilterOptions {
-	input := value.JSValue()
+// BiquadFilterOptions object and copy all values in the value javascript object.
+func BiquadFilterOptionsFromJS(value js.Value) *BiquadFilterOptions {
 	var out BiquadFilterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1330,21 +1305,21 @@ func BiquadFilterOptionsFromJS(value js.Wrapper) *BiquadFilterOptions {
 		value6 float32               // javascript: float {frequency Frequency frequency}
 		value7 float32               // javascript: float {gain Gain gain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = BiquadFilterTypeFromJS(input.Get("type"))
+	value3 = BiquadFilterTypeFromJS(value.Get("type"))
 	out.Type = value3
-	value4 = (float32)((input.Get("Q")).Float())
+	value4 = (float32)((value.Get("Q")).Float())
 	out.Q = value4
-	value5 = (float32)((input.Get("detune")).Float())
+	value5 = (float32)((value.Get("detune")).Float())
 	out.Detune = value5
-	value6 = (float32)((input.Get("frequency")).Float())
+	value6 = (float32)((value.Get("frequency")).Float())
 	out.Frequency = value6
-	value7 = (float32)((input.Get("gain")).Float())
+	value7 = (float32)((value.Get("gain")).Float())
 	out.Gain = value7
 	return &out
 }
@@ -1357,7 +1332,7 @@ type ChannelMergerOptions struct {
 	NumberOfInputs        uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ChannelMergerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1373,10 +1348,8 @@ func (_this *ChannelMergerOptions) JSValue() js.Value {
 }
 
 // ChannelMergerOptionsFromJS is allocating a new
-// ChannelMergerOptions object and copy all values from
-// input javascript object
-func ChannelMergerOptionsFromJS(value js.Wrapper) *ChannelMergerOptions {
-	input := value.JSValue()
+// ChannelMergerOptions object and copy all values in the value javascript object.
+func ChannelMergerOptionsFromJS(value js.Value) *ChannelMergerOptions {
 	var out ChannelMergerOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1384,13 +1357,13 @@ func ChannelMergerOptionsFromJS(value js.Wrapper) *ChannelMergerOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 uint                  // javascript: unsigned long {numberOfInputs NumberOfInputs numberOfInputs}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfInputs")).Int())
+	value3 = (uint)((value.Get("numberOfInputs")).Int())
 	out.NumberOfInputs = value3
 	return &out
 }
@@ -1403,7 +1376,7 @@ type ChannelSplitterOptions struct {
 	NumberOfOutputs       uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ChannelSplitterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1419,10 +1392,8 @@ func (_this *ChannelSplitterOptions) JSValue() js.Value {
 }
 
 // ChannelSplitterOptionsFromJS is allocating a new
-// ChannelSplitterOptions object and copy all values from
-// input javascript object
-func ChannelSplitterOptionsFromJS(value js.Wrapper) *ChannelSplitterOptions {
-	input := value.JSValue()
+// ChannelSplitterOptions object and copy all values in the value javascript object.
+func ChannelSplitterOptionsFromJS(value js.Value) *ChannelSplitterOptions {
 	var out ChannelSplitterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1430,13 +1401,13 @@ func ChannelSplitterOptionsFromJS(value js.Wrapper) *ChannelSplitterOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 uint                  // javascript: unsigned long {numberOfOutputs NumberOfOutputs numberOfOutputs}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (uint)((input.Get("numberOfOutputs")).Int())
+	value3 = (uint)((value.Get("numberOfOutputs")).Int())
 	out.NumberOfOutputs = value3
 	return &out
 }
@@ -1446,7 +1417,7 @@ type ConstantSourceOptions struct {
 	Offset float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstantSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1456,15 +1427,13 @@ func (_this *ConstantSourceOptions) JSValue() js.Value {
 }
 
 // ConstantSourceOptionsFromJS is allocating a new
-// ConstantSourceOptions object and copy all values from
-// input javascript object
-func ConstantSourceOptionsFromJS(value js.Wrapper) *ConstantSourceOptions {
-	input := value.JSValue()
+// ConstantSourceOptions object and copy all values in the value javascript object.
+func ConstantSourceOptionsFromJS(value js.Value) *ConstantSourceOptions {
 	var out ConstantSourceOptions
 	var (
 		value0 float32 // javascript: float {offset Offset offset}
 	)
-	value0 = (float32)((input.Get("offset")).Float())
+	value0 = (float32)((value.Get("offset")).Float())
 	out.Offset = value0
 	return &out
 }
@@ -1478,7 +1447,7 @@ type ConvolverOptions struct {
 	DisableNormalization  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConvolverOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1496,10 +1465,8 @@ func (_this *ConvolverOptions) JSValue() js.Value {
 }
 
 // ConvolverOptionsFromJS is allocating a new
-// ConvolverOptions object and copy all values from
-// input javascript object
-func ConvolverOptionsFromJS(value js.Wrapper) *ConvolverOptions {
-	input := value.JSValue()
+// ConvolverOptions object and copy all values in the value javascript object.
+func ConvolverOptionsFromJS(value js.Value) *ConvolverOptions {
 	var out ConvolverOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1508,17 +1475,17 @@ func ConvolverOptionsFromJS(value js.Wrapper) *ConvolverOptions {
 		value3 *AudioBuffer          // javascript: AudioBuffer {buffer Buffer buffer}
 		value4 bool                  // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	if input.Get("buffer").Type() != js.TypeNull && input.Get("buffer").Type() != js.TypeUndefined {
-		value3 = AudioBufferFromJS(input.Get("buffer"))
+	if value.Get("buffer").Type() != js.TypeNull && value.Get("buffer").Type() != js.TypeUndefined {
+		value3 = AudioBufferFromJS(value.Get("buffer"))
 	}
 	out.Buffer = value3
-	value4 = (input.Get("disableNormalization")).Bool()
+	value4 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value4
 	return &out
 }
@@ -1532,7 +1499,7 @@ type DelayOptions struct {
 	DelayTime             float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DelayOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1550,10 +1517,8 @@ func (_this *DelayOptions) JSValue() js.Value {
 }
 
 // DelayOptionsFromJS is allocating a new
-// DelayOptions object and copy all values from
-// input javascript object
-func DelayOptionsFromJS(value js.Wrapper) *DelayOptions {
-	input := value.JSValue()
+// DelayOptions object and copy all values in the value javascript object.
+func DelayOptionsFromJS(value js.Value) *DelayOptions {
 	var out DelayOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1562,15 +1527,15 @@ func DelayOptionsFromJS(value js.Wrapper) *DelayOptions {
 		value3 float64               // javascript: double {maxDelayTime MaxDelayTime maxDelayTime}
 		value4 float64               // javascript: double {delayTime DelayTime delayTime}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (input.Get("maxDelayTime")).Float()
+	value3 = (value.Get("maxDelayTime")).Float()
 	out.MaxDelayTime = value3
-	value4 = (input.Get("delayTime")).Float()
+	value4 = (value.Get("delayTime")).Float()
 	out.DelayTime = value4
 	return &out
 }
@@ -1587,7 +1552,7 @@ type DynamicsCompressorOptions struct {
 	Threshold             float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DynamicsCompressorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1611,10 +1576,8 @@ func (_this *DynamicsCompressorOptions) JSValue() js.Value {
 }
 
 // DynamicsCompressorOptionsFromJS is allocating a new
-// DynamicsCompressorOptions object and copy all values from
-// input javascript object
-func DynamicsCompressorOptionsFromJS(value js.Wrapper) *DynamicsCompressorOptions {
-	input := value.JSValue()
+// DynamicsCompressorOptions object and copy all values in the value javascript object.
+func DynamicsCompressorOptionsFromJS(value js.Value) *DynamicsCompressorOptions {
 	var out DynamicsCompressorOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1626,21 +1589,21 @@ func DynamicsCompressorOptionsFromJS(value js.Wrapper) *DynamicsCompressorOption
 		value6 float32               // javascript: float {release Release release}
 		value7 float32               // javascript: float {threshold Threshold threshold}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("attack")).Float())
+	value3 = (float32)((value.Get("attack")).Float())
 	out.Attack = value3
-	value4 = (float32)((input.Get("knee")).Float())
+	value4 = (float32)((value.Get("knee")).Float())
 	out.Knee = value4
-	value5 = (float32)((input.Get("ratio")).Float())
+	value5 = (float32)((value.Get("ratio")).Float())
 	out.Ratio = value5
-	value6 = (float32)((input.Get("release")).Float())
+	value6 = (float32)((value.Get("release")).Float())
 	out.Release = value6
-	value7 = (float32)((input.Get("threshold")).Float())
+	value7 = (float32)((value.Get("threshold")).Float())
 	out.Threshold = value7
 	return &out
 }
@@ -1653,7 +1616,7 @@ type GainOptions struct {
 	Gain                  float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GainOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1669,10 +1632,8 @@ func (_this *GainOptions) JSValue() js.Value {
 }
 
 // GainOptionsFromJS is allocating a new
-// GainOptions object and copy all values from
-// input javascript object
-func GainOptionsFromJS(value js.Wrapper) *GainOptions {
-	input := value.JSValue()
+// GainOptions object and copy all values in the value javascript object.
+func GainOptionsFromJS(value js.Value) *GainOptions {
 	var out GainOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1680,13 +1641,13 @@ func GainOptionsFromJS(value js.Wrapper) *GainOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 float32               // javascript: float {gain Gain gain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("gain")).Float())
+	value3 = (float32)((value.Get("gain")).Float())
 	out.Gain = value3
 	return &out
 }
@@ -1700,7 +1661,7 @@ type IIRFilterOptions struct {
 	Feedback              []float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IIRFilterOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1718,10 +1679,8 @@ func (_this *IIRFilterOptions) JSValue() js.Value {
 }
 
 // IIRFilterOptionsFromJS is allocating a new
-// IIRFilterOptions object and copy all values from
-// input javascript object
-func IIRFilterOptionsFromJS(value js.Wrapper) *IIRFilterOptions {
-	input := value.JSValue()
+// IIRFilterOptions object and copy all values in the value javascript object.
+func IIRFilterOptionsFromJS(value js.Value) *IIRFilterOptions {
 	var out IIRFilterOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1730,15 +1689,15 @@ func IIRFilterOptionsFromJS(value js.Wrapper) *IIRFilterOptions {
 		value3 []float64             // javascript: typed-array {feedforward Feedforward feedforward}
 		value4 []float64             // javascript: typed-array {feedback Feedback feedback}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = jsarray.Float64ToGo(input.Get("feedforward"))
+	value3 = jsarray.Float64ToGo(value.Get("feedforward"))
 	out.Feedforward = value3
-	value4 = jsarray.Float64ToGo(input.Get("feedback"))
+	value4 = jsarray.Float64ToGo(value.Get("feedback"))
 	out.Feedback = value4
 	return &out
 }
@@ -1748,7 +1707,7 @@ type MediaElementAudioSourceOptions struct {
 	MediaElement *media.HTMLMediaElement
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaElementAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1758,15 +1717,13 @@ func (_this *MediaElementAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaElementAudioSourceOptionsFromJS is allocating a new
-// MediaElementAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaElementAudioSourceOptionsFromJS(value js.Wrapper) *MediaElementAudioSourceOptions {
-	input := value.JSValue()
+// MediaElementAudioSourceOptions object and copy all values in the value javascript object.
+func MediaElementAudioSourceOptionsFromJS(value js.Value) *MediaElementAudioSourceOptions {
 	var out MediaElementAudioSourceOptions
 	var (
 		value0 *media.HTMLMediaElement // javascript: HTMLMediaElement {mediaElement MediaElement mediaElement}
 	)
-	value0 = media.HTMLMediaElementFromJS(input.Get("mediaElement"))
+	value0 = media.HTMLMediaElementFromJS(value.Get("mediaElement"))
 	out.MediaElement = value0
 	return &out
 }
@@ -1776,7 +1733,7 @@ type MediaStreamAudioSourceOptions struct {
 	MediaStream *local.MediaStream
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1786,15 +1743,13 @@ func (_this *MediaStreamAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaStreamAudioSourceOptionsFromJS is allocating a new
-// MediaStreamAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaStreamAudioSourceOptionsFromJS(value js.Wrapper) *MediaStreamAudioSourceOptions {
-	input := value.JSValue()
+// MediaStreamAudioSourceOptions object and copy all values in the value javascript object.
+func MediaStreamAudioSourceOptionsFromJS(value js.Value) *MediaStreamAudioSourceOptions {
 	var out MediaStreamAudioSourceOptions
 	var (
 		value0 *local.MediaStream // javascript: MediaStream {mediaStream MediaStream mediaStream}
 	)
-	value0 = local.MediaStreamFromJS(input.Get("mediaStream"))
+	value0 = local.MediaStreamFromJS(value.Get("mediaStream"))
 	out.MediaStream = value0
 	return &out
 }
@@ -1804,7 +1759,7 @@ type MediaStreamTrackAudioSourceOptions struct {
 	MediaStreamTrack *local.MediaStreamTrack
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamTrackAudioSourceOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1814,15 +1769,13 @@ func (_this *MediaStreamTrackAudioSourceOptions) JSValue() js.Value {
 }
 
 // MediaStreamTrackAudioSourceOptionsFromJS is allocating a new
-// MediaStreamTrackAudioSourceOptions object and copy all values from
-// input javascript object
-func MediaStreamTrackAudioSourceOptionsFromJS(value js.Wrapper) *MediaStreamTrackAudioSourceOptions {
-	input := value.JSValue()
+// MediaStreamTrackAudioSourceOptions object and copy all values in the value javascript object.
+func MediaStreamTrackAudioSourceOptionsFromJS(value js.Value) *MediaStreamTrackAudioSourceOptions {
 	var out MediaStreamTrackAudioSourceOptions
 	var (
 		value0 *local.MediaStreamTrack // javascript: MediaStreamTrack {mediaStreamTrack MediaStreamTrack mediaStreamTrack}
 	)
-	value0 = local.MediaStreamTrackFromJS(input.Get("mediaStreamTrack"))
+	value0 = local.MediaStreamTrackFromJS(value.Get("mediaStreamTrack"))
 	out.MediaStreamTrack = value0
 	return &out
 }
@@ -1835,7 +1788,7 @@ type OfflineAudioCompletionEventInit struct {
 	RenderedBuffer *AudioBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfflineAudioCompletionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1851,10 +1804,8 @@ func (_this *OfflineAudioCompletionEventInit) JSValue() js.Value {
 }
 
 // OfflineAudioCompletionEventInitFromJS is allocating a new
-// OfflineAudioCompletionEventInit object and copy all values from
-// input javascript object
-func OfflineAudioCompletionEventInitFromJS(value js.Wrapper) *OfflineAudioCompletionEventInit {
-	input := value.JSValue()
+// OfflineAudioCompletionEventInit object and copy all values in the value javascript object.
+func OfflineAudioCompletionEventInitFromJS(value js.Value) *OfflineAudioCompletionEventInit {
 	var out OfflineAudioCompletionEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1862,13 +1813,13 @@ func OfflineAudioCompletionEventInitFromJS(value js.Wrapper) *OfflineAudioComple
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *AudioBuffer // javascript: AudioBuffer {renderedBuffer RenderedBuffer renderedBuffer}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = AudioBufferFromJS(input.Get("renderedBuffer"))
+	value3 = AudioBufferFromJS(value.Get("renderedBuffer"))
 	out.RenderedBuffer = value3
 	return &out
 }
@@ -1880,7 +1831,7 @@ type OfflineAudioContextOptions struct {
 	SampleRate       float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfflineAudioContextOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1894,21 +1845,19 @@ func (_this *OfflineAudioContextOptions) JSValue() js.Value {
 }
 
 // OfflineAudioContextOptionsFromJS is allocating a new
-// OfflineAudioContextOptions object and copy all values from
-// input javascript object
-func OfflineAudioContextOptionsFromJS(value js.Wrapper) *OfflineAudioContextOptions {
-	input := value.JSValue()
+// OfflineAudioContextOptions object and copy all values in the value javascript object.
+func OfflineAudioContextOptionsFromJS(value js.Value) *OfflineAudioContextOptions {
 	var out OfflineAudioContextOptions
 	var (
 		value0 uint    // javascript: unsigned long {numberOfChannels NumberOfChannels numberOfChannels}
 		value1 uint    // javascript: unsigned long {length Length length}
 		value2 float32 // javascript: float {sampleRate SampleRate sampleRate}
 	)
-	value0 = (uint)((input.Get("numberOfChannels")).Int())
+	value0 = (uint)((value.Get("numberOfChannels")).Int())
 	out.NumberOfChannels = value0
-	value1 = (uint)((input.Get("length")).Int())
+	value1 = (uint)((value.Get("length")).Int())
 	out.Length = value1
-	value2 = (float32)((input.Get("sampleRate")).Float())
+	value2 = (float32)((value.Get("sampleRate")).Float())
 	out.SampleRate = value2
 	return &out
 }
@@ -1924,7 +1873,7 @@ type OscillatorOptions struct {
 	PeriodicWave          *PeriodicWave
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OscillatorOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1946,10 +1895,8 @@ func (_this *OscillatorOptions) JSValue() js.Value {
 }
 
 // OscillatorOptionsFromJS is allocating a new
-// OscillatorOptions object and copy all values from
-// input javascript object
-func OscillatorOptionsFromJS(value js.Wrapper) *OscillatorOptions {
-	input := value.JSValue()
+// OscillatorOptions object and copy all values in the value javascript object.
+func OscillatorOptionsFromJS(value js.Value) *OscillatorOptions {
 	var out OscillatorOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -1960,19 +1907,19 @@ func OscillatorOptionsFromJS(value js.Wrapper) *OscillatorOptions {
 		value5 float32               // javascript: float {detune Detune detune}
 		value6 *PeriodicWave         // javascript: PeriodicWave {periodicWave PeriodicWave periodicWave}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = OscillatorTypeFromJS(input.Get("type"))
+	value3 = OscillatorTypeFromJS(value.Get("type"))
 	out.Type = value3
-	value4 = (float32)((input.Get("frequency")).Float())
+	value4 = (float32)((value.Get("frequency")).Float())
 	out.Frequency = value4
-	value5 = (float32)((input.Get("detune")).Float())
+	value5 = (float32)((value.Get("detune")).Float())
 	out.Detune = value5
-	value6 = PeriodicWaveFromJS(input.Get("periodicWave"))
+	value6 = PeriodicWaveFromJS(value.Get("periodicWave"))
 	out.PeriodicWave = value6
 	return &out
 }
@@ -1998,7 +1945,7 @@ type PannerOptions struct {
 	ConeOuterGain         float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PannerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2040,10 +1987,8 @@ func (_this *PannerOptions) JSValue() js.Value {
 }
 
 // PannerOptionsFromJS is allocating a new
-// PannerOptions object and copy all values from
-// input javascript object
-func PannerOptionsFromJS(value js.Wrapper) *PannerOptions {
-	input := value.JSValue()
+// PannerOptions object and copy all values in the value javascript object.
+func PannerOptionsFromJS(value js.Value) *PannerOptions {
 	var out PannerOptions
 	var (
 		value0  uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2064,39 +2009,39 @@ func PannerOptionsFromJS(value js.Wrapper) *PannerOptions {
 		value15 float64               // javascript: double {coneOuterAngle ConeOuterAngle coneOuterAngle}
 		value16 float64               // javascript: double {coneOuterGain ConeOuterGain coneOuterGain}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = PanningModelTypeFromJS(input.Get("panningModel"))
+	value3 = PanningModelTypeFromJS(value.Get("panningModel"))
 	out.PanningModel = value3
-	value4 = DistanceModelTypeFromJS(input.Get("distanceModel"))
+	value4 = DistanceModelTypeFromJS(value.Get("distanceModel"))
 	out.DistanceModel = value4
-	value5 = (float32)((input.Get("positionX")).Float())
+	value5 = (float32)((value.Get("positionX")).Float())
 	out.PositionX = value5
-	value6 = (float32)((input.Get("positionY")).Float())
+	value6 = (float32)((value.Get("positionY")).Float())
 	out.PositionY = value6
-	value7 = (float32)((input.Get("positionZ")).Float())
+	value7 = (float32)((value.Get("positionZ")).Float())
 	out.PositionZ = value7
-	value8 = (float32)((input.Get("orientationX")).Float())
+	value8 = (float32)((value.Get("orientationX")).Float())
 	out.OrientationX = value8
-	value9 = (float32)((input.Get("orientationY")).Float())
+	value9 = (float32)((value.Get("orientationY")).Float())
 	out.OrientationY = value9
-	value10 = (float32)((input.Get("orientationZ")).Float())
+	value10 = (float32)((value.Get("orientationZ")).Float())
 	out.OrientationZ = value10
-	value11 = (input.Get("refDistance")).Float()
+	value11 = (value.Get("refDistance")).Float()
 	out.RefDistance = value11
-	value12 = (input.Get("maxDistance")).Float()
+	value12 = (value.Get("maxDistance")).Float()
 	out.MaxDistance = value12
-	value13 = (input.Get("rolloffFactor")).Float()
+	value13 = (value.Get("rolloffFactor")).Float()
 	out.RolloffFactor = value13
-	value14 = (input.Get("coneInnerAngle")).Float()
+	value14 = (value.Get("coneInnerAngle")).Float()
 	out.ConeInnerAngle = value14
-	value15 = (input.Get("coneOuterAngle")).Float()
+	value15 = (value.Get("coneOuterAngle")).Float()
 	out.ConeOuterAngle = value15
-	value16 = (input.Get("coneOuterGain")).Float()
+	value16 = (value.Get("coneOuterGain")).Float()
 	out.ConeOuterGain = value16
 	return &out
 }
@@ -2106,7 +2051,7 @@ type PeriodicWaveConstraints struct {
 	DisableNormalization bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeriodicWaveConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2116,15 +2061,13 @@ func (_this *PeriodicWaveConstraints) JSValue() js.Value {
 }
 
 // PeriodicWaveConstraintsFromJS is allocating a new
-// PeriodicWaveConstraints object and copy all values from
-// input javascript object
-func PeriodicWaveConstraintsFromJS(value js.Wrapper) *PeriodicWaveConstraints {
-	input := value.JSValue()
+// PeriodicWaveConstraints object and copy all values in the value javascript object.
+func PeriodicWaveConstraintsFromJS(value js.Value) *PeriodicWaveConstraints {
 	var out PeriodicWaveConstraints
 	var (
 		value0 bool // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 	)
-	value0 = (input.Get("disableNormalization")).Bool()
+	value0 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value0
 	return &out
 }
@@ -2136,7 +2079,7 @@ type PeriodicWaveOptions struct {
 	Imag                 []float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeriodicWaveOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2150,21 +2093,19 @@ func (_this *PeriodicWaveOptions) JSValue() js.Value {
 }
 
 // PeriodicWaveOptionsFromJS is allocating a new
-// PeriodicWaveOptions object and copy all values from
-// input javascript object
-func PeriodicWaveOptionsFromJS(value js.Wrapper) *PeriodicWaveOptions {
-	input := value.JSValue()
+// PeriodicWaveOptions object and copy all values in the value javascript object.
+func PeriodicWaveOptionsFromJS(value js.Value) *PeriodicWaveOptions {
 	var out PeriodicWaveOptions
 	var (
 		value0 bool      // javascript: boolean {disableNormalization DisableNormalization disableNormalization}
 		value1 []float32 // javascript: typed-array {real Real real}
 		value2 []float32 // javascript: typed-array {imag Imag imag}
 	)
-	value0 = (input.Get("disableNormalization")).Bool()
+	value0 = (value.Get("disableNormalization")).Bool()
 	out.DisableNormalization = value0
-	value1 = jsarray.Float32ToGo(input.Get("real"))
+	value1 = jsarray.Float32ToGo(value.Get("real"))
 	out.Real = value1
-	value2 = jsarray.Float32ToGo(input.Get("imag"))
+	value2 = jsarray.Float32ToGo(value.Get("imag"))
 	out.Imag = value2
 	return &out
 }
@@ -2177,7 +2118,7 @@ type StereoPannerOptions struct {
 	Pan                   float32
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StereoPannerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2193,10 +2134,8 @@ func (_this *StereoPannerOptions) JSValue() js.Value {
 }
 
 // StereoPannerOptionsFromJS is allocating a new
-// StereoPannerOptions object and copy all values from
-// input javascript object
-func StereoPannerOptionsFromJS(value js.Wrapper) *StereoPannerOptions {
-	input := value.JSValue()
+// StereoPannerOptions object and copy all values in the value javascript object.
+func StereoPannerOptionsFromJS(value js.Value) *StereoPannerOptions {
 	var out StereoPannerOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2204,13 +2143,13 @@ func StereoPannerOptionsFromJS(value js.Wrapper) *StereoPannerOptions {
 		value2 ChannelInterpretation // javascript: ChannelInterpretation {channelInterpretation ChannelInterpretation channelInterpretation}
 		value3 float32               // javascript: float {pan Pan pan}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = (float32)((input.Get("pan")).Float())
+	value3 = (float32)((value.Get("pan")).Float())
 	out.Pan = value3
 	return &out
 }
@@ -2224,7 +2163,7 @@ type WaveShaperOptions struct {
 	Oversample            OverSampleType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WaveShaperOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2242,10 +2181,8 @@ func (_this *WaveShaperOptions) JSValue() js.Value {
 }
 
 // WaveShaperOptionsFromJS is allocating a new
-// WaveShaperOptions object and copy all values from
-// input javascript object
-func WaveShaperOptionsFromJS(value js.Wrapper) *WaveShaperOptions {
-	input := value.JSValue()
+// WaveShaperOptions object and copy all values in the value javascript object.
+func WaveShaperOptionsFromJS(value js.Value) *WaveShaperOptions {
 	var out WaveShaperOptions
 	var (
 		value0 uint                  // javascript: unsigned long {channelCount ChannelCount channelCount}
@@ -2254,15 +2191,15 @@ func WaveShaperOptionsFromJS(value js.Wrapper) *WaveShaperOptions {
 		value3 []float32             // javascript: typed-array {curve Curve curve}
 		value4 OverSampleType        // javascript: OverSampleType {oversample Oversample oversample}
 	)
-	value0 = (uint)((input.Get("channelCount")).Int())
+	value0 = (uint)((value.Get("channelCount")).Int())
 	out.ChannelCount = value0
-	value1 = ChannelCountModeFromJS(input.Get("channelCountMode"))
+	value1 = ChannelCountModeFromJS(value.Get("channelCountMode"))
 	out.ChannelCountMode = value1
-	value2 = ChannelInterpretationFromJS(input.Get("channelInterpretation"))
+	value2 = ChannelInterpretationFromJS(value.Get("channelInterpretation"))
 	out.ChannelInterpretation = value2
-	value3 = jsarray.Float32ToGo(input.Get("curve"))
+	value3 = jsarray.Float32ToGo(value.Get("curve"))
 	out.Curve = value3
-	value4 = OverSampleTypeFromJS(input.Get("oversample"))
+	value4 = OverSampleTypeFromJS(value.Get("oversample"))
 	out.Oversample = value4
 	return &out
 }
@@ -2272,15 +2209,19 @@ type AnalyserNode struct {
 	AudioNode
 }
 
-// AnalyserNodeFromJS is casting a js.Wrapper into AnalyserNode.
-func AnalyserNodeFromJS(value js.Wrapper) *AnalyserNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AnalyserNodeFromJS is casting a js.Value into AnalyserNode.
+func AnalyserNodeFromJS(value js.Value) *AnalyserNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AnalyserNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AnalyserNodeFromJS is casting from something that holds a js.Value into AnalyserNode.
+func AnalyserNodeFromWrapper(input core.Wrapper) *AnalyserNode {
+	return AnalyserNodeFromJS(input.JSValue())
 }
 
 func NewAnalyserNode(context *BaseAudioContext, options *AnalyserOptions) (_result *AnalyserNode) {
@@ -2437,15 +2378,19 @@ func (_this *AudioBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioBufferFromJS is casting a js.Wrapper into AudioBuffer.
-func AudioBufferFromJS(value js.Wrapper) *AudioBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioBufferFromJS is casting a js.Value into AudioBuffer.
+func AudioBufferFromJS(value js.Value) *AudioBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioBufferFromJS is casting from something that holds a js.Value into AudioBuffer.
+func AudioBufferFromWrapper(input core.Wrapper) *AudioBuffer {
+	return AudioBufferFromJS(input.JSValue())
 }
 
 func NewAudioBuffer(options *AudioBufferOptions) (_result *AudioBuffer) {
@@ -2576,15 +2521,19 @@ type AudioBufferSourceNode struct {
 	AudioScheduledSourceNode
 }
 
-// AudioBufferSourceNodeFromJS is casting a js.Wrapper into AudioBufferSourceNode.
-func AudioBufferSourceNodeFromJS(value js.Wrapper) *AudioBufferSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioBufferSourceNodeFromJS is casting a js.Value into AudioBufferSourceNode.
+func AudioBufferSourceNodeFromJS(value js.Value) *AudioBufferSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioBufferSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioBufferSourceNodeFromJS is casting from something that holds a js.Value into AudioBufferSourceNode.
+func AudioBufferSourceNodeFromWrapper(input core.Wrapper) *AudioBufferSourceNode {
+	return AudioBufferSourceNodeFromJS(input.JSValue())
 }
 
 func NewAudioBufferSourceNode(context *BaseAudioContext, options *AudioBufferSourceOptions) (_result *AudioBufferSourceNode) {
@@ -2741,15 +2690,19 @@ type AudioContext struct {
 	BaseAudioContext
 }
 
-// AudioContextFromJS is casting a js.Wrapper into AudioContext.
-func AudioContextFromJS(value js.Wrapper) *AudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioContextFromJS is casting a js.Value into AudioContext.
+func AudioContextFromJS(value js.Value) *AudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioContextFromJS is casting from something that holds a js.Value into AudioContext.
+func AudioContextFromWrapper(input core.Wrapper) *AudioContext {
+	return AudioContextFromJS(input.JSValue())
 }
 
 func NewAudioContext(contextOptions *AudioContextOptions) (_result *AudioContext) {
@@ -2916,15 +2869,19 @@ type AudioDestinationNode struct {
 	AudioNode
 }
 
-// AudioDestinationNodeFromJS is casting a js.Wrapper into AudioDestinationNode.
-func AudioDestinationNodeFromJS(value js.Wrapper) *AudioDestinationNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioDestinationNodeFromJS is casting a js.Value into AudioDestinationNode.
+func AudioDestinationNodeFromJS(value js.Value) *AudioDestinationNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioDestinationNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioDestinationNodeFromJS is casting from something that holds a js.Value into AudioDestinationNode.
+func AudioDestinationNodeFromWrapper(input core.Wrapper) *AudioDestinationNode {
+	return AudioDestinationNodeFromJS(input.JSValue())
 }
 
 // MaxChannelCount returning attribute 'maxChannelCount' with
@@ -2946,15 +2903,19 @@ func (_this *AudioListener) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioListenerFromJS is casting a js.Wrapper into AudioListener.
-func AudioListenerFromJS(value js.Wrapper) *AudioListener {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioListenerFromJS is casting a js.Value into AudioListener.
+func AudioListenerFromJS(value js.Value) *AudioListener {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioListener{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioListenerFromJS is casting from something that holds a js.Value into AudioListener.
+func AudioListenerFromWrapper(input core.Wrapper) *AudioListener {
+	return AudioListenerFromJS(input.JSValue())
 }
 
 // PositionX returning attribute 'positionX' with
@@ -3088,15 +3049,19 @@ type AudioNode struct {
 	domcore.EventTarget
 }
 
-// AudioNodeFromJS is casting a js.Wrapper into AudioNode.
-func AudioNodeFromJS(value js.Wrapper) *AudioNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioNodeFromJS is casting a js.Value into AudioNode.
+func AudioNodeFromJS(value js.Value) *AudioNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioNodeFromJS is casting from something that holds a js.Value into AudioNode.
+func AudioNodeFromWrapper(input core.Wrapper) *AudioNode {
+	return AudioNodeFromJS(input.JSValue())
 }
 
 // Context returning attribute 'context' with
@@ -3339,15 +3304,19 @@ func (_this *AudioParam) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamFromJS is casting a js.Wrapper into AudioParam.
-func AudioParamFromJS(value js.Wrapper) *AudioParam {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamFromJS is casting a js.Value into AudioParam.
+func AudioParamFromJS(value js.Value) *AudioParam {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParam{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamFromJS is casting from something that holds a js.Value into AudioParam.
+func AudioParamFromWrapper(input core.Wrapper) *AudioParam {
+	return AudioParamFromJS(input.JSValue())
 }
 
 // Value returning attribute 'value' with
@@ -3559,15 +3528,19 @@ func (_this *AudioParamMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapFromJS is casting a js.Wrapper into AudioParamMap.
-func AudioParamMapFromJS(value js.Wrapper) *AudioParamMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapFromJS is casting a js.Value into AudioParamMap.
+func AudioParamMapFromJS(value js.Value) *AudioParamMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapFromJS is casting from something that holds a js.Value into AudioParamMap.
+func AudioParamMapFromWrapper(input core.Wrapper) *AudioParamMap {
+	return AudioParamMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -3691,15 +3664,19 @@ func (_this *AudioParamMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapEntryIteratorFromJS is casting a js.Wrapper into AudioParamMapEntryIterator.
-func AudioParamMapEntryIteratorFromJS(value js.Wrapper) *AudioParamMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapEntryIteratorFromJS is casting a js.Value into AudioParamMapEntryIterator.
+func AudioParamMapEntryIteratorFromJS(value js.Value) *AudioParamMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapEntryIteratorFromJS is casting from something that holds a js.Value into AudioParamMapEntryIterator.
+func AudioParamMapEntryIteratorFromWrapper(input core.Wrapper) *AudioParamMapEntryIterator {
+	return AudioParamMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapEntryIterator) Next() (_result *AudioParamMapEntryIteratorValue) {
@@ -3726,15 +3703,19 @@ func (_this *AudioParamMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapKeyIteratorFromJS is casting a js.Wrapper into AudioParamMapKeyIterator.
-func AudioParamMapKeyIteratorFromJS(value js.Wrapper) *AudioParamMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapKeyIteratorFromJS is casting a js.Value into AudioParamMapKeyIterator.
+func AudioParamMapKeyIteratorFromJS(value js.Value) *AudioParamMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapKeyIteratorFromJS is casting from something that holds a js.Value into AudioParamMapKeyIterator.
+func AudioParamMapKeyIteratorFromWrapper(input core.Wrapper) *AudioParamMapKeyIterator {
+	return AudioParamMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapKeyIterator) Next() (_result *AudioParamMapKeyIteratorValue) {
@@ -3761,15 +3742,19 @@ func (_this *AudioParamMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioParamMapValueIteratorFromJS is casting a js.Wrapper into AudioParamMapValueIterator.
-func AudioParamMapValueIteratorFromJS(value js.Wrapper) *AudioParamMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioParamMapValueIteratorFromJS is casting a js.Value into AudioParamMapValueIterator.
+func AudioParamMapValueIteratorFromJS(value js.Value) *AudioParamMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioParamMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioParamMapValueIteratorFromJS is casting from something that holds a js.Value into AudioParamMapValueIterator.
+func AudioParamMapValueIteratorFromWrapper(input core.Wrapper) *AudioParamMapValueIterator {
+	return AudioParamMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *AudioParamMapValueIterator) Next() (_result *AudioParamMapValueIteratorValue) {
@@ -3791,15 +3776,19 @@ type AudioProcessingEvent struct {
 	domcore.Event
 }
 
-// AudioProcessingEventFromJS is casting a js.Wrapper into AudioProcessingEvent.
-func AudioProcessingEventFromJS(value js.Wrapper) *AudioProcessingEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioProcessingEventFromJS is casting a js.Value into AudioProcessingEvent.
+func AudioProcessingEventFromJS(value js.Value) *AudioProcessingEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioProcessingEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioProcessingEventFromJS is casting from something that holds a js.Value into AudioProcessingEvent.
+func AudioProcessingEventFromWrapper(input core.Wrapper) *AudioProcessingEvent {
+	return AudioProcessingEventFromJS(input.JSValue())
 }
 
 func NewAudioProcessingEvent(_type string, eventInitDict *AudioProcessingEventInit) (_result *AudioProcessingEvent) {
@@ -3855,15 +3844,19 @@ type AudioScheduledSourceNode struct {
 	AudioNode
 }
 
-// AudioScheduledSourceNodeFromJS is casting a js.Wrapper into AudioScheduledSourceNode.
-func AudioScheduledSourceNodeFromJS(value js.Wrapper) *AudioScheduledSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioScheduledSourceNodeFromJS is casting a js.Value into AudioScheduledSourceNode.
+func AudioScheduledSourceNodeFromJS(value js.Value) *AudioScheduledSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioScheduledSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioScheduledSourceNodeFromJS is casting from something that holds a js.Value into AudioScheduledSourceNode.
+func AudioScheduledSourceNodeFromWrapper(input core.Wrapper) *AudioScheduledSourceNode {
+	return AudioScheduledSourceNodeFromJS(input.JSValue())
 }
 
 // OnEnded returning attribute 'onended' with
@@ -3952,15 +3945,19 @@ type AudioWorklet struct {
 	worklets.Worklet
 }
 
-// AudioWorkletFromJS is casting a js.Wrapper into AudioWorklet.
-func AudioWorkletFromJS(value js.Wrapper) *AudioWorklet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletFromJS is casting a js.Value into AudioWorklet.
+func AudioWorkletFromJS(value js.Value) *AudioWorklet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorklet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletFromJS is casting from something that holds a js.Value into AudioWorklet.
+func AudioWorkletFromWrapper(input core.Wrapper) *AudioWorklet {
+	return AudioWorkletFromJS(input.JSValue())
 }
 
 // class: AudioWorkletGlobalScope
@@ -3968,15 +3965,19 @@ type AudioWorkletGlobalScope struct {
 	worklets.WorkletGlobalScope
 }
 
-// AudioWorkletGlobalScopeFromJS is casting a js.Wrapper into AudioWorkletGlobalScope.
-func AudioWorkletGlobalScopeFromJS(value js.Wrapper) *AudioWorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletGlobalScopeFromJS is casting a js.Value into AudioWorkletGlobalScope.
+func AudioWorkletGlobalScopeFromJS(value js.Value) *AudioWorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletGlobalScopeFromJS is casting from something that holds a js.Value into AudioWorkletGlobalScope.
+func AudioWorkletGlobalScopeFromWrapper(input core.Wrapper) *AudioWorkletGlobalScope {
+	return AudioWorkletGlobalScopeFromJS(input.JSValue())
 }
 
 // CurrentFrame returning attribute 'currentFrame' with
@@ -4033,15 +4034,19 @@ type AudioWorkletNode struct {
 	AudioNode
 }
 
-// AudioWorkletNodeFromJS is casting a js.Wrapper into AudioWorkletNode.
-func AudioWorkletNodeFromJS(value js.Wrapper) *AudioWorkletNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletNodeFromJS is casting a js.Value into AudioWorkletNode.
+func AudioWorkletNodeFromJS(value js.Value) *AudioWorkletNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletNodeFromJS is casting from something that holds a js.Value into AudioWorkletNode.
+func AudioWorkletNodeFromWrapper(input core.Wrapper) *AudioWorkletNode {
+	return AudioWorkletNodeFromJS(input.JSValue())
 }
 
 func NewAudioWorkletNode(context *BaseAudioContext, name string, options *AudioWorkletNodeOptions) (_result *AudioWorkletNode) {
@@ -4139,15 +4144,19 @@ func (_this *AudioWorkletProcessor) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// AudioWorkletProcessorFromJS is casting a js.Wrapper into AudioWorkletProcessor.
-func AudioWorkletProcessorFromJS(value js.Wrapper) *AudioWorkletProcessor {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AudioWorkletProcessorFromJS is casting a js.Value into AudioWorkletProcessor.
+func AudioWorkletProcessorFromJS(value js.Value) *AudioWorkletProcessor {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &AudioWorkletProcessor{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AudioWorkletProcessorFromJS is casting from something that holds a js.Value into AudioWorkletProcessor.
+func AudioWorkletProcessorFromWrapper(input core.Wrapper) *AudioWorkletProcessor {
+	return AudioWorkletProcessorFromJS(input.JSValue())
 }
 
 func NewAudioWorkletProcessor(options *AudioWorkletNodeOptions) (_result *AudioWorkletProcessor) {
@@ -4184,15 +4193,19 @@ type BaseAudioContext struct {
 	domcore.EventTarget
 }
 
-// BaseAudioContextFromJS is casting a js.Wrapper into BaseAudioContext.
-func BaseAudioContextFromJS(value js.Wrapper) *BaseAudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BaseAudioContextFromJS is casting a js.Value into BaseAudioContext.
+func BaseAudioContextFromJS(value js.Value) *BaseAudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BaseAudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BaseAudioContextFromJS is casting from something that holds a js.Value into BaseAudioContext.
+func BaseAudioContextFromWrapper(input core.Wrapper) *BaseAudioContext {
+	return BaseAudioContextFromJS(input.JSValue())
 }
 
 // Destination returning attribute 'destination' with
@@ -4680,15 +4693,19 @@ type BiquadFilterNode struct {
 	AudioNode
 }
 
-// BiquadFilterNodeFromJS is casting a js.Wrapper into BiquadFilterNode.
-func BiquadFilterNodeFromJS(value js.Wrapper) *BiquadFilterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BiquadFilterNodeFromJS is casting a js.Value into BiquadFilterNode.
+func BiquadFilterNodeFromJS(value js.Value) *BiquadFilterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BiquadFilterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BiquadFilterNodeFromJS is casting from something that holds a js.Value into BiquadFilterNode.
+func BiquadFilterNodeFromWrapper(input core.Wrapper) *BiquadFilterNode {
+	return BiquadFilterNodeFromJS(input.JSValue())
 }
 
 func NewBiquadFilterNode(context *BaseAudioContext, options *BiquadFilterOptions) (_result *BiquadFilterNode) {
@@ -4789,15 +4806,19 @@ type ChannelMergerNode struct {
 	AudioNode
 }
 
-// ChannelMergerNodeFromJS is casting a js.Wrapper into ChannelMergerNode.
-func ChannelMergerNodeFromJS(value js.Wrapper) *ChannelMergerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChannelMergerNodeFromJS is casting a js.Value into ChannelMergerNode.
+func ChannelMergerNodeFromJS(value js.Value) *ChannelMergerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChannelMergerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChannelMergerNodeFromJS is casting from something that holds a js.Value into ChannelMergerNode.
+func ChannelMergerNodeFromWrapper(input core.Wrapper) *ChannelMergerNode {
+	return ChannelMergerNodeFromJS(input.JSValue())
 }
 
 func NewChannelMergerNode(context *BaseAudioContext, options *ChannelMergerOptions) (_result *ChannelMergerNode) {
@@ -4828,15 +4849,19 @@ type ChannelSplitterNode struct {
 	AudioNode
 }
 
-// ChannelSplitterNodeFromJS is casting a js.Wrapper into ChannelSplitterNode.
-func ChannelSplitterNodeFromJS(value js.Wrapper) *ChannelSplitterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ChannelSplitterNodeFromJS is casting a js.Value into ChannelSplitterNode.
+func ChannelSplitterNodeFromJS(value js.Value) *ChannelSplitterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ChannelSplitterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ChannelSplitterNodeFromJS is casting from something that holds a js.Value into ChannelSplitterNode.
+func ChannelSplitterNodeFromWrapper(input core.Wrapper) *ChannelSplitterNode {
+	return ChannelSplitterNodeFromJS(input.JSValue())
 }
 
 func NewChannelSplitterNode(context *BaseAudioContext, options *ChannelSplitterOptions) (_result *ChannelSplitterNode) {
@@ -4867,15 +4892,19 @@ type ConstantSourceNode struct {
 	AudioScheduledSourceNode
 }
 
-// ConstantSourceNodeFromJS is casting a js.Wrapper into ConstantSourceNode.
-func ConstantSourceNodeFromJS(value js.Wrapper) *ConstantSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConstantSourceNodeFromJS is casting a js.Value into ConstantSourceNode.
+func ConstantSourceNodeFromJS(value js.Value) *ConstantSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConstantSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConstantSourceNodeFromJS is casting from something that holds a js.Value into ConstantSourceNode.
+func ConstantSourceNodeFromWrapper(input core.Wrapper) *ConstantSourceNode {
+	return ConstantSourceNodeFromJS(input.JSValue())
 }
 
 func NewConstantSourceNode(context *BaseAudioContext, options *ConstantSourceOptions) (_result *ConstantSourceNode) {
@@ -4915,15 +4944,19 @@ type ConvolverNode struct {
 	AudioNode
 }
 
-// ConvolverNodeFromJS is casting a js.Wrapper into ConvolverNode.
-func ConvolverNodeFromJS(value js.Wrapper) *ConvolverNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConvolverNodeFromJS is casting a js.Value into ConvolverNode.
+func ConvolverNodeFromJS(value js.Value) *ConvolverNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConvolverNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConvolverNodeFromJS is casting from something that holds a js.Value into ConvolverNode.
+func ConvolverNodeFromWrapper(input core.Wrapper) *ConvolverNode {
+	return ConvolverNodeFromJS(input.JSValue())
 }
 
 func NewConvolverNode(context *BaseAudioContext, options *ConvolverOptions) (_result *ConvolverNode) {
@@ -4988,15 +5021,19 @@ type DelayNode struct {
 	AudioNode
 }
 
-// DelayNodeFromJS is casting a js.Wrapper into DelayNode.
-func DelayNodeFromJS(value js.Wrapper) *DelayNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DelayNodeFromJS is casting a js.Value into DelayNode.
+func DelayNodeFromJS(value js.Value) *DelayNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DelayNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DelayNodeFromJS is casting from something that holds a js.Value into DelayNode.
+func DelayNodeFromWrapper(input core.Wrapper) *DelayNode {
+	return DelayNodeFromJS(input.JSValue())
 }
 
 func NewDelayNode(context *BaseAudioContext, options *DelayOptions) (_result *DelayNode) {
@@ -5036,15 +5073,19 @@ type DynamicsCompressorNode struct {
 	AudioNode
 }
 
-// DynamicsCompressorNodeFromJS is casting a js.Wrapper into DynamicsCompressorNode.
-func DynamicsCompressorNodeFromJS(value js.Wrapper) *DynamicsCompressorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DynamicsCompressorNodeFromJS is casting a js.Value into DynamicsCompressorNode.
+func DynamicsCompressorNodeFromJS(value js.Value) *DynamicsCompressorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DynamicsCompressorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DynamicsCompressorNodeFromJS is casting from something that holds a js.Value into DynamicsCompressorNode.
+func DynamicsCompressorNodeFromWrapper(input core.Wrapper) *DynamicsCompressorNode {
+	return DynamicsCompressorNodeFromJS(input.JSValue())
 }
 
 func NewDynamicsCompressorNode(context *BaseAudioContext, options *DynamicsCompressorOptions) (_result *DynamicsCompressorNode) {
@@ -5129,15 +5170,19 @@ type GainNode struct {
 	AudioNode
 }
 
-// GainNodeFromJS is casting a js.Wrapper into GainNode.
-func GainNodeFromJS(value js.Wrapper) *GainNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// GainNodeFromJS is casting a js.Value into GainNode.
+func GainNodeFromJS(value js.Value) *GainNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &GainNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// GainNodeFromJS is casting from something that holds a js.Value into GainNode.
+func GainNodeFromWrapper(input core.Wrapper) *GainNode {
+	return GainNodeFromJS(input.JSValue())
 }
 
 func NewGainNode(context *BaseAudioContext, options *GainOptions) (_result *GainNode) {
@@ -5177,15 +5222,19 @@ type IIRFilterNode struct {
 	AudioNode
 }
 
-// IIRFilterNodeFromJS is casting a js.Wrapper into IIRFilterNode.
-func IIRFilterNodeFromJS(value js.Wrapper) *IIRFilterNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IIRFilterNodeFromJS is casting a js.Value into IIRFilterNode.
+func IIRFilterNodeFromJS(value js.Value) *IIRFilterNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IIRFilterNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IIRFilterNodeFromJS is casting from something that holds a js.Value into IIRFilterNode.
+func IIRFilterNodeFromWrapper(input core.Wrapper) *IIRFilterNode {
+	return IIRFilterNodeFromJS(input.JSValue())
 }
 
 func NewIIRFilterNode(context *BaseAudioContext, options *IIRFilterOptions) (_result *IIRFilterNode) {
@@ -5232,15 +5281,19 @@ type MediaElementAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaElementAudioSourceNodeFromJS is casting a js.Wrapper into MediaElementAudioSourceNode.
-func MediaElementAudioSourceNodeFromJS(value js.Wrapper) *MediaElementAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaElementAudioSourceNodeFromJS is casting a js.Value into MediaElementAudioSourceNode.
+func MediaElementAudioSourceNodeFromJS(value js.Value) *MediaElementAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaElementAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaElementAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaElementAudioSourceNode.
+func MediaElementAudioSourceNodeFromWrapper(input core.Wrapper) *MediaElementAudioSourceNode {
+	return MediaElementAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaElementAudioSourceNode(context *AudioContext, options *MediaElementAudioSourceOptions) (_result *MediaElementAudioSourceNode) {
@@ -5278,15 +5331,19 @@ type MediaStreamAudioDestinationNode struct {
 	AudioNode
 }
 
-// MediaStreamAudioDestinationNodeFromJS is casting a js.Wrapper into MediaStreamAudioDestinationNode.
-func MediaStreamAudioDestinationNodeFromJS(value js.Wrapper) *MediaStreamAudioDestinationNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamAudioDestinationNodeFromJS is casting a js.Value into MediaStreamAudioDestinationNode.
+func MediaStreamAudioDestinationNodeFromJS(value js.Value) *MediaStreamAudioDestinationNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamAudioDestinationNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamAudioDestinationNodeFromJS is casting from something that holds a js.Value into MediaStreamAudioDestinationNode.
+func MediaStreamAudioDestinationNodeFromWrapper(input core.Wrapper) *MediaStreamAudioDestinationNode {
+	return MediaStreamAudioDestinationNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamAudioDestinationNode(context *AudioContext, options *AudioNodeOptions) (_result *MediaStreamAudioDestinationNode) {
@@ -5326,15 +5383,19 @@ type MediaStreamAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaStreamAudioSourceNodeFromJS is casting a js.Wrapper into MediaStreamAudioSourceNode.
-func MediaStreamAudioSourceNodeFromJS(value js.Wrapper) *MediaStreamAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamAudioSourceNodeFromJS is casting a js.Value into MediaStreamAudioSourceNode.
+func MediaStreamAudioSourceNodeFromJS(value js.Value) *MediaStreamAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaStreamAudioSourceNode.
+func MediaStreamAudioSourceNodeFromWrapper(input core.Wrapper) *MediaStreamAudioSourceNode {
+	return MediaStreamAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamAudioSourceNode(context *AudioContext, options *MediaStreamAudioSourceOptions) (_result *MediaStreamAudioSourceNode) {
@@ -5372,15 +5433,19 @@ type MediaStreamTrackAudioSourceNode struct {
 	AudioNode
 }
 
-// MediaStreamTrackAudioSourceNodeFromJS is casting a js.Wrapper into MediaStreamTrackAudioSourceNode.
-func MediaStreamTrackAudioSourceNodeFromJS(value js.Wrapper) *MediaStreamTrackAudioSourceNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackAudioSourceNodeFromJS is casting a js.Value into MediaStreamTrackAudioSourceNode.
+func MediaStreamTrackAudioSourceNodeFromJS(value js.Value) *MediaStreamTrackAudioSourceNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrackAudioSourceNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackAudioSourceNodeFromJS is casting from something that holds a js.Value into MediaStreamTrackAudioSourceNode.
+func MediaStreamTrackAudioSourceNodeFromWrapper(input core.Wrapper) *MediaStreamTrackAudioSourceNode {
+	return MediaStreamTrackAudioSourceNodeFromJS(input.JSValue())
 }
 
 func NewMediaStreamTrackAudioSourceNode(context *AudioContext, options *MediaStreamTrackAudioSourceOptions) (_result *MediaStreamTrackAudioSourceNode) {
@@ -5409,15 +5474,19 @@ type OfflineAudioCompletionEvent struct {
 	domcore.Event
 }
 
-// OfflineAudioCompletionEventFromJS is casting a js.Wrapper into OfflineAudioCompletionEvent.
-func OfflineAudioCompletionEventFromJS(value js.Wrapper) *OfflineAudioCompletionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OfflineAudioCompletionEventFromJS is casting a js.Value into OfflineAudioCompletionEvent.
+func OfflineAudioCompletionEventFromJS(value js.Value) *OfflineAudioCompletionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OfflineAudioCompletionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OfflineAudioCompletionEventFromJS is casting from something that holds a js.Value into OfflineAudioCompletionEvent.
+func OfflineAudioCompletionEventFromWrapper(input core.Wrapper) *OfflineAudioCompletionEvent {
+	return OfflineAudioCompletionEventFromJS(input.JSValue())
 }
 
 func NewOfflineAudioCompletionEvent(_type string, eventInitDict *OfflineAudioCompletionEventInit) (_result *OfflineAudioCompletionEvent) {
@@ -5455,15 +5524,19 @@ type OfflineAudioContext struct {
 	BaseAudioContext
 }
 
-// OfflineAudioContextFromJS is casting a js.Wrapper into OfflineAudioContext.
-func OfflineAudioContextFromJS(value js.Wrapper) *OfflineAudioContext {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OfflineAudioContextFromJS is casting a js.Value into OfflineAudioContext.
+func OfflineAudioContextFromJS(value js.Value) *OfflineAudioContext {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OfflineAudioContext{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OfflineAudioContextFromJS is casting from something that holds a js.Value into OfflineAudioContext.
+func OfflineAudioContextFromWrapper(input core.Wrapper) *OfflineAudioContext {
+	return OfflineAudioContextFromJS(input.JSValue())
 }
 
 func NewOfflineAudioContext(numberOfChannels uint, length uint, sampleRate float32) (_result *OfflineAudioContext) {
@@ -5590,15 +5663,19 @@ type OscillatorNode struct {
 	AudioScheduledSourceNode
 }
 
-// OscillatorNodeFromJS is casting a js.Wrapper into OscillatorNode.
-func OscillatorNodeFromJS(value js.Wrapper) *OscillatorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OscillatorNodeFromJS is casting a js.Value into OscillatorNode.
+func OscillatorNodeFromJS(value js.Value) *OscillatorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OscillatorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OscillatorNodeFromJS is casting from something that holds a js.Value into OscillatorNode.
+func OscillatorNodeFromWrapper(input core.Wrapper) *OscillatorNode {
+	return OscillatorNodeFromJS(input.JSValue())
 }
 
 func NewOscillatorNode(context *BaseAudioContext, options *OscillatorOptions) (_result *OscillatorNode) {
@@ -5675,15 +5752,19 @@ type PannerNode struct {
 	AudioNode
 }
 
-// PannerNodeFromJS is casting a js.Wrapper into PannerNode.
-func PannerNodeFromJS(value js.Wrapper) *PannerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PannerNodeFromJS is casting a js.Value into PannerNode.
+func PannerNodeFromJS(value js.Value) *PannerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PannerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PannerNodeFromJS is casting from something that holds a js.Value into PannerNode.
+func PannerNodeFromWrapper(input core.Wrapper) *PannerNode {
+	return PannerNodeFromJS(input.JSValue())
 }
 
 func NewPannerNode(context *BaseAudioContext, options *PannerOptions) (_result *PannerNode) {
@@ -5937,15 +6018,19 @@ func (_this *PeriodicWave) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PeriodicWaveFromJS is casting a js.Wrapper into PeriodicWave.
-func PeriodicWaveFromJS(value js.Wrapper) *PeriodicWave {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeriodicWaveFromJS is casting a js.Value into PeriodicWave.
+func PeriodicWaveFromJS(value js.Value) *PeriodicWave {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeriodicWave{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeriodicWaveFromJS is casting from something that holds a js.Value into PeriodicWave.
+func PeriodicWaveFromWrapper(input core.Wrapper) *PeriodicWave {
+	return PeriodicWaveFromJS(input.JSValue())
 }
 
 func NewPeriodicWave(context *BaseAudioContext, options *PeriodicWaveOptions) (_result *PeriodicWave) {
@@ -5981,15 +6066,19 @@ func (_this *PromiseAudioBuffer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAudioBufferFromJS is casting a js.Wrapper into PromiseAudioBuffer.
-func PromiseAudioBufferFromJS(value js.Wrapper) *PromiseAudioBuffer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAudioBufferFromJS is casting a js.Value into PromiseAudioBuffer.
+func PromiseAudioBufferFromJS(value js.Value) *PromiseAudioBuffer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAudioBuffer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAudioBufferFromJS is casting from something that holds a js.Value into PromiseAudioBuffer.
+func PromiseAudioBufferFromWrapper(input core.Wrapper) *PromiseAudioBuffer {
+	return PromiseAudioBufferFromJS(input.JSValue())
 }
 
 func (_this *PromiseAudioBuffer) Then(onFulfilled *PromiseAudioBufferOnFulfilled, onRejected *PromiseAudioBufferOnRejected) (_result *PromiseAudioBuffer) {
@@ -6081,15 +6170,19 @@ type ScriptProcessorNode struct {
 	AudioNode
 }
 
-// ScriptProcessorNodeFromJS is casting a js.Wrapper into ScriptProcessorNode.
-func ScriptProcessorNodeFromJS(value js.Wrapper) *ScriptProcessorNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScriptProcessorNodeFromJS is casting a js.Value into ScriptProcessorNode.
+func ScriptProcessorNodeFromJS(value js.Value) *ScriptProcessorNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScriptProcessorNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScriptProcessorNodeFromJS is casting from something that holds a js.Value into ScriptProcessorNode.
+func ScriptProcessorNodeFromWrapper(input core.Wrapper) *ScriptProcessorNode {
+	return ScriptProcessorNodeFromJS(input.JSValue())
 }
 
 // OnAudioProcess returning attribute 'onaudioprocess' with
@@ -6147,15 +6240,19 @@ type StereoPannerNode struct {
 	AudioNode
 }
 
-// StereoPannerNodeFromJS is casting a js.Wrapper into StereoPannerNode.
-func StereoPannerNodeFromJS(value js.Wrapper) *StereoPannerNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StereoPannerNodeFromJS is casting a js.Value into StereoPannerNode.
+func StereoPannerNodeFromJS(value js.Value) *StereoPannerNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StereoPannerNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StereoPannerNodeFromJS is casting from something that holds a js.Value into StereoPannerNode.
+func StereoPannerNodeFromWrapper(input core.Wrapper) *StereoPannerNode {
+	return StereoPannerNodeFromJS(input.JSValue())
 }
 
 func NewStereoPannerNode(context *BaseAudioContext, options *StereoPannerOptions) (_result *StereoPannerNode) {
@@ -6195,15 +6292,19 @@ type WaveShaperNode struct {
 	AudioNode
 }
 
-// WaveShaperNodeFromJS is casting a js.Wrapper into WaveShaperNode.
-func WaveShaperNodeFromJS(value js.Wrapper) *WaveShaperNode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WaveShaperNodeFromJS is casting a js.Value into WaveShaperNode.
+func WaveShaperNodeFromJS(value js.Value) *WaveShaperNode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WaveShaperNode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WaveShaperNodeFromJS is casting from something that holds a js.Value into WaveShaperNode.
+func WaveShaperNodeFromWrapper(input core.Wrapper) *WaveShaperNode {
+	return WaveShaperNodeFromJS(input.JSValue())
 }
 
 func NewWaveShaperNode(context *BaseAudioContext, options *WaveShaperOptions) (_result *WaveShaperNode) {

--- a/media/capabilities/capabilities.go
+++ b/media/capabilities/capabilities.go
@@ -7,6 +7,7 @@ package capabilities
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/media/encrypted"
 )
@@ -336,7 +337,7 @@ type AudioConfiguration struct {
 	Samplerate  uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -352,10 +353,8 @@ func (_this *AudioConfiguration) JSValue() js.Value {
 }
 
 // AudioConfigurationFromJS is allocating a new
-// AudioConfiguration object and copy all values from
-// input javascript object
-func AudioConfigurationFromJS(value js.Wrapper) *AudioConfiguration {
-	input := value.JSValue()
+// AudioConfiguration object and copy all values in the value javascript object.
+func AudioConfigurationFromJS(value js.Value) *AudioConfiguration {
 	var out AudioConfiguration
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
@@ -363,13 +362,13 @@ func AudioConfigurationFromJS(value js.Wrapper) *AudioConfiguration {
 		value2 int    // javascript: unsigned long long {bitrate Bitrate bitrate}
 		value3 uint   // javascript: unsigned long {samplerate Samplerate samplerate}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (input.Get("channels")).String()
+	value1 = (value.Get("channels")).String()
 	out.Channels = value1
-	value2 = (input.Get("bitrate")).Int()
+	value2 = (value.Get("bitrate")).Int()
 	out.Bitrate = value2
-	value3 = (uint)((input.Get("samplerate")).Int())
+	value3 = (uint)((value.Get("samplerate")).Int())
 	out.Samplerate = value3
 	return &out
 }
@@ -382,7 +381,7 @@ type MediaCapabilitiesDecodingInfo struct {
 	KeySystemAccess *encrypted.MediaKeySystemAccess
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesDecodingInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -398,10 +397,8 @@ func (_this *MediaCapabilitiesDecodingInfo) JSValue() js.Value {
 }
 
 // MediaCapabilitiesDecodingInfoFromJS is allocating a new
-// MediaCapabilitiesDecodingInfo object and copy all values from
-// input javascript object
-func MediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *MediaCapabilitiesDecodingInfo {
-	input := value.JSValue()
+// MediaCapabilitiesDecodingInfo object and copy all values in the value javascript object.
+func MediaCapabilitiesDecodingInfoFromJS(value js.Value) *MediaCapabilitiesDecodingInfo {
 	var out MediaCapabilitiesDecodingInfo
 	var (
 		value0 bool                            // javascript: boolean {supported Supported supported}
@@ -409,13 +406,13 @@ func MediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *MediaCapabilitiesDec
 		value2 bool                            // javascript: boolean {powerEfficient PowerEfficient powerEfficient}
 		value3 *encrypted.MediaKeySystemAccess // javascript: MediaKeySystemAccess {keySystemAccess KeySystemAccess keySystemAccess}
 	)
-	value0 = (input.Get("supported")).Bool()
+	value0 = (value.Get("supported")).Bool()
 	out.Supported = value0
-	value1 = (input.Get("smooth")).Bool()
+	value1 = (value.Get("smooth")).Bool()
 	out.Smooth = value1
-	value2 = (input.Get("powerEfficient")).Bool()
+	value2 = (value.Get("powerEfficient")).Bool()
 	out.PowerEfficient = value2
-	value3 = encrypted.MediaKeySystemAccessFromJS(input.Get("keySystemAccess"))
+	value3 = encrypted.MediaKeySystemAccessFromJS(value.Get("keySystemAccess"))
 	out.KeySystemAccess = value3
 	return &out
 }
@@ -427,7 +424,7 @@ type MediaCapabilitiesInfo struct {
 	PowerEfficient bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -441,21 +438,19 @@ func (_this *MediaCapabilitiesInfo) JSValue() js.Value {
 }
 
 // MediaCapabilitiesInfoFromJS is allocating a new
-// MediaCapabilitiesInfo object and copy all values from
-// input javascript object
-func MediaCapabilitiesInfoFromJS(value js.Wrapper) *MediaCapabilitiesInfo {
-	input := value.JSValue()
+// MediaCapabilitiesInfo object and copy all values in the value javascript object.
+func MediaCapabilitiesInfoFromJS(value js.Value) *MediaCapabilitiesInfo {
 	var out MediaCapabilitiesInfo
 	var (
 		value0 bool // javascript: boolean {supported Supported supported}
 		value1 bool // javascript: boolean {smooth Smooth smooth}
 		value2 bool // javascript: boolean {powerEfficient PowerEfficient powerEfficient}
 	)
-	value0 = (input.Get("supported")).Bool()
+	value0 = (value.Get("supported")).Bool()
 	out.Supported = value0
-	value1 = (input.Get("smooth")).Bool()
+	value1 = (value.Get("smooth")).Bool()
 	out.Smooth = value1
-	value2 = (input.Get("powerEfficient")).Bool()
+	value2 = (value.Get("powerEfficient")).Bool()
 	out.PowerEfficient = value2
 	return &out
 }
@@ -471,7 +466,7 @@ type MediaCapabilitiesKeySystemConfiguration struct {
 	SessionTypes          []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesKeySystemConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -497,10 +492,8 @@ func (_this *MediaCapabilitiesKeySystemConfiguration) JSValue() js.Value {
 }
 
 // MediaCapabilitiesKeySystemConfigurationFromJS is allocating a new
-// MediaCapabilitiesKeySystemConfiguration object and copy all values from
-// input javascript object
-func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Wrapper) *MediaCapabilitiesKeySystemConfiguration {
-	input := value.JSValue()
+// MediaCapabilitiesKeySystemConfiguration object and copy all values in the value javascript object.
+func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Value) *MediaCapabilitiesKeySystemConfiguration {
 	var out MediaCapabilitiesKeySystemConfiguration
 	var (
 		value0 string                         // javascript: DOMString {keySystem KeySystem keySystem}
@@ -511,23 +504,23 @@ func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Wrapper) *MediaCapab
 		value5 encrypted.MediaKeysRequirement // javascript: MediaKeysRequirement {persistentState PersistentState persistentState}
 		value6 []string                       // javascript: sequence<DOMString> {sessionTypes SessionTypes sessionTypes}
 	)
-	value0 = (input.Get("keySystem")).String()
+	value0 = (value.Get("keySystem")).String()
 	out.KeySystem = value0
-	value1 = (input.Get("initDataType")).String()
+	value1 = (value.Get("initDataType")).String()
 	out.InitDataType = value1
-	value2 = (input.Get("audioRobustness")).String()
+	value2 = (value.Get("audioRobustness")).String()
 	out.AudioRobustness = value2
-	value3 = (input.Get("videoRobustness")).String()
+	value3 = (value.Get("videoRobustness")).String()
 	out.VideoRobustness = value3
-	value4 = encrypted.MediaKeysRequirementFromJS(input.Get("distinctiveIdentifier"))
+	value4 = encrypted.MediaKeysRequirementFromJS(value.Get("distinctiveIdentifier"))
 	out.DistinctiveIdentifier = value4
-	value5 = encrypted.MediaKeysRequirementFromJS(input.Get("persistentState"))
+	value5 = encrypted.MediaKeysRequirementFromJS(value.Get("persistentState"))
 	out.PersistentState = value5
-	__length6 := input.Get("sessionTypes").Length()
+	__length6 := value.Get("sessionTypes").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("sessionTypes").Index(__idx6)
+		__seq_in6 := value.Get("sessionTypes").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -542,7 +535,7 @@ type MediaConfiguration struct {
 	Audio *AudioConfiguration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -554,18 +547,16 @@ func (_this *MediaConfiguration) JSValue() js.Value {
 }
 
 // MediaConfigurationFromJS is allocating a new
-// MediaConfiguration object and copy all values from
-// input javascript object
-func MediaConfigurationFromJS(value js.Wrapper) *MediaConfiguration {
-	input := value.JSValue()
+// MediaConfiguration object and copy all values in the value javascript object.
+func MediaConfigurationFromJS(value js.Value) *MediaConfiguration {
 	var out MediaConfiguration
 	var (
 		value0 *VideoConfiguration // javascript: VideoConfiguration {video Video video}
 		value1 *AudioConfiguration // javascript: AudioConfiguration {audio Audio audio}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }
@@ -578,7 +569,7 @@ type MediaDecodingConfiguration struct {
 	KeySystemConfiguration *MediaCapabilitiesKeySystemConfiguration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaDecodingConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -594,10 +585,8 @@ func (_this *MediaDecodingConfiguration) JSValue() js.Value {
 }
 
 // MediaDecodingConfigurationFromJS is allocating a new
-// MediaDecodingConfiguration object and copy all values from
-// input javascript object
-func MediaDecodingConfigurationFromJS(value js.Wrapper) *MediaDecodingConfiguration {
-	input := value.JSValue()
+// MediaDecodingConfiguration object and copy all values in the value javascript object.
+func MediaDecodingConfigurationFromJS(value js.Value) *MediaDecodingConfiguration {
 	var out MediaDecodingConfiguration
 	var (
 		value0 *VideoConfiguration                      // javascript: VideoConfiguration {video Video video}
@@ -605,13 +594,13 @@ func MediaDecodingConfigurationFromJS(value js.Wrapper) *MediaDecodingConfigurat
 		value2 MediaDecodingType                        // javascript: MediaDecodingType {type Type _type}
 		value3 *MediaCapabilitiesKeySystemConfiguration // javascript: MediaCapabilitiesKeySystemConfiguration {keySystemConfiguration KeySystemConfiguration keySystemConfiguration}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
-	value2 = MediaDecodingTypeFromJS(input.Get("type"))
+	value2 = MediaDecodingTypeFromJS(value.Get("type"))
 	out.Type = value2
-	value3 = MediaCapabilitiesKeySystemConfigurationFromJS(input.Get("keySystemConfiguration"))
+	value3 = MediaCapabilitiesKeySystemConfigurationFromJS(value.Get("keySystemConfiguration"))
 	out.KeySystemConfiguration = value3
 	return &out
 }
@@ -623,7 +612,7 @@ type MediaEncodingConfiguration struct {
 	Type  MediaEncodingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaEncodingConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -637,21 +626,19 @@ func (_this *MediaEncodingConfiguration) JSValue() js.Value {
 }
 
 // MediaEncodingConfigurationFromJS is allocating a new
-// MediaEncodingConfiguration object and copy all values from
-// input javascript object
-func MediaEncodingConfigurationFromJS(value js.Wrapper) *MediaEncodingConfiguration {
-	input := value.JSValue()
+// MediaEncodingConfiguration object and copy all values in the value javascript object.
+func MediaEncodingConfigurationFromJS(value js.Value) *MediaEncodingConfiguration {
 	var out MediaEncodingConfiguration
 	var (
 		value0 *VideoConfiguration // javascript: VideoConfiguration {video Video video}
 		value1 *AudioConfiguration // javascript: AudioConfiguration {audio Audio audio}
 		value2 MediaEncodingType   // javascript: MediaEncodingType {type Type _type}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
-	value2 = MediaEncodingTypeFromJS(input.Get("type"))
+	value2 = MediaEncodingTypeFromJS(value.Get("type"))
 	out.Type = value2
 	return &out
 }
@@ -665,7 +652,7 @@ type VideoConfiguration struct {
 	Framerate   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -683,10 +670,8 @@ func (_this *VideoConfiguration) JSValue() js.Value {
 }
 
 // VideoConfigurationFromJS is allocating a new
-// VideoConfiguration object and copy all values from
-// input javascript object
-func VideoConfigurationFromJS(value js.Wrapper) *VideoConfiguration {
-	input := value.JSValue()
+// VideoConfiguration object and copy all values in the value javascript object.
+func VideoConfigurationFromJS(value js.Value) *VideoConfiguration {
 	var out VideoConfiguration
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
@@ -695,15 +680,15 @@ func VideoConfigurationFromJS(value js.Wrapper) *VideoConfiguration {
 		value3 int    // javascript: unsigned long long {bitrate Bitrate bitrate}
 		value4 string // javascript: DOMString {framerate Framerate framerate}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (uint)((input.Get("width")).Int())
+	value1 = (uint)((value.Get("width")).Int())
 	out.Width = value1
-	value2 = (uint)((input.Get("height")).Int())
+	value2 = (uint)((value.Get("height")).Int())
 	out.Height = value2
-	value3 = (input.Get("bitrate")).Int()
+	value3 = (value.Get("bitrate")).Int()
 	out.Bitrate = value3
-	value4 = (input.Get("framerate")).String()
+	value4 = (value.Get("framerate")).String()
 	out.Framerate = value4
 	return &out
 }
@@ -718,15 +703,19 @@ func (_this *MediaCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaCapabilitiesFromJS is casting a js.Wrapper into MediaCapabilities.
-func MediaCapabilitiesFromJS(value js.Wrapper) *MediaCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaCapabilitiesFromJS is casting a js.Value into MediaCapabilities.
+func MediaCapabilitiesFromJS(value js.Value) *MediaCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaCapabilitiesFromJS is casting from something that holds a js.Value into MediaCapabilities.
+func MediaCapabilitiesFromWrapper(input core.Wrapper) *MediaCapabilities {
+	return MediaCapabilitiesFromJS(input.JSValue())
 }
 
 func (_this *MediaCapabilities) DecodingInfo(configuration *MediaDecodingConfiguration) (_result *PromiseMediaCapabilitiesDecodingInfo) {
@@ -773,15 +762,19 @@ func (_this *PromiseMediaCapabilitiesDecodingInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaCapabilitiesDecodingInfoFromJS is casting a js.Wrapper into PromiseMediaCapabilitiesDecodingInfo.
-func PromiseMediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *PromiseMediaCapabilitiesDecodingInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaCapabilitiesDecodingInfoFromJS is casting a js.Value into PromiseMediaCapabilitiesDecodingInfo.
+func PromiseMediaCapabilitiesDecodingInfoFromJS(value js.Value) *PromiseMediaCapabilitiesDecodingInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaCapabilitiesDecodingInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaCapabilitiesDecodingInfoFromJS is casting from something that holds a js.Value into PromiseMediaCapabilitiesDecodingInfo.
+func PromiseMediaCapabilitiesDecodingInfoFromWrapper(input core.Wrapper) *PromiseMediaCapabilitiesDecodingInfo {
+	return PromiseMediaCapabilitiesDecodingInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaCapabilitiesDecodingInfo) Then(onFulfilled *PromiseMediaCapabilitiesDecodingInfoOnFulfilled, onRejected *PromiseMediaCapabilitiesDecodingInfoOnRejected) (_result *PromiseMediaCapabilitiesDecodingInfo) {
@@ -878,15 +871,19 @@ func (_this *PromiseMediaCapabilitiesInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaCapabilitiesInfoFromJS is casting a js.Wrapper into PromiseMediaCapabilitiesInfo.
-func PromiseMediaCapabilitiesInfoFromJS(value js.Wrapper) *PromiseMediaCapabilitiesInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaCapabilitiesInfoFromJS is casting a js.Value into PromiseMediaCapabilitiesInfo.
+func PromiseMediaCapabilitiesInfoFromJS(value js.Value) *PromiseMediaCapabilitiesInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaCapabilitiesInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaCapabilitiesInfoFromJS is casting from something that holds a js.Value into PromiseMediaCapabilitiesInfo.
+func PromiseMediaCapabilitiesInfoFromWrapper(input core.Wrapper) *PromiseMediaCapabilitiesInfo {
+	return PromiseMediaCapabilitiesInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaCapabilitiesInfo) Then(onFulfilled *PromiseMediaCapabilitiesInfoOnFulfilled, onRejected *PromiseMediaCapabilitiesInfoOnRejected) (_result *PromiseMediaCapabilitiesInfo) {
@@ -983,15 +980,19 @@ func (_this *ScreenLuminance) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ScreenLuminanceFromJS is casting a js.Wrapper into ScreenLuminance.
-func ScreenLuminanceFromJS(value js.Wrapper) *ScreenLuminance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenLuminanceFromJS is casting a js.Value into ScreenLuminance.
+func ScreenLuminanceFromJS(value js.Value) *ScreenLuminance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScreenLuminance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenLuminanceFromJS is casting from something that holds a js.Value into ScreenLuminance.
+func ScreenLuminanceFromWrapper(input core.Wrapper) *ScreenLuminance {
+	return ScreenLuminanceFromJS(input.JSValue())
 }
 
 // Min returning attribute 'min' with

--- a/media/capabilities/capabilities_js.go
+++ b/media/capabilities/capabilities_js.go
@@ -5,6 +5,7 @@ package capabilities
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/media/encrypted"
 )
@@ -334,7 +335,7 @@ type AudioConfiguration struct {
 	Samplerate  uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -350,10 +351,8 @@ func (_this *AudioConfiguration) JSValue() js.Value {
 }
 
 // AudioConfigurationFromJS is allocating a new
-// AudioConfiguration object and copy all values from
-// input javascript object
-func AudioConfigurationFromJS(value js.Wrapper) *AudioConfiguration {
-	input := value.JSValue()
+// AudioConfiguration object and copy all values in the value javascript object.
+func AudioConfigurationFromJS(value js.Value) *AudioConfiguration {
 	var out AudioConfiguration
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
@@ -361,13 +360,13 @@ func AudioConfigurationFromJS(value js.Wrapper) *AudioConfiguration {
 		value2 int    // javascript: unsigned long long {bitrate Bitrate bitrate}
 		value3 uint   // javascript: unsigned long {samplerate Samplerate samplerate}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (input.Get("channels")).String()
+	value1 = (value.Get("channels")).String()
 	out.Channels = value1
-	value2 = (input.Get("bitrate")).Int()
+	value2 = (value.Get("bitrate")).Int()
 	out.Bitrate = value2
-	value3 = (uint)((input.Get("samplerate")).Int())
+	value3 = (uint)((value.Get("samplerate")).Int())
 	out.Samplerate = value3
 	return &out
 }
@@ -380,7 +379,7 @@ type MediaCapabilitiesDecodingInfo struct {
 	KeySystemAccess *encrypted.MediaKeySystemAccess
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesDecodingInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -396,10 +395,8 @@ func (_this *MediaCapabilitiesDecodingInfo) JSValue() js.Value {
 }
 
 // MediaCapabilitiesDecodingInfoFromJS is allocating a new
-// MediaCapabilitiesDecodingInfo object and copy all values from
-// input javascript object
-func MediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *MediaCapabilitiesDecodingInfo {
-	input := value.JSValue()
+// MediaCapabilitiesDecodingInfo object and copy all values in the value javascript object.
+func MediaCapabilitiesDecodingInfoFromJS(value js.Value) *MediaCapabilitiesDecodingInfo {
 	var out MediaCapabilitiesDecodingInfo
 	var (
 		value0 bool                            // javascript: boolean {supported Supported supported}
@@ -407,13 +404,13 @@ func MediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *MediaCapabilitiesDec
 		value2 bool                            // javascript: boolean {powerEfficient PowerEfficient powerEfficient}
 		value3 *encrypted.MediaKeySystemAccess // javascript: MediaKeySystemAccess {keySystemAccess KeySystemAccess keySystemAccess}
 	)
-	value0 = (input.Get("supported")).Bool()
+	value0 = (value.Get("supported")).Bool()
 	out.Supported = value0
-	value1 = (input.Get("smooth")).Bool()
+	value1 = (value.Get("smooth")).Bool()
 	out.Smooth = value1
-	value2 = (input.Get("powerEfficient")).Bool()
+	value2 = (value.Get("powerEfficient")).Bool()
 	out.PowerEfficient = value2
-	value3 = encrypted.MediaKeySystemAccessFromJS(input.Get("keySystemAccess"))
+	value3 = encrypted.MediaKeySystemAccessFromJS(value.Get("keySystemAccess"))
 	out.KeySystemAccess = value3
 	return &out
 }
@@ -425,7 +422,7 @@ type MediaCapabilitiesInfo struct {
 	PowerEfficient bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesInfo) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -439,21 +436,19 @@ func (_this *MediaCapabilitiesInfo) JSValue() js.Value {
 }
 
 // MediaCapabilitiesInfoFromJS is allocating a new
-// MediaCapabilitiesInfo object and copy all values from
-// input javascript object
-func MediaCapabilitiesInfoFromJS(value js.Wrapper) *MediaCapabilitiesInfo {
-	input := value.JSValue()
+// MediaCapabilitiesInfo object and copy all values in the value javascript object.
+func MediaCapabilitiesInfoFromJS(value js.Value) *MediaCapabilitiesInfo {
 	var out MediaCapabilitiesInfo
 	var (
 		value0 bool // javascript: boolean {supported Supported supported}
 		value1 bool // javascript: boolean {smooth Smooth smooth}
 		value2 bool // javascript: boolean {powerEfficient PowerEfficient powerEfficient}
 	)
-	value0 = (input.Get("supported")).Bool()
+	value0 = (value.Get("supported")).Bool()
 	out.Supported = value0
-	value1 = (input.Get("smooth")).Bool()
+	value1 = (value.Get("smooth")).Bool()
 	out.Smooth = value1
-	value2 = (input.Get("powerEfficient")).Bool()
+	value2 = (value.Get("powerEfficient")).Bool()
 	out.PowerEfficient = value2
 	return &out
 }
@@ -469,7 +464,7 @@ type MediaCapabilitiesKeySystemConfiguration struct {
 	SessionTypes          []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaCapabilitiesKeySystemConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -495,10 +490,8 @@ func (_this *MediaCapabilitiesKeySystemConfiguration) JSValue() js.Value {
 }
 
 // MediaCapabilitiesKeySystemConfigurationFromJS is allocating a new
-// MediaCapabilitiesKeySystemConfiguration object and copy all values from
-// input javascript object
-func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Wrapper) *MediaCapabilitiesKeySystemConfiguration {
-	input := value.JSValue()
+// MediaCapabilitiesKeySystemConfiguration object and copy all values in the value javascript object.
+func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Value) *MediaCapabilitiesKeySystemConfiguration {
 	var out MediaCapabilitiesKeySystemConfiguration
 	var (
 		value0 string                         // javascript: DOMString {keySystem KeySystem keySystem}
@@ -509,23 +502,23 @@ func MediaCapabilitiesKeySystemConfigurationFromJS(value js.Wrapper) *MediaCapab
 		value5 encrypted.MediaKeysRequirement // javascript: MediaKeysRequirement {persistentState PersistentState persistentState}
 		value6 []string                       // javascript: sequence<DOMString> {sessionTypes SessionTypes sessionTypes}
 	)
-	value0 = (input.Get("keySystem")).String()
+	value0 = (value.Get("keySystem")).String()
 	out.KeySystem = value0
-	value1 = (input.Get("initDataType")).String()
+	value1 = (value.Get("initDataType")).String()
 	out.InitDataType = value1
-	value2 = (input.Get("audioRobustness")).String()
+	value2 = (value.Get("audioRobustness")).String()
 	out.AudioRobustness = value2
-	value3 = (input.Get("videoRobustness")).String()
+	value3 = (value.Get("videoRobustness")).String()
 	out.VideoRobustness = value3
-	value4 = encrypted.MediaKeysRequirementFromJS(input.Get("distinctiveIdentifier"))
+	value4 = encrypted.MediaKeysRequirementFromJS(value.Get("distinctiveIdentifier"))
 	out.DistinctiveIdentifier = value4
-	value5 = encrypted.MediaKeysRequirementFromJS(input.Get("persistentState"))
+	value5 = encrypted.MediaKeysRequirementFromJS(value.Get("persistentState"))
 	out.PersistentState = value5
-	__length6 := input.Get("sessionTypes").Length()
+	__length6 := value.Get("sessionTypes").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("sessionTypes").Index(__idx6)
+		__seq_in6 := value.Get("sessionTypes").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -540,7 +533,7 @@ type MediaConfiguration struct {
 	Audio *AudioConfiguration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -552,18 +545,16 @@ func (_this *MediaConfiguration) JSValue() js.Value {
 }
 
 // MediaConfigurationFromJS is allocating a new
-// MediaConfiguration object and copy all values from
-// input javascript object
-func MediaConfigurationFromJS(value js.Wrapper) *MediaConfiguration {
-	input := value.JSValue()
+// MediaConfiguration object and copy all values in the value javascript object.
+func MediaConfigurationFromJS(value js.Value) *MediaConfiguration {
 	var out MediaConfiguration
 	var (
 		value0 *VideoConfiguration // javascript: VideoConfiguration {video Video video}
 		value1 *AudioConfiguration // javascript: AudioConfiguration {audio Audio audio}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }
@@ -576,7 +567,7 @@ type MediaDecodingConfiguration struct {
 	KeySystemConfiguration *MediaCapabilitiesKeySystemConfiguration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaDecodingConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -592,10 +583,8 @@ func (_this *MediaDecodingConfiguration) JSValue() js.Value {
 }
 
 // MediaDecodingConfigurationFromJS is allocating a new
-// MediaDecodingConfiguration object and copy all values from
-// input javascript object
-func MediaDecodingConfigurationFromJS(value js.Wrapper) *MediaDecodingConfiguration {
-	input := value.JSValue()
+// MediaDecodingConfiguration object and copy all values in the value javascript object.
+func MediaDecodingConfigurationFromJS(value js.Value) *MediaDecodingConfiguration {
 	var out MediaDecodingConfiguration
 	var (
 		value0 *VideoConfiguration                      // javascript: VideoConfiguration {video Video video}
@@ -603,13 +592,13 @@ func MediaDecodingConfigurationFromJS(value js.Wrapper) *MediaDecodingConfigurat
 		value2 MediaDecodingType                        // javascript: MediaDecodingType {type Type _type}
 		value3 *MediaCapabilitiesKeySystemConfiguration // javascript: MediaCapabilitiesKeySystemConfiguration {keySystemConfiguration KeySystemConfiguration keySystemConfiguration}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
-	value2 = MediaDecodingTypeFromJS(input.Get("type"))
+	value2 = MediaDecodingTypeFromJS(value.Get("type"))
 	out.Type = value2
-	value3 = MediaCapabilitiesKeySystemConfigurationFromJS(input.Get("keySystemConfiguration"))
+	value3 = MediaCapabilitiesKeySystemConfigurationFromJS(value.Get("keySystemConfiguration"))
 	out.KeySystemConfiguration = value3
 	return &out
 }
@@ -621,7 +610,7 @@ type MediaEncodingConfiguration struct {
 	Type  MediaEncodingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaEncodingConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -635,21 +624,19 @@ func (_this *MediaEncodingConfiguration) JSValue() js.Value {
 }
 
 // MediaEncodingConfigurationFromJS is allocating a new
-// MediaEncodingConfiguration object and copy all values from
-// input javascript object
-func MediaEncodingConfigurationFromJS(value js.Wrapper) *MediaEncodingConfiguration {
-	input := value.JSValue()
+// MediaEncodingConfiguration object and copy all values in the value javascript object.
+func MediaEncodingConfigurationFromJS(value js.Value) *MediaEncodingConfiguration {
 	var out MediaEncodingConfiguration
 	var (
 		value0 *VideoConfiguration // javascript: VideoConfiguration {video Video video}
 		value1 *AudioConfiguration // javascript: AudioConfiguration {audio Audio audio}
 		value2 MediaEncodingType   // javascript: MediaEncodingType {type Type _type}
 	)
-	value0 = VideoConfigurationFromJS(input.Get("video"))
+	value0 = VideoConfigurationFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = AudioConfigurationFromJS(input.Get("audio"))
+	value1 = AudioConfigurationFromJS(value.Get("audio"))
 	out.Audio = value1
-	value2 = MediaEncodingTypeFromJS(input.Get("type"))
+	value2 = MediaEncodingTypeFromJS(value.Get("type"))
 	out.Type = value2
 	return &out
 }
@@ -663,7 +650,7 @@ type VideoConfiguration struct {
 	Framerate   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -681,10 +668,8 @@ func (_this *VideoConfiguration) JSValue() js.Value {
 }
 
 // VideoConfigurationFromJS is allocating a new
-// VideoConfiguration object and copy all values from
-// input javascript object
-func VideoConfigurationFromJS(value js.Wrapper) *VideoConfiguration {
-	input := value.JSValue()
+// VideoConfiguration object and copy all values in the value javascript object.
+func VideoConfigurationFromJS(value js.Value) *VideoConfiguration {
 	var out VideoConfiguration
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
@@ -693,15 +678,15 @@ func VideoConfigurationFromJS(value js.Wrapper) *VideoConfiguration {
 		value3 int    // javascript: unsigned long long {bitrate Bitrate bitrate}
 		value4 string // javascript: DOMString {framerate Framerate framerate}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (uint)((input.Get("width")).Int())
+	value1 = (uint)((value.Get("width")).Int())
 	out.Width = value1
-	value2 = (uint)((input.Get("height")).Int())
+	value2 = (uint)((value.Get("height")).Int())
 	out.Height = value2
-	value3 = (input.Get("bitrate")).Int()
+	value3 = (value.Get("bitrate")).Int()
 	out.Bitrate = value3
-	value4 = (input.Get("framerate")).String()
+	value4 = (value.Get("framerate")).String()
 	out.Framerate = value4
 	return &out
 }
@@ -716,15 +701,19 @@ func (_this *MediaCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaCapabilitiesFromJS is casting a js.Wrapper into MediaCapabilities.
-func MediaCapabilitiesFromJS(value js.Wrapper) *MediaCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaCapabilitiesFromJS is casting a js.Value into MediaCapabilities.
+func MediaCapabilitiesFromJS(value js.Value) *MediaCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaCapabilitiesFromJS is casting from something that holds a js.Value into MediaCapabilities.
+func MediaCapabilitiesFromWrapper(input core.Wrapper) *MediaCapabilities {
+	return MediaCapabilitiesFromJS(input.JSValue())
 }
 
 func (_this *MediaCapabilities) DecodingInfo(configuration *MediaDecodingConfiguration) (_result *PromiseMediaCapabilitiesDecodingInfo) {
@@ -771,15 +760,19 @@ func (_this *PromiseMediaCapabilitiesDecodingInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaCapabilitiesDecodingInfoFromJS is casting a js.Wrapper into PromiseMediaCapabilitiesDecodingInfo.
-func PromiseMediaCapabilitiesDecodingInfoFromJS(value js.Wrapper) *PromiseMediaCapabilitiesDecodingInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaCapabilitiesDecodingInfoFromJS is casting a js.Value into PromiseMediaCapabilitiesDecodingInfo.
+func PromiseMediaCapabilitiesDecodingInfoFromJS(value js.Value) *PromiseMediaCapabilitiesDecodingInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaCapabilitiesDecodingInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaCapabilitiesDecodingInfoFromJS is casting from something that holds a js.Value into PromiseMediaCapabilitiesDecodingInfo.
+func PromiseMediaCapabilitiesDecodingInfoFromWrapper(input core.Wrapper) *PromiseMediaCapabilitiesDecodingInfo {
+	return PromiseMediaCapabilitiesDecodingInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaCapabilitiesDecodingInfo) Then(onFulfilled *PromiseMediaCapabilitiesDecodingInfoOnFulfilled, onRejected *PromiseMediaCapabilitiesDecodingInfoOnRejected) (_result *PromiseMediaCapabilitiesDecodingInfo) {
@@ -876,15 +869,19 @@ func (_this *PromiseMediaCapabilitiesInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaCapabilitiesInfoFromJS is casting a js.Wrapper into PromiseMediaCapabilitiesInfo.
-func PromiseMediaCapabilitiesInfoFromJS(value js.Wrapper) *PromiseMediaCapabilitiesInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaCapabilitiesInfoFromJS is casting a js.Value into PromiseMediaCapabilitiesInfo.
+func PromiseMediaCapabilitiesInfoFromJS(value js.Value) *PromiseMediaCapabilitiesInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaCapabilitiesInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaCapabilitiesInfoFromJS is casting from something that holds a js.Value into PromiseMediaCapabilitiesInfo.
+func PromiseMediaCapabilitiesInfoFromWrapper(input core.Wrapper) *PromiseMediaCapabilitiesInfo {
+	return PromiseMediaCapabilitiesInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaCapabilitiesInfo) Then(onFulfilled *PromiseMediaCapabilitiesInfoOnFulfilled, onRejected *PromiseMediaCapabilitiesInfoOnRejected) (_result *PromiseMediaCapabilitiesInfo) {
@@ -981,15 +978,19 @@ func (_this *ScreenLuminance) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ScreenLuminanceFromJS is casting a js.Wrapper into ScreenLuminance.
-func ScreenLuminanceFromJS(value js.Wrapper) *ScreenLuminance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenLuminanceFromJS is casting a js.Value into ScreenLuminance.
+func ScreenLuminanceFromJS(value js.Value) *ScreenLuminance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScreenLuminance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenLuminanceFromJS is casting from something that holds a js.Value into ScreenLuminance.
+func ScreenLuminanceFromWrapper(input core.Wrapper) *ScreenLuminance {
+	return ScreenLuminanceFromJS(input.JSValue())
 }
 
 // Min returning attribute 'min' with

--- a/media/capture/depth/depth.go
+++ b/media/capture/depth/depth.go
@@ -45,7 +45,7 @@ type DistortionCoefficients struct {
 	K3 float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DistortionCoefficients) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -63,10 +63,8 @@ func (_this *DistortionCoefficients) JSValue() js.Value {
 }
 
 // DistortionCoefficientsFromJS is allocating a new
-// DistortionCoefficients object and copy all values from
-// input javascript object
-func DistortionCoefficientsFromJS(value js.Wrapper) *DistortionCoefficients {
-	input := value.JSValue()
+// DistortionCoefficients object and copy all values in the value javascript object.
+func DistortionCoefficientsFromJS(value js.Value) *DistortionCoefficients {
 	var out DistortionCoefficients
 	var (
 		value0 float64 // javascript: double {k1 K1 k1}
@@ -75,15 +73,15 @@ func DistortionCoefficientsFromJS(value js.Wrapper) *DistortionCoefficients {
 		value3 float64 // javascript: double {p2 P2 p2}
 		value4 float64 // javascript: double {k3 K3 k3}
 	)
-	value0 = (input.Get("k1")).Float()
+	value0 = (value.Get("k1")).Float()
 	out.K1 = value0
-	value1 = (input.Get("k2")).Float()
+	value1 = (value.Get("k2")).Float()
 	out.K2 = value1
-	value2 = (input.Get("p1")).Float()
+	value2 = (value.Get("p1")).Float()
 	out.P1 = value2
-	value3 = (input.Get("p2")).Float()
+	value3 = (value.Get("p2")).Float()
 	out.P2 = value3
-	value4 = (input.Get("k3")).Float()
+	value4 = (value.Get("k3")).Float()
 	out.K3 = value4
 	return &out
 }
@@ -94,7 +92,7 @@ type Transformation struct {
 	VideoDeviceId        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Transformation) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -106,18 +104,16 @@ func (_this *Transformation) JSValue() js.Value {
 }
 
 // TransformationFromJS is allocating a new
-// Transformation object and copy all values from
-// input javascript object
-func TransformationFromJS(value js.Wrapper) *Transformation {
-	input := value.JSValue()
+// Transformation object and copy all values in the value javascript object.
+func TransformationFromJS(value js.Value) *Transformation {
 	var out Transformation
 	var (
 		value0 *javascript.Float32Array // javascript: Float32Array {transformationMatrix TransformationMatrix transformationMatrix}
 		value1 string                   // javascript: DOMString {videoDeviceId VideoDeviceId videoDeviceId}
 	)
-	value0 = javascript.Float32ArrayFromJS(input.Get("transformationMatrix"))
+	value0 = javascript.Float32ArrayFromJS(value.Get("transformationMatrix"))
 	out.TransformationMatrix = value0
-	value1 = (input.Get("videoDeviceId")).String()
+	value1 = (value.Get("videoDeviceId")).String()
 	out.VideoDeviceId = value1
 	return &out
 }

--- a/media/capture/depth/depth_js.go
+++ b/media/capture/depth/depth_js.go
@@ -43,7 +43,7 @@ type DistortionCoefficients struct {
 	K3 float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DistortionCoefficients) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -61,10 +61,8 @@ func (_this *DistortionCoefficients) JSValue() js.Value {
 }
 
 // DistortionCoefficientsFromJS is allocating a new
-// DistortionCoefficients object and copy all values from
-// input javascript object
-func DistortionCoefficientsFromJS(value js.Wrapper) *DistortionCoefficients {
-	input := value.JSValue()
+// DistortionCoefficients object and copy all values in the value javascript object.
+func DistortionCoefficientsFromJS(value js.Value) *DistortionCoefficients {
 	var out DistortionCoefficients
 	var (
 		value0 float64 // javascript: double {k1 K1 k1}
@@ -73,15 +71,15 @@ func DistortionCoefficientsFromJS(value js.Wrapper) *DistortionCoefficients {
 		value3 float64 // javascript: double {p2 P2 p2}
 		value4 float64 // javascript: double {k3 K3 k3}
 	)
-	value0 = (input.Get("k1")).Float()
+	value0 = (value.Get("k1")).Float()
 	out.K1 = value0
-	value1 = (input.Get("k2")).Float()
+	value1 = (value.Get("k2")).Float()
 	out.K2 = value1
-	value2 = (input.Get("p1")).Float()
+	value2 = (value.Get("p1")).Float()
 	out.P1 = value2
-	value3 = (input.Get("p2")).Float()
+	value3 = (value.Get("p2")).Float()
 	out.P2 = value3
-	value4 = (input.Get("k3")).Float()
+	value4 = (value.Get("k3")).Float()
 	out.K3 = value4
 	return &out
 }
@@ -92,7 +90,7 @@ type Transformation struct {
 	VideoDeviceId        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Transformation) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -104,18 +102,16 @@ func (_this *Transformation) JSValue() js.Value {
 }
 
 // TransformationFromJS is allocating a new
-// Transformation object and copy all values from
-// input javascript object
-func TransformationFromJS(value js.Wrapper) *Transformation {
-	input := value.JSValue()
+// Transformation object and copy all values in the value javascript object.
+func TransformationFromJS(value js.Value) *Transformation {
 	var out Transformation
 	var (
 		value0 *javascript.Float32Array // javascript: Float32Array {transformationMatrix TransformationMatrix transformationMatrix}
 		value1 string                   // javascript: DOMString {videoDeviceId VideoDeviceId videoDeviceId}
 	)
-	value0 = javascript.Float32ArrayFromJS(input.Get("transformationMatrix"))
+	value0 = javascript.Float32ArrayFromJS(value.Get("transformationMatrix"))
 	out.TransformationMatrix = value0
-	value1 = (input.Get("videoDeviceId")).String()
+	value1 = (value.Get("videoDeviceId")).String()
 	out.VideoDeviceId = value1
 	return &out
 }

--- a/media/capture/fromelement/fromelement.go
+++ b/media/capture/fromelement/fromelement.go
@@ -7,6 +7,7 @@ package fromelement
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/html/canvas"
 	"github.com/gowebapi/webapi/media/capture/local"
 )
@@ -43,15 +44,19 @@ type CanvasCaptureMediaStreamTrack struct {
 	local.MediaStreamTrack
 }
 
-// CanvasCaptureMediaStreamTrackFromJS is casting a js.Wrapper into CanvasCaptureMediaStreamTrack.
-func CanvasCaptureMediaStreamTrackFromJS(value js.Wrapper) *CanvasCaptureMediaStreamTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasCaptureMediaStreamTrackFromJS is casting a js.Value into CanvasCaptureMediaStreamTrack.
+func CanvasCaptureMediaStreamTrackFromJS(value js.Value) *CanvasCaptureMediaStreamTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasCaptureMediaStreamTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasCaptureMediaStreamTrackFromJS is casting from something that holds a js.Value into CanvasCaptureMediaStreamTrack.
+func CanvasCaptureMediaStreamTrackFromWrapper(input core.Wrapper) *CanvasCaptureMediaStreamTrack {
+	return CanvasCaptureMediaStreamTrackFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with

--- a/media/capture/fromelement/fromelement_js.go
+++ b/media/capture/fromelement/fromelement_js.go
@@ -5,6 +5,7 @@ package fromelement
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/html/canvas"
 	"github.com/gowebapi/webapi/media/capture/local"
 )
@@ -41,15 +42,19 @@ type CanvasCaptureMediaStreamTrack struct {
 	local.MediaStreamTrack
 }
 
-// CanvasCaptureMediaStreamTrackFromJS is casting a js.Wrapper into CanvasCaptureMediaStreamTrack.
-func CanvasCaptureMediaStreamTrackFromJS(value js.Wrapper) *CanvasCaptureMediaStreamTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanvasCaptureMediaStreamTrackFromJS is casting a js.Value into CanvasCaptureMediaStreamTrack.
+func CanvasCaptureMediaStreamTrackFromJS(value js.Value) *CanvasCaptureMediaStreamTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanvasCaptureMediaStreamTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanvasCaptureMediaStreamTrackFromJS is casting from something that holds a js.Value into CanvasCaptureMediaStreamTrack.
+func CanvasCaptureMediaStreamTrackFromWrapper(input core.Wrapper) *CanvasCaptureMediaStreamTrack {
+	return CanvasCaptureMediaStreamTrackFromJS(input.JSValue())
 }
 
 // Canvas returning attribute 'canvas' with

--- a/media/capture/image/image.go
+++ b/media/capture/image/image.go
@@ -7,6 +7,7 @@ package image
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/canvas"
 	"github.com/gowebapi/webapi/javascript"
@@ -300,7 +301,7 @@ type ConstrainPoint2DParameters struct {
 	Ideal []*mediatype.Point2D
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainPoint2DParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -320,30 +321,28 @@ func (_this *ConstrainPoint2DParameters) JSValue() js.Value {
 }
 
 // ConstrainPoint2DParametersFromJS is allocating a new
-// ConstrainPoint2DParameters object and copy all values from
-// input javascript object
-func ConstrainPoint2DParametersFromJS(value js.Wrapper) *ConstrainPoint2DParameters {
-	input := value.JSValue()
+// ConstrainPoint2DParameters object and copy all values in the value javascript object.
+func ConstrainPoint2DParametersFromJS(value js.Value) *ConstrainPoint2DParameters {
 	var out ConstrainPoint2DParameters
 	var (
 		value0 []*mediatype.Point2D // javascript: sequence<Point2D> {exact Exact exact}
 		value1 []*mediatype.Point2D // javascript: sequence<Point2D> {ideal Ideal ideal}
 	)
-	__length0 := input.Get("exact").Length()
+	__length0 := value.Get("exact").Length()
 	__array0 := make([]*mediatype.Point2D, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *mediatype.Point2D
-		__seq_in0 := input.Get("exact").Index(__idx0)
+		__seq_in0 := value.Get("exact").Index(__idx0)
 		__seq_out0 = mediatype.Point2DFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Exact = value0
-	__length1 := input.Get("ideal").Length()
+	__length1 := value.Get("ideal").Length()
 	__array1 := make([]*mediatype.Point2D, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *mediatype.Point2D
-		__seq_in1 := input.Get("ideal").Index(__idx1)
+		__seq_in1 := value.Get("ideal").Index(__idx1)
 		__seq_out1 = mediatype.Point2DFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -360,7 +359,7 @@ type PhotoSettings struct {
 	RedEyeReduction bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PhotoSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -376,10 +375,8 @@ func (_this *PhotoSettings) JSValue() js.Value {
 }
 
 // PhotoSettingsFromJS is allocating a new
-// PhotoSettings object and copy all values from
-// input javascript object
-func PhotoSettingsFromJS(value js.Wrapper) *PhotoSettings {
-	input := value.JSValue()
+// PhotoSettings object and copy all values in the value javascript object.
+func PhotoSettingsFromJS(value js.Value) *PhotoSettings {
 	var out PhotoSettings
 	var (
 		value0 FillLightMode // javascript: FillLightMode {fillLightMode FillLightMode fillLightMode}
@@ -387,13 +384,13 @@ func PhotoSettingsFromJS(value js.Wrapper) *PhotoSettings {
 		value2 float64       // javascript: double {imageWidth ImageWidth imageWidth}
 		value3 bool          // javascript: boolean {redEyeReduction RedEyeReduction redEyeReduction}
 	)
-	value0 = FillLightModeFromJS(input.Get("fillLightMode"))
+	value0 = FillLightModeFromJS(value.Get("fillLightMode"))
 	out.FillLightMode = value0
-	value1 = (input.Get("imageHeight")).Float()
+	value1 = (value.Get("imageHeight")).Float()
 	out.ImageHeight = value1
-	value2 = (input.Get("imageWidth")).Float()
+	value2 = (value.Get("imageWidth")).Float()
 	out.ImageWidth = value2
-	value3 = (input.Get("redEyeReduction")).Bool()
+	value3 = (value.Get("redEyeReduction")).Bool()
 	out.RedEyeReduction = value3
 	return &out
 }
@@ -408,15 +405,19 @@ func (_this *ImageCapture) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageCaptureFromJS is casting a js.Wrapper into ImageCapture.
-func ImageCaptureFromJS(value js.Wrapper) *ImageCapture {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageCaptureFromJS is casting a js.Value into ImageCapture.
+func ImageCaptureFromJS(value js.Value) *ImageCapture {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageCapture{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageCaptureFromJS is casting from something that holds a js.Value into ImageCapture.
+func ImageCaptureFromWrapper(input core.Wrapper) *ImageCapture {
+	return ImageCaptureFromJS(input.JSValue())
 }
 
 func NewImageCapture(videoTrack *local.MediaStreamTrack) (_result *ImageCapture) {
@@ -517,15 +518,19 @@ func (_this *PhotoCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PhotoCapabilitiesFromJS is casting a js.Wrapper into PhotoCapabilities.
-func PhotoCapabilitiesFromJS(value js.Wrapper) *PhotoCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PhotoCapabilitiesFromJS is casting a js.Value into PhotoCapabilities.
+func PhotoCapabilitiesFromJS(value js.Value) *PhotoCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PhotoCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PhotoCapabilitiesFromJS is casting from something that holds a js.Value into PhotoCapabilities.
+func PhotoCapabilitiesFromWrapper(input core.Wrapper) *PhotoCapabilities {
+	return PhotoCapabilitiesFromJS(input.JSValue())
 }
 
 // RedEyeReduction returning attribute 'redEyeReduction' with
@@ -574,15 +579,19 @@ func (_this *PromisePhotoCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePhotoCapabilitiesFromJS is casting a js.Wrapper into PromisePhotoCapabilities.
-func PromisePhotoCapabilitiesFromJS(value js.Wrapper) *PromisePhotoCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePhotoCapabilitiesFromJS is casting a js.Value into PromisePhotoCapabilities.
+func PromisePhotoCapabilitiesFromJS(value js.Value) *PromisePhotoCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePhotoCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePhotoCapabilitiesFromJS is casting from something that holds a js.Value into PromisePhotoCapabilities.
+func PromisePhotoCapabilitiesFromWrapper(input core.Wrapper) *PromisePhotoCapabilities {
+	return PromisePhotoCapabilitiesFromJS(input.JSValue())
 }
 
 func (_this *PromisePhotoCapabilities) Then(onFulfilled *PromisePhotoCapabilitiesOnFulfilled, onRejected *PromisePhotoCapabilitiesOnRejected) (_result *PromisePhotoCapabilities) {
@@ -679,15 +688,19 @@ func (_this *PromisePhotoSettings) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePhotoSettingsFromJS is casting a js.Wrapper into PromisePhotoSettings.
-func PromisePhotoSettingsFromJS(value js.Wrapper) *PromisePhotoSettings {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePhotoSettingsFromJS is casting a js.Value into PromisePhotoSettings.
+func PromisePhotoSettingsFromJS(value js.Value) *PromisePhotoSettings {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePhotoSettings{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePhotoSettingsFromJS is casting from something that holds a js.Value into PromisePhotoSettings.
+func PromisePhotoSettingsFromWrapper(input core.Wrapper) *PromisePhotoSettings {
+	return PromisePhotoSettingsFromJS(input.JSValue())
 }
 
 func (_this *PromisePhotoSettings) Then(onFulfilled *PromisePhotoSettingsOnFulfilled, onRejected *PromisePhotoSettingsOnRejected) (_result *PromisePhotoSettings) {

--- a/media/capture/image/image_js.go
+++ b/media/capture/image/image_js.go
@@ -5,6 +5,7 @@ package image
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/canvas"
 	"github.com/gowebapi/webapi/javascript"
@@ -298,7 +299,7 @@ type ConstrainPoint2DParameters struct {
 	Ideal []*mediatype.Point2D
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainPoint2DParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -318,30 +319,28 @@ func (_this *ConstrainPoint2DParameters) JSValue() js.Value {
 }
 
 // ConstrainPoint2DParametersFromJS is allocating a new
-// ConstrainPoint2DParameters object and copy all values from
-// input javascript object
-func ConstrainPoint2DParametersFromJS(value js.Wrapper) *ConstrainPoint2DParameters {
-	input := value.JSValue()
+// ConstrainPoint2DParameters object and copy all values in the value javascript object.
+func ConstrainPoint2DParametersFromJS(value js.Value) *ConstrainPoint2DParameters {
 	var out ConstrainPoint2DParameters
 	var (
 		value0 []*mediatype.Point2D // javascript: sequence<Point2D> {exact Exact exact}
 		value1 []*mediatype.Point2D // javascript: sequence<Point2D> {ideal Ideal ideal}
 	)
-	__length0 := input.Get("exact").Length()
+	__length0 := value.Get("exact").Length()
 	__array0 := make([]*mediatype.Point2D, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *mediatype.Point2D
-		__seq_in0 := input.Get("exact").Index(__idx0)
+		__seq_in0 := value.Get("exact").Index(__idx0)
 		__seq_out0 = mediatype.Point2DFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Exact = value0
-	__length1 := input.Get("ideal").Length()
+	__length1 := value.Get("ideal").Length()
 	__array1 := make([]*mediatype.Point2D, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *mediatype.Point2D
-		__seq_in1 := input.Get("ideal").Index(__idx1)
+		__seq_in1 := value.Get("ideal").Index(__idx1)
 		__seq_out1 = mediatype.Point2DFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -358,7 +357,7 @@ type PhotoSettings struct {
 	RedEyeReduction bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PhotoSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -374,10 +373,8 @@ func (_this *PhotoSettings) JSValue() js.Value {
 }
 
 // PhotoSettingsFromJS is allocating a new
-// PhotoSettings object and copy all values from
-// input javascript object
-func PhotoSettingsFromJS(value js.Wrapper) *PhotoSettings {
-	input := value.JSValue()
+// PhotoSettings object and copy all values in the value javascript object.
+func PhotoSettingsFromJS(value js.Value) *PhotoSettings {
 	var out PhotoSettings
 	var (
 		value0 FillLightMode // javascript: FillLightMode {fillLightMode FillLightMode fillLightMode}
@@ -385,13 +382,13 @@ func PhotoSettingsFromJS(value js.Wrapper) *PhotoSettings {
 		value2 float64       // javascript: double {imageWidth ImageWidth imageWidth}
 		value3 bool          // javascript: boolean {redEyeReduction RedEyeReduction redEyeReduction}
 	)
-	value0 = FillLightModeFromJS(input.Get("fillLightMode"))
+	value0 = FillLightModeFromJS(value.Get("fillLightMode"))
 	out.FillLightMode = value0
-	value1 = (input.Get("imageHeight")).Float()
+	value1 = (value.Get("imageHeight")).Float()
 	out.ImageHeight = value1
-	value2 = (input.Get("imageWidth")).Float()
+	value2 = (value.Get("imageWidth")).Float()
 	out.ImageWidth = value2
-	value3 = (input.Get("redEyeReduction")).Bool()
+	value3 = (value.Get("redEyeReduction")).Bool()
 	out.RedEyeReduction = value3
 	return &out
 }
@@ -406,15 +403,19 @@ func (_this *ImageCapture) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ImageCaptureFromJS is casting a js.Wrapper into ImageCapture.
-func ImageCaptureFromJS(value js.Wrapper) *ImageCapture {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ImageCaptureFromJS is casting a js.Value into ImageCapture.
+func ImageCaptureFromJS(value js.Value) *ImageCapture {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ImageCapture{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ImageCaptureFromJS is casting from something that holds a js.Value into ImageCapture.
+func ImageCaptureFromWrapper(input core.Wrapper) *ImageCapture {
+	return ImageCaptureFromJS(input.JSValue())
 }
 
 func NewImageCapture(videoTrack *local.MediaStreamTrack) (_result *ImageCapture) {
@@ -515,15 +516,19 @@ func (_this *PhotoCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PhotoCapabilitiesFromJS is casting a js.Wrapper into PhotoCapabilities.
-func PhotoCapabilitiesFromJS(value js.Wrapper) *PhotoCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PhotoCapabilitiesFromJS is casting a js.Value into PhotoCapabilities.
+func PhotoCapabilitiesFromJS(value js.Value) *PhotoCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PhotoCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PhotoCapabilitiesFromJS is casting from something that holds a js.Value into PhotoCapabilities.
+func PhotoCapabilitiesFromWrapper(input core.Wrapper) *PhotoCapabilities {
+	return PhotoCapabilitiesFromJS(input.JSValue())
 }
 
 // RedEyeReduction returning attribute 'redEyeReduction' with
@@ -572,15 +577,19 @@ func (_this *PromisePhotoCapabilities) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePhotoCapabilitiesFromJS is casting a js.Wrapper into PromisePhotoCapabilities.
-func PromisePhotoCapabilitiesFromJS(value js.Wrapper) *PromisePhotoCapabilities {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePhotoCapabilitiesFromJS is casting a js.Value into PromisePhotoCapabilities.
+func PromisePhotoCapabilitiesFromJS(value js.Value) *PromisePhotoCapabilities {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePhotoCapabilities{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePhotoCapabilitiesFromJS is casting from something that holds a js.Value into PromisePhotoCapabilities.
+func PromisePhotoCapabilitiesFromWrapper(input core.Wrapper) *PromisePhotoCapabilities {
+	return PromisePhotoCapabilitiesFromJS(input.JSValue())
 }
 
 func (_this *PromisePhotoCapabilities) Then(onFulfilled *PromisePhotoCapabilitiesOnFulfilled, onRejected *PromisePhotoCapabilitiesOnRejected) (_result *PromisePhotoCapabilities) {
@@ -677,15 +686,19 @@ func (_this *PromisePhotoSettings) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePhotoSettingsFromJS is casting a js.Wrapper into PromisePhotoSettings.
-func PromisePhotoSettingsFromJS(value js.Wrapper) *PromisePhotoSettings {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePhotoSettingsFromJS is casting a js.Value into PromisePhotoSettings.
+func PromisePhotoSettingsFromJS(value js.Value) *PromisePhotoSettings {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePhotoSettings{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePhotoSettingsFromJS is casting from something that holds a js.Value into PromisePhotoSettings.
+func PromisePhotoSettingsFromWrapper(input core.Wrapper) *PromisePhotoSettings {
+	return PromisePhotoSettingsFromJS(input.JSValue())
 }
 
 func (_this *PromisePhotoSettings) Then(onFulfilled *PromisePhotoSettingsOnFulfilled, onRejected *PromisePhotoSettingsOnRejected) (_result *PromisePhotoSettings) {

--- a/media/capture/local/local.go
+++ b/media/capture/local/local.go
@@ -7,6 +7,7 @@ package local
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/media/capture/depth"
@@ -395,7 +396,7 @@ func PromiseSequenceMediaDeviceInfoOnRejectedFromJS(_value js.Value) PromiseSequ
 type Capabilities struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Capabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -403,9 +404,8 @@ func (_this *Capabilities) JSValue() js.Value {
 }
 
 // CapabilitiesFromJS is allocating a new
-// Capabilities object and copy all values from
-// input javascript object
-func CapabilitiesFromJS(value js.Wrapper) *Capabilities {
+// Capabilities object and copy all values in the value javascript object.
+func CapabilitiesFromJS(value js.Value) *Capabilities {
 	var out Capabilities
 	var ()
 	return &out
@@ -417,7 +417,7 @@ type ConstrainBooleanParameters struct {
 	Ideal bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainBooleanParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -429,18 +429,16 @@ func (_this *ConstrainBooleanParameters) JSValue() js.Value {
 }
 
 // ConstrainBooleanParametersFromJS is allocating a new
-// ConstrainBooleanParameters object and copy all values from
-// input javascript object
-func ConstrainBooleanParametersFromJS(value js.Wrapper) *ConstrainBooleanParameters {
-	input := value.JSValue()
+// ConstrainBooleanParameters object and copy all values in the value javascript object.
+func ConstrainBooleanParametersFromJS(value js.Value) *ConstrainBooleanParameters {
 	var out ConstrainBooleanParameters
 	var (
 		value0 bool // javascript: boolean {exact Exact exact}
 		value1 bool // javascript: boolean {ideal Ideal ideal}
 	)
-	value0 = (input.Get("exact")).Bool()
+	value0 = (value.Get("exact")).Bool()
 	out.Exact = value0
-	value1 = (input.Get("ideal")).Bool()
+	value1 = (value.Get("ideal")).Bool()
 	out.Ideal = value1
 	return &out
 }
@@ -451,7 +449,7 @@ type ConstrainDOMStringParameters struct {
 	Ideal *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainDOMStringParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -463,18 +461,16 @@ func (_this *ConstrainDOMStringParameters) JSValue() js.Value {
 }
 
 // ConstrainDOMStringParametersFromJS is allocating a new
-// ConstrainDOMStringParameters object and copy all values from
-// input javascript object
-func ConstrainDOMStringParametersFromJS(value js.Wrapper) *ConstrainDOMStringParameters {
-	input := value.JSValue()
+// ConstrainDOMStringParameters object and copy all values in the value javascript object.
+func ConstrainDOMStringParametersFromJS(value js.Value) *ConstrainDOMStringParameters {
 	var out ConstrainDOMStringParameters
 	var (
 		value0 *Union // javascript: Union {exact Exact exact}
 		value1 *Union // javascript: Union {ideal Ideal ideal}
 	)
-	value0 = UnionFromJS(input.Get("exact"))
+	value0 = UnionFromJS(value.Get("exact"))
 	out.Exact = value0
-	value1 = UnionFromJS(input.Get("ideal"))
+	value1 = UnionFromJS(value.Get("ideal"))
 	out.Ideal = value1
 	return &out
 }
@@ -487,7 +483,7 @@ type ConstrainDoubleRange struct {
 	Ideal float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainDoubleRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -503,10 +499,8 @@ func (_this *ConstrainDoubleRange) JSValue() js.Value {
 }
 
 // ConstrainDoubleRangeFromJS is allocating a new
-// ConstrainDoubleRange object and copy all values from
-// input javascript object
-func ConstrainDoubleRangeFromJS(value js.Wrapper) *ConstrainDoubleRange {
-	input := value.JSValue()
+// ConstrainDoubleRange object and copy all values in the value javascript object.
+func ConstrainDoubleRangeFromJS(value js.Value) *ConstrainDoubleRange {
 	var out ConstrainDoubleRange
 	var (
 		value0 float64 // javascript: double {max Max max}
@@ -514,13 +508,13 @@ func ConstrainDoubleRangeFromJS(value js.Wrapper) *ConstrainDoubleRange {
 		value2 float64 // javascript: double {exact Exact exact}
 		value3 float64 // javascript: double {ideal Ideal ideal}
 	)
-	value0 = (input.Get("max")).Float()
+	value0 = (value.Get("max")).Float()
 	out.Max = value0
-	value1 = (input.Get("min")).Float()
+	value1 = (value.Get("min")).Float()
 	out.Min = value1
-	value2 = (input.Get("exact")).Float()
+	value2 = (value.Get("exact")).Float()
 	out.Exact = value2
-	value3 = (input.Get("ideal")).Float()
+	value3 = (value.Get("ideal")).Float()
 	out.Ideal = value3
 	return &out
 }
@@ -533,7 +527,7 @@ type ConstrainULongRange struct {
 	Ideal uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainULongRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -549,10 +543,8 @@ func (_this *ConstrainULongRange) JSValue() js.Value {
 }
 
 // ConstrainULongRangeFromJS is allocating a new
-// ConstrainULongRange object and copy all values from
-// input javascript object
-func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
-	input := value.JSValue()
+// ConstrainULongRange object and copy all values in the value javascript object.
+func ConstrainULongRangeFromJS(value js.Value) *ConstrainULongRange {
 	var out ConstrainULongRange
 	var (
 		value0 uint // javascript: unsigned long {max Max max}
@@ -560,13 +552,13 @@ func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
 		value2 uint // javascript: unsigned long {exact Exact exact}
 		value3 uint // javascript: unsigned long {ideal Ideal ideal}
 	)
-	value0 = (uint)((input.Get("max")).Int())
+	value0 = (uint)((value.Get("max")).Int())
 	out.Max = value0
-	value1 = (uint)((input.Get("min")).Int())
+	value1 = (uint)((value.Get("min")).Int())
 	out.Min = value1
-	value2 = (uint)((input.Get("exact")).Int())
+	value2 = (uint)((value.Get("exact")).Int())
 	out.Exact = value2
-	value3 = (uint)((input.Get("ideal")).Int())
+	value3 = (uint)((value.Get("ideal")).Int())
 	out.Ideal = value3
 	return &out
 }
@@ -575,7 +567,7 @@ func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
 type ConstraintSet struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstraintSet) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -583,9 +575,8 @@ func (_this *ConstraintSet) JSValue() js.Value {
 }
 
 // ConstraintSetFromJS is allocating a new
-// ConstraintSet object and copy all values from
-// input javascript object
-func ConstraintSetFromJS(value js.Wrapper) *ConstraintSet {
+// ConstraintSet object and copy all values in the value javascript object.
+func ConstraintSetFromJS(value js.Value) *ConstraintSet {
 	var out ConstraintSet
 	var ()
 	return &out
@@ -596,7 +587,7 @@ type Constraints struct {
 	Advanced []*ConstraintSet
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Constraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -610,19 +601,17 @@ func (_this *Constraints) JSValue() js.Value {
 }
 
 // ConstraintsFromJS is allocating a new
-// Constraints object and copy all values from
-// input javascript object
-func ConstraintsFromJS(value js.Wrapper) *Constraints {
-	input := value.JSValue()
+// Constraints object and copy all values in the value javascript object.
+func ConstraintsFromJS(value js.Value) *Constraints {
 	var out Constraints
 	var (
 		value0 []*ConstraintSet // javascript: sequence<ConstraintSet> {advanced Advanced advanced}
 	)
-	__length0 := input.Get("advanced").Length()
+	__length0 := value.Get("advanced").Length()
 	__array0 := make([]*ConstraintSet, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *ConstraintSet
-		__seq_in0 := input.Get("advanced").Index(__idx0)
+		__seq_in0 := value.Get("advanced").Index(__idx0)
 		__seq_out0 = ConstraintSetFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -637,7 +626,7 @@ type DoubleRange struct {
 	Min float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DoubleRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -649,18 +638,16 @@ func (_this *DoubleRange) JSValue() js.Value {
 }
 
 // DoubleRangeFromJS is allocating a new
-// DoubleRange object and copy all values from
-// input javascript object
-func DoubleRangeFromJS(value js.Wrapper) *DoubleRange {
-	input := value.JSValue()
+// DoubleRange object and copy all values in the value javascript object.
+func DoubleRangeFromJS(value js.Value) *DoubleRange {
 	var out DoubleRange
 	var (
 		value0 float64 // javascript: double {max Max max}
 		value1 float64 // javascript: double {min Min min}
 	)
-	value0 = (input.Get("max")).Float()
+	value0 = (value.Get("max")).Float()
 	out.Max = value0
-	value1 = (input.Get("min")).Float()
+	value1 = (value.Get("min")).Float()
 	out.Min = value1
 	return &out
 }
@@ -671,7 +658,7 @@ type MediaStreamConstraints struct {
 	Audio *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -683,18 +670,16 @@ func (_this *MediaStreamConstraints) JSValue() js.Value {
 }
 
 // MediaStreamConstraintsFromJS is allocating a new
-// MediaStreamConstraints object and copy all values from
-// input javascript object
-func MediaStreamConstraintsFromJS(value js.Wrapper) *MediaStreamConstraints {
-	input := value.JSValue()
+// MediaStreamConstraints object and copy all values in the value javascript object.
+func MediaStreamConstraintsFromJS(value js.Value) *MediaStreamConstraints {
 	var out MediaStreamConstraints
 	var (
 		value0 *Union // javascript: Union {video Video video}
 		value1 *Union // javascript: Union {audio Audio audio}
 	)
-	value0 = UnionFromJS(input.Get("video"))
+	value0 = UnionFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = UnionFromJS(input.Get("audio"))
+	value1 = UnionFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }
@@ -707,7 +692,7 @@ type MediaStreamTrackEventInit struct {
 	Track      *MediaStreamTrack
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamTrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -723,10 +708,8 @@ func (_this *MediaStreamTrackEventInit) JSValue() js.Value {
 }
 
 // MediaStreamTrackEventInitFromJS is allocating a new
-// MediaStreamTrackEventInit object and copy all values from
-// input javascript object
-func MediaStreamTrackEventInitFromJS(value js.Wrapper) *MediaStreamTrackEventInit {
-	input := value.JSValue()
+// MediaStreamTrackEventInit object and copy all values in the value javascript object.
+func MediaStreamTrackEventInitFromJS(value js.Value) *MediaStreamTrackEventInit {
 	var out MediaStreamTrackEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -734,13 +717,13 @@ func MediaStreamTrackEventInitFromJS(value js.Wrapper) *MediaStreamTrackEventIni
 		value2 bool              // javascript: boolean {composed Composed composed}
 		value3 *MediaStreamTrack // javascript: MediaStreamTrack {track Track track}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = MediaStreamTrackFromJS(input.Get("track"))
+	value3 = MediaStreamTrackFromJS(value.Get("track"))
 	out.Track = value3
 	return &out
 }
@@ -789,7 +772,7 @@ type MediaTrackCapabilities struct {
 	DepthToVideoTransform              bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackCapabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -909,10 +892,8 @@ func (_this *MediaTrackCapabilities) JSValue() js.Value {
 }
 
 // MediaTrackCapabilitiesFromJS is allocating a new
-// MediaTrackCapabilities object and copy all values from
-// input javascript object
-func MediaTrackCapabilitiesFromJS(value js.Wrapper) *MediaTrackCapabilities {
-	input := value.JSValue()
+// MediaTrackCapabilities object and copy all values in the value javascript object.
+func MediaTrackCapabilitiesFromJS(value js.Value) *MediaTrackCapabilities {
 	var out MediaTrackCapabilities
 	var (
 		value0  *ULongRange                   // javascript: ULongRange {width Width width}
@@ -956,149 +937,149 @@ func MediaTrackCapabilitiesFromJS(value js.Wrapper) *MediaTrackCapabilities {
 		value38 *Union                        // javascript: Union {depthFar DepthFar depthFar}
 		value39 bool                          // javascript: boolean {depthToVideoTransform DepthToVideoTransform depthToVideoTransform}
 	)
-	value0 = ULongRangeFromJS(input.Get("width"))
+	value0 = ULongRangeFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = ULongRangeFromJS(input.Get("height"))
+	value1 = ULongRangeFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = DoubleRangeFromJS(input.Get("aspectRatio"))
+	value2 = DoubleRangeFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = DoubleRangeFromJS(input.Get("frameRate"))
+	value3 = DoubleRangeFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	__length4 := input.Get("facingMode").Length()
+	__length4 := value.Get("facingMode").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("facingMode").Index(__idx4)
+		__seq_in4 := value.Get("facingMode").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.FacingMode = value4
-	__length5 := input.Get("resizeMode").Length()
+	__length5 := value.Get("resizeMode").Length()
 	__array5 := make([]string, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 string
-		__seq_in5 := input.Get("resizeMode").Index(__idx5)
+		__seq_in5 := value.Get("resizeMode").Index(__idx5)
 		__seq_out5 = (__seq_in5).String()
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.ResizeMode = value5
-	value6 = DoubleRangeFromJS(input.Get("volume"))
+	value6 = DoubleRangeFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = ULongRangeFromJS(input.Get("sampleRate"))
+	value7 = ULongRangeFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = ULongRangeFromJS(input.Get("sampleSize"))
+	value8 = ULongRangeFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	__length9 := input.Get("echoCancellation").Length()
+	__length9 := value.Get("echoCancellation").Length()
 	__array9 := make([]bool, __length9, __length9)
 	for __idx9 := 0; __idx9 < __length9; __idx9++ {
 		var __seq_out9 bool
-		__seq_in9 := input.Get("echoCancellation").Index(__idx9)
+		__seq_in9 := value.Get("echoCancellation").Index(__idx9)
 		__seq_out9 = (__seq_in9).Bool()
 		__array9[__idx9] = __seq_out9
 	}
 	value9 = __array9
 	out.EchoCancellation = value9
-	__length10 := input.Get("autoGainControl").Length()
+	__length10 := value.Get("autoGainControl").Length()
 	__array10 := make([]bool, __length10, __length10)
 	for __idx10 := 0; __idx10 < __length10; __idx10++ {
 		var __seq_out10 bool
-		__seq_in10 := input.Get("autoGainControl").Index(__idx10)
+		__seq_in10 := value.Get("autoGainControl").Index(__idx10)
 		__seq_out10 = (__seq_in10).Bool()
 		__array10[__idx10] = __seq_out10
 	}
 	value10 = __array10
 	out.AutoGainControl = value10
-	__length11 := input.Get("noiseSuppression").Length()
+	__length11 := value.Get("noiseSuppression").Length()
 	__array11 := make([]bool, __length11, __length11)
 	for __idx11 := 0; __idx11 < __length11; __idx11++ {
 		var __seq_out11 bool
-		__seq_in11 := input.Get("noiseSuppression").Index(__idx11)
+		__seq_in11 := value.Get("noiseSuppression").Index(__idx11)
 		__seq_out11 = (__seq_in11).Bool()
 		__array11[__idx11] = __seq_out11
 	}
 	value11 = __array11
 	out.NoiseSuppression = value11
-	value12 = DoubleRangeFromJS(input.Get("latency"))
+	value12 = DoubleRangeFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = ULongRangeFromJS(input.Get("channelCount"))
+	value13 = ULongRangeFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).String()
+	value14 = (value.Get("deviceId")).String()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).String()
+	value15 = (value.Get("groupId")).String()
 	out.GroupId = value15
-	__length16 := input.Get("whiteBalanceMode").Length()
+	__length16 := value.Get("whiteBalanceMode").Length()
 	__array16 := make([]string, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 string
-		__seq_in16 := input.Get("whiteBalanceMode").Index(__idx16)
+		__seq_in16 := value.Get("whiteBalanceMode").Index(__idx16)
 		__seq_out16 = (__seq_in16).String()
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.WhiteBalanceMode = value16
-	__length17 := input.Get("exposureMode").Length()
+	__length17 := value.Get("exposureMode").Length()
 	__array17 := make([]string, __length17, __length17)
 	for __idx17 := 0; __idx17 < __length17; __idx17++ {
 		var __seq_out17 string
-		__seq_in17 := input.Get("exposureMode").Index(__idx17)
+		__seq_in17 := value.Get("exposureMode").Index(__idx17)
 		__seq_out17 = (__seq_in17).String()
 		__array17[__idx17] = __seq_out17
 	}
 	value17 = __array17
 	out.ExposureMode = value17
-	__length18 := input.Get("focusMode").Length()
+	__length18 := value.Get("focusMode").Length()
 	__array18 := make([]string, __length18, __length18)
 	for __idx18 := 0; __idx18 < __length18; __idx18++ {
 		var __seq_out18 string
-		__seq_in18 := input.Get("focusMode").Index(__idx18)
+		__seq_in18 := value.Get("focusMode").Index(__idx18)
 		__seq_out18 = (__seq_in18).String()
 		__array18[__idx18] = __seq_out18
 	}
 	value18 = __array18
 	out.FocusMode = value18
-	value19 = mediatype.MediaSettingsRangeFromJS(input.Get("exposureCompensation"))
+	value19 = mediatype.MediaSettingsRangeFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value19
-	value20 = mediatype.MediaSettingsRangeFromJS(input.Get("exposureTime"))
+	value20 = mediatype.MediaSettingsRangeFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value20
-	value21 = mediatype.MediaSettingsRangeFromJS(input.Get("colorTemperature"))
+	value21 = mediatype.MediaSettingsRangeFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value21
-	value22 = mediatype.MediaSettingsRangeFromJS(input.Get("iso"))
+	value22 = mediatype.MediaSettingsRangeFromJS(value.Get("iso"))
 	out.Iso = value22
-	value23 = mediatype.MediaSettingsRangeFromJS(input.Get("brightness"))
+	value23 = mediatype.MediaSettingsRangeFromJS(value.Get("brightness"))
 	out.Brightness = value23
-	value24 = mediatype.MediaSettingsRangeFromJS(input.Get("contrast"))
+	value24 = mediatype.MediaSettingsRangeFromJS(value.Get("contrast"))
 	out.Contrast = value24
-	value25 = mediatype.MediaSettingsRangeFromJS(input.Get("saturation"))
+	value25 = mediatype.MediaSettingsRangeFromJS(value.Get("saturation"))
 	out.Saturation = value25
-	value26 = mediatype.MediaSettingsRangeFromJS(input.Get("sharpness"))
+	value26 = mediatype.MediaSettingsRangeFromJS(value.Get("sharpness"))
 	out.Sharpness = value26
-	value27 = mediatype.MediaSettingsRangeFromJS(input.Get("focusDistance"))
+	value27 = mediatype.MediaSettingsRangeFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value27
-	value28 = mediatype.MediaSettingsRangeFromJS(input.Get("zoom"))
+	value28 = mediatype.MediaSettingsRangeFromJS(value.Get("zoom"))
 	out.Zoom = value28
-	value29 = (input.Get("torch")).Bool()
+	value29 = (value.Get("torch")).Bool()
 	out.Torch = value29
-	value30 = (input.Get("videoKind")).String()
+	value30 = (value.Get("videoKind")).String()
 	out.VideoKind = value30
-	value31 = UnionFromJS(input.Get("focalLengthX"))
+	value31 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value31
-	value32 = UnionFromJS(input.Get("focalLengthY"))
+	value32 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value32
-	value33 = UnionFromJS(input.Get("principalPointX"))
+	value33 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value33
-	value34 = UnionFromJS(input.Get("principalPointY"))
+	value34 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value34
-	value35 = (input.Get("deprojectionDistortionCoefficients")).Bool()
+	value35 = (value.Get("deprojectionDistortionCoefficients")).Bool()
 	out.DeprojectionDistortionCoefficients = value35
-	value36 = (input.Get("projectionDistortionCoefficients")).Bool()
+	value36 = (value.Get("projectionDistortionCoefficients")).Bool()
 	out.ProjectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("depthNear"))
+	value37 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value37
-	value38 = UnionFromJS(input.Get("depthFar"))
+	value38 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value38
-	value39 = (input.Get("depthToVideoTransform")).Bool()
+	value39 = (value.Get("depthToVideoTransform")).Bool()
 	out.DepthToVideoTransform = value39
 	return &out
 }
@@ -1151,7 +1132,7 @@ type MediaTrackConstraintSet struct {
 	Cursor                             *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackConstraintSet) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1247,10 +1228,8 @@ func (_this *MediaTrackConstraintSet) JSValue() js.Value {
 }
 
 // MediaTrackConstraintSetFromJS is allocating a new
-// MediaTrackConstraintSet object and copy all values from
-// input javascript object
-func MediaTrackConstraintSetFromJS(value js.Wrapper) *MediaTrackConstraintSet {
-	input := value.JSValue()
+// MediaTrackConstraintSet object and copy all values in the value javascript object.
+func MediaTrackConstraintSetFromJS(value js.Value) *MediaTrackConstraintSet {
 	var out MediaTrackConstraintSet
 	var (
 		value0  *Union // javascript: Union {width Width width}
@@ -1298,93 +1277,93 @@ func MediaTrackConstraintSetFromJS(value js.Wrapper) *MediaTrackConstraintSet {
 		value42 *Union // javascript: Union {logicalSurface LogicalSurface logicalSurface}
 		value43 *Union // javascript: Union {cursor Cursor cursor}
 	)
-	value0 = UnionFromJS(input.Get("width"))
+	value0 = UnionFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = UnionFromJS(input.Get("height"))
+	value1 = UnionFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = UnionFromJS(input.Get("aspectRatio"))
+	value2 = UnionFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = UnionFromJS(input.Get("frameRate"))
+	value3 = UnionFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	value4 = UnionFromJS(input.Get("facingMode"))
+	value4 = UnionFromJS(value.Get("facingMode"))
 	out.FacingMode = value4
-	value5 = UnionFromJS(input.Get("resizeMode"))
+	value5 = UnionFromJS(value.Get("resizeMode"))
 	out.ResizeMode = value5
-	value6 = UnionFromJS(input.Get("volume"))
+	value6 = UnionFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = UnionFromJS(input.Get("sampleRate"))
+	value7 = UnionFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = UnionFromJS(input.Get("sampleSize"))
+	value8 = UnionFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	value9 = UnionFromJS(input.Get("echoCancellation"))
+	value9 = UnionFromJS(value.Get("echoCancellation"))
 	out.EchoCancellation = value9
-	value10 = UnionFromJS(input.Get("autoGainControl"))
+	value10 = UnionFromJS(value.Get("autoGainControl"))
 	out.AutoGainControl = value10
-	value11 = UnionFromJS(input.Get("noiseSuppression"))
+	value11 = UnionFromJS(value.Get("noiseSuppression"))
 	out.NoiseSuppression = value11
-	value12 = UnionFromJS(input.Get("latency"))
+	value12 = UnionFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = UnionFromJS(input.Get("channelCount"))
+	value13 = UnionFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = UnionFromJS(input.Get("deviceId"))
+	value14 = UnionFromJS(value.Get("deviceId"))
 	out.DeviceId = value14
-	value15 = UnionFromJS(input.Get("groupId"))
+	value15 = UnionFromJS(value.Get("groupId"))
 	out.GroupId = value15
-	value16 = UnionFromJS(input.Get("whiteBalanceMode"))
+	value16 = UnionFromJS(value.Get("whiteBalanceMode"))
 	out.WhiteBalanceMode = value16
-	value17 = UnionFromJS(input.Get("exposureMode"))
+	value17 = UnionFromJS(value.Get("exposureMode"))
 	out.ExposureMode = value17
-	value18 = UnionFromJS(input.Get("focusMode"))
+	value18 = UnionFromJS(value.Get("focusMode"))
 	out.FocusMode = value18
-	value19 = UnionFromJS(input.Get("pointsOfInterest"))
+	value19 = UnionFromJS(value.Get("pointsOfInterest"))
 	out.PointsOfInterest = value19
-	value20 = UnionFromJS(input.Get("exposureCompensation"))
+	value20 = UnionFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value20
-	value21 = UnionFromJS(input.Get("exposureTime"))
+	value21 = UnionFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value21
-	value22 = UnionFromJS(input.Get("colorTemperature"))
+	value22 = UnionFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value22
-	value23 = UnionFromJS(input.Get("iso"))
+	value23 = UnionFromJS(value.Get("iso"))
 	out.Iso = value23
-	value24 = UnionFromJS(input.Get("brightness"))
+	value24 = UnionFromJS(value.Get("brightness"))
 	out.Brightness = value24
-	value25 = UnionFromJS(input.Get("contrast"))
+	value25 = UnionFromJS(value.Get("contrast"))
 	out.Contrast = value25
-	value26 = UnionFromJS(input.Get("saturation"))
+	value26 = UnionFromJS(value.Get("saturation"))
 	out.Saturation = value26
-	value27 = UnionFromJS(input.Get("sharpness"))
+	value27 = UnionFromJS(value.Get("sharpness"))
 	out.Sharpness = value27
-	value28 = UnionFromJS(input.Get("focusDistance"))
+	value28 = UnionFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value28
-	value29 = UnionFromJS(input.Get("zoom"))
+	value29 = UnionFromJS(value.Get("zoom"))
 	out.Zoom = value29
-	value30 = UnionFromJS(input.Get("torch"))
+	value30 = UnionFromJS(value.Get("torch"))
 	out.Torch = value30
-	value31 = UnionFromJS(input.Get("videoKind"))
+	value31 = UnionFromJS(value.Get("videoKind"))
 	out.VideoKind = value31
-	value32 = UnionFromJS(input.Get("focalLengthX"))
+	value32 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value32
-	value33 = UnionFromJS(input.Get("focalLengthY"))
+	value33 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value33
-	value34 = UnionFromJS(input.Get("principalPointX"))
+	value34 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value34
-	value35 = UnionFromJS(input.Get("principalPointY"))
+	value35 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value35
-	value36 = UnionFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = UnionFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = UnionFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = UnionFromJS(input.Get("depthNear"))
+	value38 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value38
-	value39 = UnionFromJS(input.Get("depthFar"))
+	value39 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value39
-	value40 = UnionFromJS(input.Get("depthToVideoTransform"))
+	value40 = UnionFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = UnionFromJS(input.Get("displaySurface"))
+	value41 = UnionFromJS(value.Get("displaySurface"))
 	out.DisplaySurface = value41
-	value42 = UnionFromJS(input.Get("logicalSurface"))
+	value42 = UnionFromJS(value.Get("logicalSurface"))
 	out.LogicalSurface = value42
-	value43 = UnionFromJS(input.Get("cursor"))
+	value43 = UnionFromJS(value.Get("cursor"))
 	out.Cursor = value43
 	return &out
 }
@@ -1438,7 +1417,7 @@ type MediaTrackConstraints struct {
 	Advanced                           []*MediaTrackConstraintSet
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1540,10 +1519,8 @@ func (_this *MediaTrackConstraints) JSValue() js.Value {
 }
 
 // MediaTrackConstraintsFromJS is allocating a new
-// MediaTrackConstraints object and copy all values from
-// input javascript object
-func MediaTrackConstraintsFromJS(value js.Wrapper) *MediaTrackConstraints {
-	input := value.JSValue()
+// MediaTrackConstraints object and copy all values in the value javascript object.
+func MediaTrackConstraintsFromJS(value js.Value) *MediaTrackConstraints {
 	var out MediaTrackConstraints
 	var (
 		value0  *Union                     // javascript: Union {width Width width}
@@ -1592,99 +1569,99 @@ func MediaTrackConstraintsFromJS(value js.Wrapper) *MediaTrackConstraints {
 		value43 *Union                     // javascript: Union {cursor Cursor cursor}
 		value44 []*MediaTrackConstraintSet // javascript: sequence<MediaTrackConstraintSet> {advanced Advanced advanced}
 	)
-	value0 = UnionFromJS(input.Get("width"))
+	value0 = UnionFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = UnionFromJS(input.Get("height"))
+	value1 = UnionFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = UnionFromJS(input.Get("aspectRatio"))
+	value2 = UnionFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = UnionFromJS(input.Get("frameRate"))
+	value3 = UnionFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	value4 = UnionFromJS(input.Get("facingMode"))
+	value4 = UnionFromJS(value.Get("facingMode"))
 	out.FacingMode = value4
-	value5 = UnionFromJS(input.Get("resizeMode"))
+	value5 = UnionFromJS(value.Get("resizeMode"))
 	out.ResizeMode = value5
-	value6 = UnionFromJS(input.Get("volume"))
+	value6 = UnionFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = UnionFromJS(input.Get("sampleRate"))
+	value7 = UnionFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = UnionFromJS(input.Get("sampleSize"))
+	value8 = UnionFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	value9 = UnionFromJS(input.Get("echoCancellation"))
+	value9 = UnionFromJS(value.Get("echoCancellation"))
 	out.EchoCancellation = value9
-	value10 = UnionFromJS(input.Get("autoGainControl"))
+	value10 = UnionFromJS(value.Get("autoGainControl"))
 	out.AutoGainControl = value10
-	value11 = UnionFromJS(input.Get("noiseSuppression"))
+	value11 = UnionFromJS(value.Get("noiseSuppression"))
 	out.NoiseSuppression = value11
-	value12 = UnionFromJS(input.Get("latency"))
+	value12 = UnionFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = UnionFromJS(input.Get("channelCount"))
+	value13 = UnionFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = UnionFromJS(input.Get("deviceId"))
+	value14 = UnionFromJS(value.Get("deviceId"))
 	out.DeviceId = value14
-	value15 = UnionFromJS(input.Get("groupId"))
+	value15 = UnionFromJS(value.Get("groupId"))
 	out.GroupId = value15
-	value16 = UnionFromJS(input.Get("whiteBalanceMode"))
+	value16 = UnionFromJS(value.Get("whiteBalanceMode"))
 	out.WhiteBalanceMode = value16
-	value17 = UnionFromJS(input.Get("exposureMode"))
+	value17 = UnionFromJS(value.Get("exposureMode"))
 	out.ExposureMode = value17
-	value18 = UnionFromJS(input.Get("focusMode"))
+	value18 = UnionFromJS(value.Get("focusMode"))
 	out.FocusMode = value18
-	value19 = UnionFromJS(input.Get("pointsOfInterest"))
+	value19 = UnionFromJS(value.Get("pointsOfInterest"))
 	out.PointsOfInterest = value19
-	value20 = UnionFromJS(input.Get("exposureCompensation"))
+	value20 = UnionFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value20
-	value21 = UnionFromJS(input.Get("exposureTime"))
+	value21 = UnionFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value21
-	value22 = UnionFromJS(input.Get("colorTemperature"))
+	value22 = UnionFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value22
-	value23 = UnionFromJS(input.Get("iso"))
+	value23 = UnionFromJS(value.Get("iso"))
 	out.Iso = value23
-	value24 = UnionFromJS(input.Get("brightness"))
+	value24 = UnionFromJS(value.Get("brightness"))
 	out.Brightness = value24
-	value25 = UnionFromJS(input.Get("contrast"))
+	value25 = UnionFromJS(value.Get("contrast"))
 	out.Contrast = value25
-	value26 = UnionFromJS(input.Get("saturation"))
+	value26 = UnionFromJS(value.Get("saturation"))
 	out.Saturation = value26
-	value27 = UnionFromJS(input.Get("sharpness"))
+	value27 = UnionFromJS(value.Get("sharpness"))
 	out.Sharpness = value27
-	value28 = UnionFromJS(input.Get("focusDistance"))
+	value28 = UnionFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value28
-	value29 = UnionFromJS(input.Get("zoom"))
+	value29 = UnionFromJS(value.Get("zoom"))
 	out.Zoom = value29
-	value30 = UnionFromJS(input.Get("torch"))
+	value30 = UnionFromJS(value.Get("torch"))
 	out.Torch = value30
-	value31 = UnionFromJS(input.Get("videoKind"))
+	value31 = UnionFromJS(value.Get("videoKind"))
 	out.VideoKind = value31
-	value32 = UnionFromJS(input.Get("focalLengthX"))
+	value32 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value32
-	value33 = UnionFromJS(input.Get("focalLengthY"))
+	value33 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value33
-	value34 = UnionFromJS(input.Get("principalPointX"))
+	value34 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value34
-	value35 = UnionFromJS(input.Get("principalPointY"))
+	value35 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value35
-	value36 = UnionFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = UnionFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = UnionFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = UnionFromJS(input.Get("depthNear"))
+	value38 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value38
-	value39 = UnionFromJS(input.Get("depthFar"))
+	value39 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value39
-	value40 = UnionFromJS(input.Get("depthToVideoTransform"))
+	value40 = UnionFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = UnionFromJS(input.Get("displaySurface"))
+	value41 = UnionFromJS(value.Get("displaySurface"))
 	out.DisplaySurface = value41
-	value42 = UnionFromJS(input.Get("logicalSurface"))
+	value42 = UnionFromJS(value.Get("logicalSurface"))
 	out.LogicalSurface = value42
-	value43 = UnionFromJS(input.Get("cursor"))
+	value43 = UnionFromJS(value.Get("cursor"))
 	out.Cursor = value43
-	__length44 := input.Get("advanced").Length()
+	__length44 := value.Get("advanced").Length()
 	__array44 := make([]*MediaTrackConstraintSet, __length44, __length44)
 	for __idx44 := 0; __idx44 < __length44; __idx44++ {
 		var __seq_out44 *MediaTrackConstraintSet
-		__seq_in44 := input.Get("advanced").Index(__idx44)
+		__seq_in44 := value.Get("advanced").Index(__idx44)
 		__seq_out44 = MediaTrackConstraintSetFromJS(__seq_in44)
 		__array44[__idx44] = __seq_out44
 	}
@@ -1741,7 +1718,7 @@ type MediaTrackSettings struct {
 	Cursor                             string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1841,10 +1818,8 @@ func (_this *MediaTrackSettings) JSValue() js.Value {
 }
 
 // MediaTrackSettingsFromJS is allocating a new
-// MediaTrackSettings object and copy all values from
-// input javascript object
-func MediaTrackSettingsFromJS(value js.Wrapper) *MediaTrackSettings {
-	input := value.JSValue()
+// MediaTrackSettings object and copy all values in the value javascript object.
+func MediaTrackSettingsFromJS(value js.Value) *MediaTrackSettings {
 	var out MediaTrackSettings
 	var (
 		value0  int                           // javascript: long {width Width width}
@@ -1892,101 +1867,101 @@ func MediaTrackSettingsFromJS(value js.Wrapper) *MediaTrackSettings {
 		value42 bool                          // javascript: boolean {logicalSurface LogicalSurface logicalSurface}
 		value43 string                        // javascript: DOMString {cursor Cursor cursor}
 	)
-	value0 = (input.Get("width")).Int()
+	value0 = (value.Get("width")).Int()
 	out.Width = value0
-	value1 = (input.Get("height")).Int()
+	value1 = (value.Get("height")).Int()
 	out.Height = value1
-	value2 = (input.Get("aspectRatio")).Float()
+	value2 = (value.Get("aspectRatio")).Float()
 	out.AspectRatio = value2
-	value3 = (input.Get("frameRate")).Float()
+	value3 = (value.Get("frameRate")).Float()
 	out.FrameRate = value3
-	value4 = (input.Get("facingMode")).String()
+	value4 = (value.Get("facingMode")).String()
 	out.FacingMode = value4
-	value5 = (input.Get("resizeMode")).String()
+	value5 = (value.Get("resizeMode")).String()
 	out.ResizeMode = value5
-	value6 = (input.Get("volume")).Float()
+	value6 = (value.Get("volume")).Float()
 	out.Volume = value6
-	value7 = (input.Get("sampleRate")).Int()
+	value7 = (value.Get("sampleRate")).Int()
 	out.SampleRate = value7
-	value8 = (input.Get("sampleSize")).Int()
+	value8 = (value.Get("sampleSize")).Int()
 	out.SampleSize = value8
-	value9 = (input.Get("echoCancellation")).Bool()
+	value9 = (value.Get("echoCancellation")).Bool()
 	out.EchoCancellation = value9
-	value10 = (input.Get("autoGainControl")).Bool()
+	value10 = (value.Get("autoGainControl")).Bool()
 	out.AutoGainControl = value10
-	value11 = (input.Get("noiseSuppression")).Bool()
+	value11 = (value.Get("noiseSuppression")).Bool()
 	out.NoiseSuppression = value11
-	value12 = (input.Get("latency")).Float()
+	value12 = (value.Get("latency")).Float()
 	out.Latency = value12
-	value13 = (input.Get("channelCount")).Int()
+	value13 = (value.Get("channelCount")).Int()
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).String()
+	value14 = (value.Get("deviceId")).String()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).String()
+	value15 = (value.Get("groupId")).String()
 	out.GroupId = value15
-	value16 = (input.Get("whiteBalanceMode")).String()
+	value16 = (value.Get("whiteBalanceMode")).String()
 	out.WhiteBalanceMode = value16
-	value17 = (input.Get("exposureMode")).String()
+	value17 = (value.Get("exposureMode")).String()
 	out.ExposureMode = value17
-	value18 = (input.Get("focusMode")).String()
+	value18 = (value.Get("focusMode")).String()
 	out.FocusMode = value18
-	__length19 := input.Get("pointsOfInterest").Length()
+	__length19 := value.Get("pointsOfInterest").Length()
 	__array19 := make([]*mediatype.Point2D, __length19, __length19)
 	for __idx19 := 0; __idx19 < __length19; __idx19++ {
 		var __seq_out19 *mediatype.Point2D
-		__seq_in19 := input.Get("pointsOfInterest").Index(__idx19)
+		__seq_in19 := value.Get("pointsOfInterest").Index(__idx19)
 		__seq_out19 = mediatype.Point2DFromJS(__seq_in19)
 		__array19[__idx19] = __seq_out19
 	}
 	value19 = __array19
 	out.PointsOfInterest = value19
-	value20 = (input.Get("exposureCompensation")).Float()
+	value20 = (value.Get("exposureCompensation")).Float()
 	out.ExposureCompensation = value20
-	value21 = (input.Get("exposureTime")).Float()
+	value21 = (value.Get("exposureTime")).Float()
 	out.ExposureTime = value21
-	value22 = (input.Get("colorTemperature")).Float()
+	value22 = (value.Get("colorTemperature")).Float()
 	out.ColorTemperature = value22
-	value23 = (input.Get("iso")).Float()
+	value23 = (value.Get("iso")).Float()
 	out.Iso = value23
-	value24 = (input.Get("brightness")).Float()
+	value24 = (value.Get("brightness")).Float()
 	out.Brightness = value24
-	value25 = (input.Get("contrast")).Float()
+	value25 = (value.Get("contrast")).Float()
 	out.Contrast = value25
-	value26 = (input.Get("saturation")).Float()
+	value26 = (value.Get("saturation")).Float()
 	out.Saturation = value26
-	value27 = (input.Get("sharpness")).Float()
+	value27 = (value.Get("sharpness")).Float()
 	out.Sharpness = value27
-	value28 = (input.Get("focusDistance")).Float()
+	value28 = (value.Get("focusDistance")).Float()
 	out.FocusDistance = value28
-	value29 = (input.Get("zoom")).Float()
+	value29 = (value.Get("zoom")).Float()
 	out.Zoom = value29
-	value30 = (input.Get("torch")).Bool()
+	value30 = (value.Get("torch")).Bool()
 	out.Torch = value30
-	value31 = (input.Get("videoKind")).String()
+	value31 = (value.Get("videoKind")).String()
 	out.VideoKind = value31
-	value32 = (input.Get("focalLengthX")).Float()
+	value32 = (value.Get("focalLengthX")).Float()
 	out.FocalLengthX = value32
-	value33 = (input.Get("focalLengthY")).Float()
+	value33 = (value.Get("focalLengthY")).Float()
 	out.FocalLengthY = value33
-	value34 = (input.Get("principalPointX")).Float()
+	value34 = (value.Get("principalPointX")).Float()
 	out.PrincipalPointX = value34
-	value35 = (input.Get("principalPointY")).Float()
+	value35 = (value.Get("principalPointY")).Float()
 	out.PrincipalPointY = value35
-	value36 = depth.DistortionCoefficientsFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = depth.DistortionCoefficientsFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = depth.DistortionCoefficientsFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = depth.DistortionCoefficientsFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = (input.Get("depthNear")).Float()
+	value38 = (value.Get("depthNear")).Float()
 	out.DepthNear = value38
-	value39 = (input.Get("depthFar")).Float()
+	value39 = (value.Get("depthFar")).Float()
 	out.DepthFar = value39
-	value40 = depth.TransformationFromJS(input.Get("depthToVideoTransform"))
+	value40 = depth.TransformationFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = (input.Get("displaySurface")).String()
+	value41 = (value.Get("displaySurface")).String()
 	out.DisplaySurface = value41
-	value42 = (input.Get("logicalSurface")).Bool()
+	value42 = (value.Get("logicalSurface")).Bool()
 	out.LogicalSurface = value42
-	value43 = (input.Get("cursor")).String()
+	value43 = (value.Get("cursor")).String()
 	out.Cursor = value43
 	return &out
 }
@@ -2039,7 +2014,7 @@ type MediaTrackSupportedConstraints struct {
 	Cursor                             bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackSupportedConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2135,10 +2110,8 @@ func (_this *MediaTrackSupportedConstraints) JSValue() js.Value {
 }
 
 // MediaTrackSupportedConstraintsFromJS is allocating a new
-// MediaTrackSupportedConstraints object and copy all values from
-// input javascript object
-func MediaTrackSupportedConstraintsFromJS(value js.Wrapper) *MediaTrackSupportedConstraints {
-	input := value.JSValue()
+// MediaTrackSupportedConstraints object and copy all values in the value javascript object.
+func MediaTrackSupportedConstraintsFromJS(value js.Value) *MediaTrackSupportedConstraints {
 	var out MediaTrackSupportedConstraints
 	var (
 		value0  bool // javascript: boolean {width Width width}
@@ -2186,93 +2159,93 @@ func MediaTrackSupportedConstraintsFromJS(value js.Wrapper) *MediaTrackSupported
 		value42 bool // javascript: boolean {logicalSurface LogicalSurface logicalSurface}
 		value43 bool // javascript: boolean {cursor Cursor cursor}
 	)
-	value0 = (input.Get("width")).Bool()
+	value0 = (value.Get("width")).Bool()
 	out.Width = value0
-	value1 = (input.Get("height")).Bool()
+	value1 = (value.Get("height")).Bool()
 	out.Height = value1
-	value2 = (input.Get("aspectRatio")).Bool()
+	value2 = (value.Get("aspectRatio")).Bool()
 	out.AspectRatio = value2
-	value3 = (input.Get("frameRate")).Bool()
+	value3 = (value.Get("frameRate")).Bool()
 	out.FrameRate = value3
-	value4 = (input.Get("facingMode")).Bool()
+	value4 = (value.Get("facingMode")).Bool()
 	out.FacingMode = value4
-	value5 = (input.Get("resizeMode")).Bool()
+	value5 = (value.Get("resizeMode")).Bool()
 	out.ResizeMode = value5
-	value6 = (input.Get("volume")).Bool()
+	value6 = (value.Get("volume")).Bool()
 	out.Volume = value6
-	value7 = (input.Get("sampleRate")).Bool()
+	value7 = (value.Get("sampleRate")).Bool()
 	out.SampleRate = value7
-	value8 = (input.Get("sampleSize")).Bool()
+	value8 = (value.Get("sampleSize")).Bool()
 	out.SampleSize = value8
-	value9 = (input.Get("echoCancellation")).Bool()
+	value9 = (value.Get("echoCancellation")).Bool()
 	out.EchoCancellation = value9
-	value10 = (input.Get("autoGainControl")).Bool()
+	value10 = (value.Get("autoGainControl")).Bool()
 	out.AutoGainControl = value10
-	value11 = (input.Get("noiseSuppression")).Bool()
+	value11 = (value.Get("noiseSuppression")).Bool()
 	out.NoiseSuppression = value11
-	value12 = (input.Get("latency")).Bool()
+	value12 = (value.Get("latency")).Bool()
 	out.Latency = value12
-	value13 = (input.Get("channelCount")).Bool()
+	value13 = (value.Get("channelCount")).Bool()
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).Bool()
+	value14 = (value.Get("deviceId")).Bool()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).Bool()
+	value15 = (value.Get("groupId")).Bool()
 	out.GroupId = value15
-	value16 = (input.Get("whiteBalanceMode")).Bool()
+	value16 = (value.Get("whiteBalanceMode")).Bool()
 	out.WhiteBalanceMode = value16
-	value17 = (input.Get("exposureMode")).Bool()
+	value17 = (value.Get("exposureMode")).Bool()
 	out.ExposureMode = value17
-	value18 = (input.Get("focusMode")).Bool()
+	value18 = (value.Get("focusMode")).Bool()
 	out.FocusMode = value18
-	value19 = (input.Get("pointsOfInterest")).Bool()
+	value19 = (value.Get("pointsOfInterest")).Bool()
 	out.PointsOfInterest = value19
-	value20 = (input.Get("exposureCompensation")).Bool()
+	value20 = (value.Get("exposureCompensation")).Bool()
 	out.ExposureCompensation = value20
-	value21 = (input.Get("exposureTime")).Bool()
+	value21 = (value.Get("exposureTime")).Bool()
 	out.ExposureTime = value21
-	value22 = (input.Get("colorTemperature")).Bool()
+	value22 = (value.Get("colorTemperature")).Bool()
 	out.ColorTemperature = value22
-	value23 = (input.Get("iso")).Bool()
+	value23 = (value.Get("iso")).Bool()
 	out.Iso = value23
-	value24 = (input.Get("brightness")).Bool()
+	value24 = (value.Get("brightness")).Bool()
 	out.Brightness = value24
-	value25 = (input.Get("contrast")).Bool()
+	value25 = (value.Get("contrast")).Bool()
 	out.Contrast = value25
-	value26 = (input.Get("saturation")).Bool()
+	value26 = (value.Get("saturation")).Bool()
 	out.Saturation = value26
-	value27 = (input.Get("sharpness")).Bool()
+	value27 = (value.Get("sharpness")).Bool()
 	out.Sharpness = value27
-	value28 = (input.Get("focusDistance")).Bool()
+	value28 = (value.Get("focusDistance")).Bool()
 	out.FocusDistance = value28
-	value29 = (input.Get("zoom")).Bool()
+	value29 = (value.Get("zoom")).Bool()
 	out.Zoom = value29
-	value30 = (input.Get("torch")).Bool()
+	value30 = (value.Get("torch")).Bool()
 	out.Torch = value30
-	value31 = (input.Get("videoKind")).Bool()
+	value31 = (value.Get("videoKind")).Bool()
 	out.VideoKind = value31
-	value32 = (input.Get("focalLengthX")).Bool()
+	value32 = (value.Get("focalLengthX")).Bool()
 	out.FocalLengthX = value32
-	value33 = (input.Get("focalLengthY")).Bool()
+	value33 = (value.Get("focalLengthY")).Bool()
 	out.FocalLengthY = value33
-	value34 = (input.Get("principalPointX")).Bool()
+	value34 = (value.Get("principalPointX")).Bool()
 	out.PrincipalPointX = value34
-	value35 = (input.Get("principalPointY")).Bool()
+	value35 = (value.Get("principalPointY")).Bool()
 	out.PrincipalPointY = value35
-	value36 = (input.Get("deprojectionDistortionCoefficients")).Bool()
+	value36 = (value.Get("deprojectionDistortionCoefficients")).Bool()
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = (input.Get("projectionDistortionCoefficients")).Bool()
+	value37 = (value.Get("projectionDistortionCoefficients")).Bool()
 	out.ProjectionDistortionCoefficients = value37
-	value38 = (input.Get("depthNear")).Bool()
+	value38 = (value.Get("depthNear")).Bool()
 	out.DepthNear = value38
-	value39 = (input.Get("depthFar")).Bool()
+	value39 = (value.Get("depthFar")).Bool()
 	out.DepthFar = value39
-	value40 = (input.Get("depthToVideoTransform")).Bool()
+	value40 = (value.Get("depthToVideoTransform")).Bool()
 	out.DepthToVideoTransform = value40
-	value41 = (input.Get("displaySurface")).Bool()
+	value41 = (value.Get("displaySurface")).Bool()
 	out.DisplaySurface = value41
-	value42 = (input.Get("logicalSurface")).Bool()
+	value42 = (value.Get("logicalSurface")).Bool()
 	out.LogicalSurface = value42
-	value43 = (input.Get("cursor")).Bool()
+	value43 = (value.Get("cursor")).Bool()
 	out.Cursor = value43
 	return &out
 }
@@ -2285,7 +2258,7 @@ type OverconstrainedErrorEventInit struct {
 	Error      *patch.OverconstrainedError
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OverconstrainedErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2301,10 +2274,8 @@ func (_this *OverconstrainedErrorEventInit) JSValue() js.Value {
 }
 
 // OverconstrainedErrorEventInitFromJS is allocating a new
-// OverconstrainedErrorEventInit object and copy all values from
-// input javascript object
-func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedErrorEventInit {
-	input := value.JSValue()
+// OverconstrainedErrorEventInit object and copy all values in the value javascript object.
+func OverconstrainedErrorEventInitFromJS(value js.Value) *OverconstrainedErrorEventInit {
 	var out OverconstrainedErrorEventInit
 	var (
 		value0 bool                        // javascript: boolean {bubbles Bubbles bubbles}
@@ -2312,14 +2283,14 @@ func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedError
 		value2 bool                        // javascript: boolean {composed Composed composed}
 		value3 *patch.OverconstrainedError // javascript: OverconstrainedError {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("error").Type() != js.TypeNull && input.Get("error").Type() != js.TypeUndefined {
-		value3 = patch.OverconstrainedErrorFromJS(input.Get("error"))
+	if value.Get("error").Type() != js.TypeNull && value.Get("error").Type() != js.TypeUndefined {
+		value3 = patch.OverconstrainedErrorFromJS(value.Get("error"))
 	}
 	out.Error = value3
 	return &out
@@ -2329,7 +2300,7 @@ func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedError
 type Settings struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Settings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2337,9 +2308,8 @@ func (_this *Settings) JSValue() js.Value {
 }
 
 // SettingsFromJS is allocating a new
-// Settings object and copy all values from
-// input javascript object
-func SettingsFromJS(value js.Wrapper) *Settings {
+// Settings object and copy all values in the value javascript object.
+func SettingsFromJS(value js.Value) *Settings {
 	var out Settings
 	var ()
 	return &out
@@ -2351,7 +2321,7 @@ type ULongRange struct {
 	Min uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ULongRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2363,18 +2333,16 @@ func (_this *ULongRange) JSValue() js.Value {
 }
 
 // ULongRangeFromJS is allocating a new
-// ULongRange object and copy all values from
-// input javascript object
-func ULongRangeFromJS(value js.Wrapper) *ULongRange {
-	input := value.JSValue()
+// ULongRange object and copy all values in the value javascript object.
+func ULongRangeFromJS(value js.Value) *ULongRange {
 	var out ULongRange
 	var (
 		value0 uint // javascript: unsigned long {max Max max}
 		value1 uint // javascript: unsigned long {min Min min}
 	)
-	value0 = (uint)((input.Get("max")).Int())
+	value0 = (uint)((value.Get("max")).Int())
 	out.Max = value0
-	value1 = (uint)((input.Get("min")).Int())
+	value1 = (uint)((value.Get("min")).Int())
 	out.Min = value1
 	return &out
 }
@@ -2389,15 +2357,19 @@ func (_this *ConstrainablePattern) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ConstrainablePatternFromJS is casting a js.Wrapper into ConstrainablePattern.
-func ConstrainablePatternFromJS(value js.Wrapper) *ConstrainablePattern {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConstrainablePatternFromJS is casting a js.Value into ConstrainablePattern.
+func ConstrainablePatternFromJS(value js.Value) *ConstrainablePattern {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConstrainablePattern{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConstrainablePatternFromJS is casting from something that holds a js.Value into ConstrainablePattern.
+func ConstrainablePatternFromWrapper(input core.Wrapper) *ConstrainablePattern {
+	return ConstrainablePatternFromJS(input.JSValue())
 }
 
 // OnOverConstrained returning attribute 'onoverconstrained' with
@@ -2507,15 +2479,19 @@ type InputDeviceInfo struct {
 	MediaDeviceInfo
 }
 
-// InputDeviceInfoFromJS is casting a js.Wrapper into InputDeviceInfo.
-func InputDeviceInfoFromJS(value js.Wrapper) *InputDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputDeviceInfoFromJS is casting a js.Value into InputDeviceInfo.
+func InputDeviceInfoFromJS(value js.Value) *InputDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputDeviceInfoFromJS is casting from something that holds a js.Value into InputDeviceInfo.
+func InputDeviceInfoFromWrapper(input core.Wrapper) *InputDeviceInfo {
+	return InputDeviceInfoFromJS(input.JSValue())
 }
 
 func (_this *InputDeviceInfo) GetCapabilities() (_result *MediaTrackCapabilities) {
@@ -2542,15 +2518,19 @@ func (_this *MediaDeviceInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaDeviceInfoFromJS is casting a js.Wrapper into MediaDeviceInfo.
-func MediaDeviceInfoFromJS(value js.Wrapper) *MediaDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaDeviceInfoFromJS is casting a js.Value into MediaDeviceInfo.
+func MediaDeviceInfoFromJS(value js.Value) *MediaDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaDeviceInfoFromJS is casting from something that holds a js.Value into MediaDeviceInfo.
+func MediaDeviceInfoFromWrapper(input core.Wrapper) *MediaDeviceInfo {
+	return MediaDeviceInfoFromJS(input.JSValue())
 }
 
 // DeviceId returning attribute 'deviceId' with
@@ -2608,15 +2588,19 @@ type MediaDevices struct {
 	domcore.EventTarget
 }
 
-// MediaDevicesFromJS is casting a js.Wrapper into MediaDevices.
-func MediaDevicesFromJS(value js.Wrapper) *MediaDevices {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaDevicesFromJS is casting a js.Value into MediaDevices.
+func MediaDevicesFromJS(value js.Value) *MediaDevices {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaDevices{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaDevicesFromJS is casting from something that holds a js.Value into MediaDevices.
+func MediaDevicesFromWrapper(input core.Wrapper) *MediaDevices {
+	return MediaDevicesFromJS(input.JSValue())
 }
 
 // OnDeviceChange returning attribute 'ondevicechange' with
@@ -2731,15 +2715,19 @@ type MediaStream struct {
 	domcore.EventTarget
 }
 
-// MediaStreamFromJS is casting a js.Wrapper into MediaStream.
-func MediaStreamFromJS(value js.Wrapper) *MediaStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamFromJS is casting a js.Value into MediaStream.
+func MediaStreamFromJS(value js.Value) *MediaStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamFromJS is casting from something that holds a js.Value into MediaStream.
+func MediaStreamFromWrapper(input core.Wrapper) *MediaStream {
+	return MediaStreamFromJS(input.JSValue())
 }
 
 func NewMediaStream(tracks []*MediaStreamTrack) (_result *MediaStream) {
@@ -2978,15 +2966,19 @@ type MediaStreamTrack struct {
 	domcore.EventTarget
 }
 
-// MediaStreamTrackFromJS is casting a js.Wrapper into MediaStreamTrack.
-func MediaStreamTrackFromJS(value js.Wrapper) *MediaStreamTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackFromJS is casting a js.Value into MediaStreamTrack.
+func MediaStreamTrackFromJS(value js.Value) *MediaStreamTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackFromJS is casting from something that holds a js.Value into MediaStreamTrack.
+func MediaStreamTrackFromWrapper(input core.Wrapper) *MediaStreamTrack {
+	return MediaStreamTrackFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -3277,15 +3269,19 @@ type MediaStreamTrackEvent struct {
 	domcore.Event
 }
 
-// MediaStreamTrackEventFromJS is casting a js.Wrapper into MediaStreamTrackEvent.
-func MediaStreamTrackEventFromJS(value js.Wrapper) *MediaStreamTrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackEventFromJS is casting a js.Value into MediaStreamTrackEvent.
+func MediaStreamTrackEventFromJS(value js.Value) *MediaStreamTrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackEventFromJS is casting from something that holds a js.Value into MediaStreamTrackEvent.
+func MediaStreamTrackEventFromWrapper(input core.Wrapper) *MediaStreamTrackEvent {
+	return MediaStreamTrackEventFromJS(input.JSValue())
 }
 
 func NewMediaStreamTrackEvent(_type string, eventInitDict *MediaStreamTrackEventInit) (_result *MediaStreamTrackEvent) {
@@ -3323,15 +3319,19 @@ type OverconstrainedErrorEvent struct {
 	domcore.Event
 }
 
-// OverconstrainedErrorEventFromJS is casting a js.Wrapper into OverconstrainedErrorEvent.
-func OverconstrainedErrorEventFromJS(value js.Wrapper) *OverconstrainedErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OverconstrainedErrorEventFromJS is casting a js.Value into OverconstrainedErrorEvent.
+func OverconstrainedErrorEventFromJS(value js.Value) *OverconstrainedErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OverconstrainedErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OverconstrainedErrorEventFromJS is casting from something that holds a js.Value into OverconstrainedErrorEvent.
+func OverconstrainedErrorEventFromWrapper(input core.Wrapper) *OverconstrainedErrorEvent {
+	return OverconstrainedErrorEventFromJS(input.JSValue())
 }
 
 func NewOverconstrainedErrorEvent(_type string, eventInitDict *OverconstrainedErrorEventInit) (_result *OverconstrainedErrorEvent) {
@@ -3376,15 +3376,19 @@ func (_this *PromiseMediaStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaStreamFromJS is casting a js.Wrapper into PromiseMediaStream.
-func PromiseMediaStreamFromJS(value js.Wrapper) *PromiseMediaStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaStreamFromJS is casting a js.Value into PromiseMediaStream.
+func PromiseMediaStreamFromJS(value js.Value) *PromiseMediaStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaStreamFromJS is casting from something that holds a js.Value into PromiseMediaStream.
+func PromiseMediaStreamFromWrapper(input core.Wrapper) *PromiseMediaStream {
+	return PromiseMediaStreamFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaStream) Then(onFulfilled *PromiseMediaStreamOnFulfilled, onRejected *PromiseMediaStreamOnRejected) (_result *PromiseMediaStream) {
@@ -3481,15 +3485,19 @@ func (_this *PromiseSequenceMediaDeviceInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceMediaDeviceInfoFromJS is casting a js.Wrapper into PromiseSequenceMediaDeviceInfo.
-func PromiseSequenceMediaDeviceInfoFromJS(value js.Wrapper) *PromiseSequenceMediaDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceMediaDeviceInfoFromJS is casting a js.Value into PromiseSequenceMediaDeviceInfo.
+func PromiseSequenceMediaDeviceInfoFromJS(value js.Value) *PromiseSequenceMediaDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceMediaDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceMediaDeviceInfoFromJS is casting from something that holds a js.Value into PromiseSequenceMediaDeviceInfo.
+func PromiseSequenceMediaDeviceInfoFromWrapper(input core.Wrapper) *PromiseSequenceMediaDeviceInfo {
+	return PromiseSequenceMediaDeviceInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceMediaDeviceInfo) Then(onFulfilled *PromiseSequenceMediaDeviceInfoOnFulfilled, onRejected *PromiseSequenceMediaDeviceInfoOnRejected) (_result *PromiseSequenceMediaDeviceInfo) {

--- a/media/capture/local/local_js.go
+++ b/media/capture/local/local_js.go
@@ -5,6 +5,7 @@ package local
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/media/capture/depth"
@@ -393,7 +394,7 @@ func PromiseSequenceMediaDeviceInfoOnRejectedFromJS(_value js.Value) PromiseSequ
 type Capabilities struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Capabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -401,9 +402,8 @@ func (_this *Capabilities) JSValue() js.Value {
 }
 
 // CapabilitiesFromJS is allocating a new
-// Capabilities object and copy all values from
-// input javascript object
-func CapabilitiesFromJS(value js.Wrapper) *Capabilities {
+// Capabilities object and copy all values in the value javascript object.
+func CapabilitiesFromJS(value js.Value) *Capabilities {
 	var out Capabilities
 	var ()
 	return &out
@@ -415,7 +415,7 @@ type ConstrainBooleanParameters struct {
 	Ideal bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainBooleanParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -427,18 +427,16 @@ func (_this *ConstrainBooleanParameters) JSValue() js.Value {
 }
 
 // ConstrainBooleanParametersFromJS is allocating a new
-// ConstrainBooleanParameters object and copy all values from
-// input javascript object
-func ConstrainBooleanParametersFromJS(value js.Wrapper) *ConstrainBooleanParameters {
-	input := value.JSValue()
+// ConstrainBooleanParameters object and copy all values in the value javascript object.
+func ConstrainBooleanParametersFromJS(value js.Value) *ConstrainBooleanParameters {
 	var out ConstrainBooleanParameters
 	var (
 		value0 bool // javascript: boolean {exact Exact exact}
 		value1 bool // javascript: boolean {ideal Ideal ideal}
 	)
-	value0 = (input.Get("exact")).Bool()
+	value0 = (value.Get("exact")).Bool()
 	out.Exact = value0
-	value1 = (input.Get("ideal")).Bool()
+	value1 = (value.Get("ideal")).Bool()
 	out.Ideal = value1
 	return &out
 }
@@ -449,7 +447,7 @@ type ConstrainDOMStringParameters struct {
 	Ideal *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainDOMStringParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -461,18 +459,16 @@ func (_this *ConstrainDOMStringParameters) JSValue() js.Value {
 }
 
 // ConstrainDOMStringParametersFromJS is allocating a new
-// ConstrainDOMStringParameters object and copy all values from
-// input javascript object
-func ConstrainDOMStringParametersFromJS(value js.Wrapper) *ConstrainDOMStringParameters {
-	input := value.JSValue()
+// ConstrainDOMStringParameters object and copy all values in the value javascript object.
+func ConstrainDOMStringParametersFromJS(value js.Value) *ConstrainDOMStringParameters {
 	var out ConstrainDOMStringParameters
 	var (
 		value0 *Union // javascript: Union {exact Exact exact}
 		value1 *Union // javascript: Union {ideal Ideal ideal}
 	)
-	value0 = UnionFromJS(input.Get("exact"))
+	value0 = UnionFromJS(value.Get("exact"))
 	out.Exact = value0
-	value1 = UnionFromJS(input.Get("ideal"))
+	value1 = UnionFromJS(value.Get("ideal"))
 	out.Ideal = value1
 	return &out
 }
@@ -485,7 +481,7 @@ type ConstrainDoubleRange struct {
 	Ideal float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainDoubleRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -501,10 +497,8 @@ func (_this *ConstrainDoubleRange) JSValue() js.Value {
 }
 
 // ConstrainDoubleRangeFromJS is allocating a new
-// ConstrainDoubleRange object and copy all values from
-// input javascript object
-func ConstrainDoubleRangeFromJS(value js.Wrapper) *ConstrainDoubleRange {
-	input := value.JSValue()
+// ConstrainDoubleRange object and copy all values in the value javascript object.
+func ConstrainDoubleRangeFromJS(value js.Value) *ConstrainDoubleRange {
 	var out ConstrainDoubleRange
 	var (
 		value0 float64 // javascript: double {max Max max}
@@ -512,13 +506,13 @@ func ConstrainDoubleRangeFromJS(value js.Wrapper) *ConstrainDoubleRange {
 		value2 float64 // javascript: double {exact Exact exact}
 		value3 float64 // javascript: double {ideal Ideal ideal}
 	)
-	value0 = (input.Get("max")).Float()
+	value0 = (value.Get("max")).Float()
 	out.Max = value0
-	value1 = (input.Get("min")).Float()
+	value1 = (value.Get("min")).Float()
 	out.Min = value1
-	value2 = (input.Get("exact")).Float()
+	value2 = (value.Get("exact")).Float()
 	out.Exact = value2
-	value3 = (input.Get("ideal")).Float()
+	value3 = (value.Get("ideal")).Float()
 	out.Ideal = value3
 	return &out
 }
@@ -531,7 +525,7 @@ type ConstrainULongRange struct {
 	Ideal uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstrainULongRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -547,10 +541,8 @@ func (_this *ConstrainULongRange) JSValue() js.Value {
 }
 
 // ConstrainULongRangeFromJS is allocating a new
-// ConstrainULongRange object and copy all values from
-// input javascript object
-func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
-	input := value.JSValue()
+// ConstrainULongRange object and copy all values in the value javascript object.
+func ConstrainULongRangeFromJS(value js.Value) *ConstrainULongRange {
 	var out ConstrainULongRange
 	var (
 		value0 uint // javascript: unsigned long {max Max max}
@@ -558,13 +550,13 @@ func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
 		value2 uint // javascript: unsigned long {exact Exact exact}
 		value3 uint // javascript: unsigned long {ideal Ideal ideal}
 	)
-	value0 = (uint)((input.Get("max")).Int())
+	value0 = (uint)((value.Get("max")).Int())
 	out.Max = value0
-	value1 = (uint)((input.Get("min")).Int())
+	value1 = (uint)((value.Get("min")).Int())
 	out.Min = value1
-	value2 = (uint)((input.Get("exact")).Int())
+	value2 = (uint)((value.Get("exact")).Int())
 	out.Exact = value2
-	value3 = (uint)((input.Get("ideal")).Int())
+	value3 = (uint)((value.Get("ideal")).Int())
 	out.Ideal = value3
 	return &out
 }
@@ -573,7 +565,7 @@ func ConstrainULongRangeFromJS(value js.Wrapper) *ConstrainULongRange {
 type ConstraintSet struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConstraintSet) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -581,9 +573,8 @@ func (_this *ConstraintSet) JSValue() js.Value {
 }
 
 // ConstraintSetFromJS is allocating a new
-// ConstraintSet object and copy all values from
-// input javascript object
-func ConstraintSetFromJS(value js.Wrapper) *ConstraintSet {
+// ConstraintSet object and copy all values in the value javascript object.
+func ConstraintSetFromJS(value js.Value) *ConstraintSet {
 	var out ConstraintSet
 	var ()
 	return &out
@@ -594,7 +585,7 @@ type Constraints struct {
 	Advanced []*ConstraintSet
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Constraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -608,19 +599,17 @@ func (_this *Constraints) JSValue() js.Value {
 }
 
 // ConstraintsFromJS is allocating a new
-// Constraints object and copy all values from
-// input javascript object
-func ConstraintsFromJS(value js.Wrapper) *Constraints {
-	input := value.JSValue()
+// Constraints object and copy all values in the value javascript object.
+func ConstraintsFromJS(value js.Value) *Constraints {
 	var out Constraints
 	var (
 		value0 []*ConstraintSet // javascript: sequence<ConstraintSet> {advanced Advanced advanced}
 	)
-	__length0 := input.Get("advanced").Length()
+	__length0 := value.Get("advanced").Length()
 	__array0 := make([]*ConstraintSet, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *ConstraintSet
-		__seq_in0 := input.Get("advanced").Index(__idx0)
+		__seq_in0 := value.Get("advanced").Index(__idx0)
 		__seq_out0 = ConstraintSetFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
@@ -635,7 +624,7 @@ type DoubleRange struct {
 	Min float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DoubleRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -647,18 +636,16 @@ func (_this *DoubleRange) JSValue() js.Value {
 }
 
 // DoubleRangeFromJS is allocating a new
-// DoubleRange object and copy all values from
-// input javascript object
-func DoubleRangeFromJS(value js.Wrapper) *DoubleRange {
-	input := value.JSValue()
+// DoubleRange object and copy all values in the value javascript object.
+func DoubleRangeFromJS(value js.Value) *DoubleRange {
 	var out DoubleRange
 	var (
 		value0 float64 // javascript: double {max Max max}
 		value1 float64 // javascript: double {min Min min}
 	)
-	value0 = (input.Get("max")).Float()
+	value0 = (value.Get("max")).Float()
 	out.Max = value0
-	value1 = (input.Get("min")).Float()
+	value1 = (value.Get("min")).Float()
 	out.Min = value1
 	return &out
 }
@@ -669,7 +656,7 @@ type MediaStreamConstraints struct {
 	Audio *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -681,18 +668,16 @@ func (_this *MediaStreamConstraints) JSValue() js.Value {
 }
 
 // MediaStreamConstraintsFromJS is allocating a new
-// MediaStreamConstraints object and copy all values from
-// input javascript object
-func MediaStreamConstraintsFromJS(value js.Wrapper) *MediaStreamConstraints {
-	input := value.JSValue()
+// MediaStreamConstraints object and copy all values in the value javascript object.
+func MediaStreamConstraintsFromJS(value js.Value) *MediaStreamConstraints {
 	var out MediaStreamConstraints
 	var (
 		value0 *Union // javascript: Union {video Video video}
 		value1 *Union // javascript: Union {audio Audio audio}
 	)
-	value0 = UnionFromJS(input.Get("video"))
+	value0 = UnionFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = UnionFromJS(input.Get("audio"))
+	value1 = UnionFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }
@@ -705,7 +690,7 @@ type MediaStreamTrackEventInit struct {
 	Track      *MediaStreamTrack
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamTrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -721,10 +706,8 @@ func (_this *MediaStreamTrackEventInit) JSValue() js.Value {
 }
 
 // MediaStreamTrackEventInitFromJS is allocating a new
-// MediaStreamTrackEventInit object and copy all values from
-// input javascript object
-func MediaStreamTrackEventInitFromJS(value js.Wrapper) *MediaStreamTrackEventInit {
-	input := value.JSValue()
+// MediaStreamTrackEventInit object and copy all values in the value javascript object.
+func MediaStreamTrackEventInitFromJS(value js.Value) *MediaStreamTrackEventInit {
 	var out MediaStreamTrackEventInit
 	var (
 		value0 bool              // javascript: boolean {bubbles Bubbles bubbles}
@@ -732,13 +715,13 @@ func MediaStreamTrackEventInitFromJS(value js.Wrapper) *MediaStreamTrackEventIni
 		value2 bool              // javascript: boolean {composed Composed composed}
 		value3 *MediaStreamTrack // javascript: MediaStreamTrack {track Track track}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = MediaStreamTrackFromJS(input.Get("track"))
+	value3 = MediaStreamTrackFromJS(value.Get("track"))
 	out.Track = value3
 	return &out
 }
@@ -787,7 +770,7 @@ type MediaTrackCapabilities struct {
 	DepthToVideoTransform              bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackCapabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -907,10 +890,8 @@ func (_this *MediaTrackCapabilities) JSValue() js.Value {
 }
 
 // MediaTrackCapabilitiesFromJS is allocating a new
-// MediaTrackCapabilities object and copy all values from
-// input javascript object
-func MediaTrackCapabilitiesFromJS(value js.Wrapper) *MediaTrackCapabilities {
-	input := value.JSValue()
+// MediaTrackCapabilities object and copy all values in the value javascript object.
+func MediaTrackCapabilitiesFromJS(value js.Value) *MediaTrackCapabilities {
 	var out MediaTrackCapabilities
 	var (
 		value0  *ULongRange                   // javascript: ULongRange {width Width width}
@@ -954,149 +935,149 @@ func MediaTrackCapabilitiesFromJS(value js.Wrapper) *MediaTrackCapabilities {
 		value38 *Union                        // javascript: Union {depthFar DepthFar depthFar}
 		value39 bool                          // javascript: boolean {depthToVideoTransform DepthToVideoTransform depthToVideoTransform}
 	)
-	value0 = ULongRangeFromJS(input.Get("width"))
+	value0 = ULongRangeFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = ULongRangeFromJS(input.Get("height"))
+	value1 = ULongRangeFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = DoubleRangeFromJS(input.Get("aspectRatio"))
+	value2 = DoubleRangeFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = DoubleRangeFromJS(input.Get("frameRate"))
+	value3 = DoubleRangeFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	__length4 := input.Get("facingMode").Length()
+	__length4 := value.Get("facingMode").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("facingMode").Index(__idx4)
+		__seq_in4 := value.Get("facingMode").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.FacingMode = value4
-	__length5 := input.Get("resizeMode").Length()
+	__length5 := value.Get("resizeMode").Length()
 	__array5 := make([]string, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 string
-		__seq_in5 := input.Get("resizeMode").Index(__idx5)
+		__seq_in5 := value.Get("resizeMode").Index(__idx5)
 		__seq_out5 = (__seq_in5).String()
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.ResizeMode = value5
-	value6 = DoubleRangeFromJS(input.Get("volume"))
+	value6 = DoubleRangeFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = ULongRangeFromJS(input.Get("sampleRate"))
+	value7 = ULongRangeFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = ULongRangeFromJS(input.Get("sampleSize"))
+	value8 = ULongRangeFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	__length9 := input.Get("echoCancellation").Length()
+	__length9 := value.Get("echoCancellation").Length()
 	__array9 := make([]bool, __length9, __length9)
 	for __idx9 := 0; __idx9 < __length9; __idx9++ {
 		var __seq_out9 bool
-		__seq_in9 := input.Get("echoCancellation").Index(__idx9)
+		__seq_in9 := value.Get("echoCancellation").Index(__idx9)
 		__seq_out9 = (__seq_in9).Bool()
 		__array9[__idx9] = __seq_out9
 	}
 	value9 = __array9
 	out.EchoCancellation = value9
-	__length10 := input.Get("autoGainControl").Length()
+	__length10 := value.Get("autoGainControl").Length()
 	__array10 := make([]bool, __length10, __length10)
 	for __idx10 := 0; __idx10 < __length10; __idx10++ {
 		var __seq_out10 bool
-		__seq_in10 := input.Get("autoGainControl").Index(__idx10)
+		__seq_in10 := value.Get("autoGainControl").Index(__idx10)
 		__seq_out10 = (__seq_in10).Bool()
 		__array10[__idx10] = __seq_out10
 	}
 	value10 = __array10
 	out.AutoGainControl = value10
-	__length11 := input.Get("noiseSuppression").Length()
+	__length11 := value.Get("noiseSuppression").Length()
 	__array11 := make([]bool, __length11, __length11)
 	for __idx11 := 0; __idx11 < __length11; __idx11++ {
 		var __seq_out11 bool
-		__seq_in11 := input.Get("noiseSuppression").Index(__idx11)
+		__seq_in11 := value.Get("noiseSuppression").Index(__idx11)
 		__seq_out11 = (__seq_in11).Bool()
 		__array11[__idx11] = __seq_out11
 	}
 	value11 = __array11
 	out.NoiseSuppression = value11
-	value12 = DoubleRangeFromJS(input.Get("latency"))
+	value12 = DoubleRangeFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = ULongRangeFromJS(input.Get("channelCount"))
+	value13 = ULongRangeFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).String()
+	value14 = (value.Get("deviceId")).String()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).String()
+	value15 = (value.Get("groupId")).String()
 	out.GroupId = value15
-	__length16 := input.Get("whiteBalanceMode").Length()
+	__length16 := value.Get("whiteBalanceMode").Length()
 	__array16 := make([]string, __length16, __length16)
 	for __idx16 := 0; __idx16 < __length16; __idx16++ {
 		var __seq_out16 string
-		__seq_in16 := input.Get("whiteBalanceMode").Index(__idx16)
+		__seq_in16 := value.Get("whiteBalanceMode").Index(__idx16)
 		__seq_out16 = (__seq_in16).String()
 		__array16[__idx16] = __seq_out16
 	}
 	value16 = __array16
 	out.WhiteBalanceMode = value16
-	__length17 := input.Get("exposureMode").Length()
+	__length17 := value.Get("exposureMode").Length()
 	__array17 := make([]string, __length17, __length17)
 	for __idx17 := 0; __idx17 < __length17; __idx17++ {
 		var __seq_out17 string
-		__seq_in17 := input.Get("exposureMode").Index(__idx17)
+		__seq_in17 := value.Get("exposureMode").Index(__idx17)
 		__seq_out17 = (__seq_in17).String()
 		__array17[__idx17] = __seq_out17
 	}
 	value17 = __array17
 	out.ExposureMode = value17
-	__length18 := input.Get("focusMode").Length()
+	__length18 := value.Get("focusMode").Length()
 	__array18 := make([]string, __length18, __length18)
 	for __idx18 := 0; __idx18 < __length18; __idx18++ {
 		var __seq_out18 string
-		__seq_in18 := input.Get("focusMode").Index(__idx18)
+		__seq_in18 := value.Get("focusMode").Index(__idx18)
 		__seq_out18 = (__seq_in18).String()
 		__array18[__idx18] = __seq_out18
 	}
 	value18 = __array18
 	out.FocusMode = value18
-	value19 = mediatype.MediaSettingsRangeFromJS(input.Get("exposureCompensation"))
+	value19 = mediatype.MediaSettingsRangeFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value19
-	value20 = mediatype.MediaSettingsRangeFromJS(input.Get("exposureTime"))
+	value20 = mediatype.MediaSettingsRangeFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value20
-	value21 = mediatype.MediaSettingsRangeFromJS(input.Get("colorTemperature"))
+	value21 = mediatype.MediaSettingsRangeFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value21
-	value22 = mediatype.MediaSettingsRangeFromJS(input.Get("iso"))
+	value22 = mediatype.MediaSettingsRangeFromJS(value.Get("iso"))
 	out.Iso = value22
-	value23 = mediatype.MediaSettingsRangeFromJS(input.Get("brightness"))
+	value23 = mediatype.MediaSettingsRangeFromJS(value.Get("brightness"))
 	out.Brightness = value23
-	value24 = mediatype.MediaSettingsRangeFromJS(input.Get("contrast"))
+	value24 = mediatype.MediaSettingsRangeFromJS(value.Get("contrast"))
 	out.Contrast = value24
-	value25 = mediatype.MediaSettingsRangeFromJS(input.Get("saturation"))
+	value25 = mediatype.MediaSettingsRangeFromJS(value.Get("saturation"))
 	out.Saturation = value25
-	value26 = mediatype.MediaSettingsRangeFromJS(input.Get("sharpness"))
+	value26 = mediatype.MediaSettingsRangeFromJS(value.Get("sharpness"))
 	out.Sharpness = value26
-	value27 = mediatype.MediaSettingsRangeFromJS(input.Get("focusDistance"))
+	value27 = mediatype.MediaSettingsRangeFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value27
-	value28 = mediatype.MediaSettingsRangeFromJS(input.Get("zoom"))
+	value28 = mediatype.MediaSettingsRangeFromJS(value.Get("zoom"))
 	out.Zoom = value28
-	value29 = (input.Get("torch")).Bool()
+	value29 = (value.Get("torch")).Bool()
 	out.Torch = value29
-	value30 = (input.Get("videoKind")).String()
+	value30 = (value.Get("videoKind")).String()
 	out.VideoKind = value30
-	value31 = UnionFromJS(input.Get("focalLengthX"))
+	value31 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value31
-	value32 = UnionFromJS(input.Get("focalLengthY"))
+	value32 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value32
-	value33 = UnionFromJS(input.Get("principalPointX"))
+	value33 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value33
-	value34 = UnionFromJS(input.Get("principalPointY"))
+	value34 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value34
-	value35 = (input.Get("deprojectionDistortionCoefficients")).Bool()
+	value35 = (value.Get("deprojectionDistortionCoefficients")).Bool()
 	out.DeprojectionDistortionCoefficients = value35
-	value36 = (input.Get("projectionDistortionCoefficients")).Bool()
+	value36 = (value.Get("projectionDistortionCoefficients")).Bool()
 	out.ProjectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("depthNear"))
+	value37 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value37
-	value38 = UnionFromJS(input.Get("depthFar"))
+	value38 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value38
-	value39 = (input.Get("depthToVideoTransform")).Bool()
+	value39 = (value.Get("depthToVideoTransform")).Bool()
 	out.DepthToVideoTransform = value39
 	return &out
 }
@@ -1149,7 +1130,7 @@ type MediaTrackConstraintSet struct {
 	Cursor                             *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackConstraintSet) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1245,10 +1226,8 @@ func (_this *MediaTrackConstraintSet) JSValue() js.Value {
 }
 
 // MediaTrackConstraintSetFromJS is allocating a new
-// MediaTrackConstraintSet object and copy all values from
-// input javascript object
-func MediaTrackConstraintSetFromJS(value js.Wrapper) *MediaTrackConstraintSet {
-	input := value.JSValue()
+// MediaTrackConstraintSet object and copy all values in the value javascript object.
+func MediaTrackConstraintSetFromJS(value js.Value) *MediaTrackConstraintSet {
 	var out MediaTrackConstraintSet
 	var (
 		value0  *Union // javascript: Union {width Width width}
@@ -1296,93 +1275,93 @@ func MediaTrackConstraintSetFromJS(value js.Wrapper) *MediaTrackConstraintSet {
 		value42 *Union // javascript: Union {logicalSurface LogicalSurface logicalSurface}
 		value43 *Union // javascript: Union {cursor Cursor cursor}
 	)
-	value0 = UnionFromJS(input.Get("width"))
+	value0 = UnionFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = UnionFromJS(input.Get("height"))
+	value1 = UnionFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = UnionFromJS(input.Get("aspectRatio"))
+	value2 = UnionFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = UnionFromJS(input.Get("frameRate"))
+	value3 = UnionFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	value4 = UnionFromJS(input.Get("facingMode"))
+	value4 = UnionFromJS(value.Get("facingMode"))
 	out.FacingMode = value4
-	value5 = UnionFromJS(input.Get("resizeMode"))
+	value5 = UnionFromJS(value.Get("resizeMode"))
 	out.ResizeMode = value5
-	value6 = UnionFromJS(input.Get("volume"))
+	value6 = UnionFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = UnionFromJS(input.Get("sampleRate"))
+	value7 = UnionFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = UnionFromJS(input.Get("sampleSize"))
+	value8 = UnionFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	value9 = UnionFromJS(input.Get("echoCancellation"))
+	value9 = UnionFromJS(value.Get("echoCancellation"))
 	out.EchoCancellation = value9
-	value10 = UnionFromJS(input.Get("autoGainControl"))
+	value10 = UnionFromJS(value.Get("autoGainControl"))
 	out.AutoGainControl = value10
-	value11 = UnionFromJS(input.Get("noiseSuppression"))
+	value11 = UnionFromJS(value.Get("noiseSuppression"))
 	out.NoiseSuppression = value11
-	value12 = UnionFromJS(input.Get("latency"))
+	value12 = UnionFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = UnionFromJS(input.Get("channelCount"))
+	value13 = UnionFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = UnionFromJS(input.Get("deviceId"))
+	value14 = UnionFromJS(value.Get("deviceId"))
 	out.DeviceId = value14
-	value15 = UnionFromJS(input.Get("groupId"))
+	value15 = UnionFromJS(value.Get("groupId"))
 	out.GroupId = value15
-	value16 = UnionFromJS(input.Get("whiteBalanceMode"))
+	value16 = UnionFromJS(value.Get("whiteBalanceMode"))
 	out.WhiteBalanceMode = value16
-	value17 = UnionFromJS(input.Get("exposureMode"))
+	value17 = UnionFromJS(value.Get("exposureMode"))
 	out.ExposureMode = value17
-	value18 = UnionFromJS(input.Get("focusMode"))
+	value18 = UnionFromJS(value.Get("focusMode"))
 	out.FocusMode = value18
-	value19 = UnionFromJS(input.Get("pointsOfInterest"))
+	value19 = UnionFromJS(value.Get("pointsOfInterest"))
 	out.PointsOfInterest = value19
-	value20 = UnionFromJS(input.Get("exposureCompensation"))
+	value20 = UnionFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value20
-	value21 = UnionFromJS(input.Get("exposureTime"))
+	value21 = UnionFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value21
-	value22 = UnionFromJS(input.Get("colorTemperature"))
+	value22 = UnionFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value22
-	value23 = UnionFromJS(input.Get("iso"))
+	value23 = UnionFromJS(value.Get("iso"))
 	out.Iso = value23
-	value24 = UnionFromJS(input.Get("brightness"))
+	value24 = UnionFromJS(value.Get("brightness"))
 	out.Brightness = value24
-	value25 = UnionFromJS(input.Get("contrast"))
+	value25 = UnionFromJS(value.Get("contrast"))
 	out.Contrast = value25
-	value26 = UnionFromJS(input.Get("saturation"))
+	value26 = UnionFromJS(value.Get("saturation"))
 	out.Saturation = value26
-	value27 = UnionFromJS(input.Get("sharpness"))
+	value27 = UnionFromJS(value.Get("sharpness"))
 	out.Sharpness = value27
-	value28 = UnionFromJS(input.Get("focusDistance"))
+	value28 = UnionFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value28
-	value29 = UnionFromJS(input.Get("zoom"))
+	value29 = UnionFromJS(value.Get("zoom"))
 	out.Zoom = value29
-	value30 = UnionFromJS(input.Get("torch"))
+	value30 = UnionFromJS(value.Get("torch"))
 	out.Torch = value30
-	value31 = UnionFromJS(input.Get("videoKind"))
+	value31 = UnionFromJS(value.Get("videoKind"))
 	out.VideoKind = value31
-	value32 = UnionFromJS(input.Get("focalLengthX"))
+	value32 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value32
-	value33 = UnionFromJS(input.Get("focalLengthY"))
+	value33 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value33
-	value34 = UnionFromJS(input.Get("principalPointX"))
+	value34 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value34
-	value35 = UnionFromJS(input.Get("principalPointY"))
+	value35 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value35
-	value36 = UnionFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = UnionFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = UnionFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = UnionFromJS(input.Get("depthNear"))
+	value38 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value38
-	value39 = UnionFromJS(input.Get("depthFar"))
+	value39 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value39
-	value40 = UnionFromJS(input.Get("depthToVideoTransform"))
+	value40 = UnionFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = UnionFromJS(input.Get("displaySurface"))
+	value41 = UnionFromJS(value.Get("displaySurface"))
 	out.DisplaySurface = value41
-	value42 = UnionFromJS(input.Get("logicalSurface"))
+	value42 = UnionFromJS(value.Get("logicalSurface"))
 	out.LogicalSurface = value42
-	value43 = UnionFromJS(input.Get("cursor"))
+	value43 = UnionFromJS(value.Get("cursor"))
 	out.Cursor = value43
 	return &out
 }
@@ -1436,7 +1415,7 @@ type MediaTrackConstraints struct {
 	Advanced                           []*MediaTrackConstraintSet
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1538,10 +1517,8 @@ func (_this *MediaTrackConstraints) JSValue() js.Value {
 }
 
 // MediaTrackConstraintsFromJS is allocating a new
-// MediaTrackConstraints object and copy all values from
-// input javascript object
-func MediaTrackConstraintsFromJS(value js.Wrapper) *MediaTrackConstraints {
-	input := value.JSValue()
+// MediaTrackConstraints object and copy all values in the value javascript object.
+func MediaTrackConstraintsFromJS(value js.Value) *MediaTrackConstraints {
 	var out MediaTrackConstraints
 	var (
 		value0  *Union                     // javascript: Union {width Width width}
@@ -1590,99 +1567,99 @@ func MediaTrackConstraintsFromJS(value js.Wrapper) *MediaTrackConstraints {
 		value43 *Union                     // javascript: Union {cursor Cursor cursor}
 		value44 []*MediaTrackConstraintSet // javascript: sequence<MediaTrackConstraintSet> {advanced Advanced advanced}
 	)
-	value0 = UnionFromJS(input.Get("width"))
+	value0 = UnionFromJS(value.Get("width"))
 	out.Width = value0
-	value1 = UnionFromJS(input.Get("height"))
+	value1 = UnionFromJS(value.Get("height"))
 	out.Height = value1
-	value2 = UnionFromJS(input.Get("aspectRatio"))
+	value2 = UnionFromJS(value.Get("aspectRatio"))
 	out.AspectRatio = value2
-	value3 = UnionFromJS(input.Get("frameRate"))
+	value3 = UnionFromJS(value.Get("frameRate"))
 	out.FrameRate = value3
-	value4 = UnionFromJS(input.Get("facingMode"))
+	value4 = UnionFromJS(value.Get("facingMode"))
 	out.FacingMode = value4
-	value5 = UnionFromJS(input.Get("resizeMode"))
+	value5 = UnionFromJS(value.Get("resizeMode"))
 	out.ResizeMode = value5
-	value6 = UnionFromJS(input.Get("volume"))
+	value6 = UnionFromJS(value.Get("volume"))
 	out.Volume = value6
-	value7 = UnionFromJS(input.Get("sampleRate"))
+	value7 = UnionFromJS(value.Get("sampleRate"))
 	out.SampleRate = value7
-	value8 = UnionFromJS(input.Get("sampleSize"))
+	value8 = UnionFromJS(value.Get("sampleSize"))
 	out.SampleSize = value8
-	value9 = UnionFromJS(input.Get("echoCancellation"))
+	value9 = UnionFromJS(value.Get("echoCancellation"))
 	out.EchoCancellation = value9
-	value10 = UnionFromJS(input.Get("autoGainControl"))
+	value10 = UnionFromJS(value.Get("autoGainControl"))
 	out.AutoGainControl = value10
-	value11 = UnionFromJS(input.Get("noiseSuppression"))
+	value11 = UnionFromJS(value.Get("noiseSuppression"))
 	out.NoiseSuppression = value11
-	value12 = UnionFromJS(input.Get("latency"))
+	value12 = UnionFromJS(value.Get("latency"))
 	out.Latency = value12
-	value13 = UnionFromJS(input.Get("channelCount"))
+	value13 = UnionFromJS(value.Get("channelCount"))
 	out.ChannelCount = value13
-	value14 = UnionFromJS(input.Get("deviceId"))
+	value14 = UnionFromJS(value.Get("deviceId"))
 	out.DeviceId = value14
-	value15 = UnionFromJS(input.Get("groupId"))
+	value15 = UnionFromJS(value.Get("groupId"))
 	out.GroupId = value15
-	value16 = UnionFromJS(input.Get("whiteBalanceMode"))
+	value16 = UnionFromJS(value.Get("whiteBalanceMode"))
 	out.WhiteBalanceMode = value16
-	value17 = UnionFromJS(input.Get("exposureMode"))
+	value17 = UnionFromJS(value.Get("exposureMode"))
 	out.ExposureMode = value17
-	value18 = UnionFromJS(input.Get("focusMode"))
+	value18 = UnionFromJS(value.Get("focusMode"))
 	out.FocusMode = value18
-	value19 = UnionFromJS(input.Get("pointsOfInterest"))
+	value19 = UnionFromJS(value.Get("pointsOfInterest"))
 	out.PointsOfInterest = value19
-	value20 = UnionFromJS(input.Get("exposureCompensation"))
+	value20 = UnionFromJS(value.Get("exposureCompensation"))
 	out.ExposureCompensation = value20
-	value21 = UnionFromJS(input.Get("exposureTime"))
+	value21 = UnionFromJS(value.Get("exposureTime"))
 	out.ExposureTime = value21
-	value22 = UnionFromJS(input.Get("colorTemperature"))
+	value22 = UnionFromJS(value.Get("colorTemperature"))
 	out.ColorTemperature = value22
-	value23 = UnionFromJS(input.Get("iso"))
+	value23 = UnionFromJS(value.Get("iso"))
 	out.Iso = value23
-	value24 = UnionFromJS(input.Get("brightness"))
+	value24 = UnionFromJS(value.Get("brightness"))
 	out.Brightness = value24
-	value25 = UnionFromJS(input.Get("contrast"))
+	value25 = UnionFromJS(value.Get("contrast"))
 	out.Contrast = value25
-	value26 = UnionFromJS(input.Get("saturation"))
+	value26 = UnionFromJS(value.Get("saturation"))
 	out.Saturation = value26
-	value27 = UnionFromJS(input.Get("sharpness"))
+	value27 = UnionFromJS(value.Get("sharpness"))
 	out.Sharpness = value27
-	value28 = UnionFromJS(input.Get("focusDistance"))
+	value28 = UnionFromJS(value.Get("focusDistance"))
 	out.FocusDistance = value28
-	value29 = UnionFromJS(input.Get("zoom"))
+	value29 = UnionFromJS(value.Get("zoom"))
 	out.Zoom = value29
-	value30 = UnionFromJS(input.Get("torch"))
+	value30 = UnionFromJS(value.Get("torch"))
 	out.Torch = value30
-	value31 = UnionFromJS(input.Get("videoKind"))
+	value31 = UnionFromJS(value.Get("videoKind"))
 	out.VideoKind = value31
-	value32 = UnionFromJS(input.Get("focalLengthX"))
+	value32 = UnionFromJS(value.Get("focalLengthX"))
 	out.FocalLengthX = value32
-	value33 = UnionFromJS(input.Get("focalLengthY"))
+	value33 = UnionFromJS(value.Get("focalLengthY"))
 	out.FocalLengthY = value33
-	value34 = UnionFromJS(input.Get("principalPointX"))
+	value34 = UnionFromJS(value.Get("principalPointX"))
 	out.PrincipalPointX = value34
-	value35 = UnionFromJS(input.Get("principalPointY"))
+	value35 = UnionFromJS(value.Get("principalPointY"))
 	out.PrincipalPointY = value35
-	value36 = UnionFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = UnionFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = UnionFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = UnionFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = UnionFromJS(input.Get("depthNear"))
+	value38 = UnionFromJS(value.Get("depthNear"))
 	out.DepthNear = value38
-	value39 = UnionFromJS(input.Get("depthFar"))
+	value39 = UnionFromJS(value.Get("depthFar"))
 	out.DepthFar = value39
-	value40 = UnionFromJS(input.Get("depthToVideoTransform"))
+	value40 = UnionFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = UnionFromJS(input.Get("displaySurface"))
+	value41 = UnionFromJS(value.Get("displaySurface"))
 	out.DisplaySurface = value41
-	value42 = UnionFromJS(input.Get("logicalSurface"))
+	value42 = UnionFromJS(value.Get("logicalSurface"))
 	out.LogicalSurface = value42
-	value43 = UnionFromJS(input.Get("cursor"))
+	value43 = UnionFromJS(value.Get("cursor"))
 	out.Cursor = value43
-	__length44 := input.Get("advanced").Length()
+	__length44 := value.Get("advanced").Length()
 	__array44 := make([]*MediaTrackConstraintSet, __length44, __length44)
 	for __idx44 := 0; __idx44 < __length44; __idx44++ {
 		var __seq_out44 *MediaTrackConstraintSet
-		__seq_in44 := input.Get("advanced").Index(__idx44)
+		__seq_in44 := value.Get("advanced").Index(__idx44)
 		__seq_out44 = MediaTrackConstraintSetFromJS(__seq_in44)
 		__array44[__idx44] = __seq_out44
 	}
@@ -1739,7 +1716,7 @@ type MediaTrackSettings struct {
 	Cursor                             string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackSettings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1839,10 +1816,8 @@ func (_this *MediaTrackSettings) JSValue() js.Value {
 }
 
 // MediaTrackSettingsFromJS is allocating a new
-// MediaTrackSettings object and copy all values from
-// input javascript object
-func MediaTrackSettingsFromJS(value js.Wrapper) *MediaTrackSettings {
-	input := value.JSValue()
+// MediaTrackSettings object and copy all values in the value javascript object.
+func MediaTrackSettingsFromJS(value js.Value) *MediaTrackSettings {
 	var out MediaTrackSettings
 	var (
 		value0  int                           // javascript: long {width Width width}
@@ -1890,101 +1865,101 @@ func MediaTrackSettingsFromJS(value js.Wrapper) *MediaTrackSettings {
 		value42 bool                          // javascript: boolean {logicalSurface LogicalSurface logicalSurface}
 		value43 string                        // javascript: DOMString {cursor Cursor cursor}
 	)
-	value0 = (input.Get("width")).Int()
+	value0 = (value.Get("width")).Int()
 	out.Width = value0
-	value1 = (input.Get("height")).Int()
+	value1 = (value.Get("height")).Int()
 	out.Height = value1
-	value2 = (input.Get("aspectRatio")).Float()
+	value2 = (value.Get("aspectRatio")).Float()
 	out.AspectRatio = value2
-	value3 = (input.Get("frameRate")).Float()
+	value3 = (value.Get("frameRate")).Float()
 	out.FrameRate = value3
-	value4 = (input.Get("facingMode")).String()
+	value4 = (value.Get("facingMode")).String()
 	out.FacingMode = value4
-	value5 = (input.Get("resizeMode")).String()
+	value5 = (value.Get("resizeMode")).String()
 	out.ResizeMode = value5
-	value6 = (input.Get("volume")).Float()
+	value6 = (value.Get("volume")).Float()
 	out.Volume = value6
-	value7 = (input.Get("sampleRate")).Int()
+	value7 = (value.Get("sampleRate")).Int()
 	out.SampleRate = value7
-	value8 = (input.Get("sampleSize")).Int()
+	value8 = (value.Get("sampleSize")).Int()
 	out.SampleSize = value8
-	value9 = (input.Get("echoCancellation")).Bool()
+	value9 = (value.Get("echoCancellation")).Bool()
 	out.EchoCancellation = value9
-	value10 = (input.Get("autoGainControl")).Bool()
+	value10 = (value.Get("autoGainControl")).Bool()
 	out.AutoGainControl = value10
-	value11 = (input.Get("noiseSuppression")).Bool()
+	value11 = (value.Get("noiseSuppression")).Bool()
 	out.NoiseSuppression = value11
-	value12 = (input.Get("latency")).Float()
+	value12 = (value.Get("latency")).Float()
 	out.Latency = value12
-	value13 = (input.Get("channelCount")).Int()
+	value13 = (value.Get("channelCount")).Int()
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).String()
+	value14 = (value.Get("deviceId")).String()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).String()
+	value15 = (value.Get("groupId")).String()
 	out.GroupId = value15
-	value16 = (input.Get("whiteBalanceMode")).String()
+	value16 = (value.Get("whiteBalanceMode")).String()
 	out.WhiteBalanceMode = value16
-	value17 = (input.Get("exposureMode")).String()
+	value17 = (value.Get("exposureMode")).String()
 	out.ExposureMode = value17
-	value18 = (input.Get("focusMode")).String()
+	value18 = (value.Get("focusMode")).String()
 	out.FocusMode = value18
-	__length19 := input.Get("pointsOfInterest").Length()
+	__length19 := value.Get("pointsOfInterest").Length()
 	__array19 := make([]*mediatype.Point2D, __length19, __length19)
 	for __idx19 := 0; __idx19 < __length19; __idx19++ {
 		var __seq_out19 *mediatype.Point2D
-		__seq_in19 := input.Get("pointsOfInterest").Index(__idx19)
+		__seq_in19 := value.Get("pointsOfInterest").Index(__idx19)
 		__seq_out19 = mediatype.Point2DFromJS(__seq_in19)
 		__array19[__idx19] = __seq_out19
 	}
 	value19 = __array19
 	out.PointsOfInterest = value19
-	value20 = (input.Get("exposureCompensation")).Float()
+	value20 = (value.Get("exposureCompensation")).Float()
 	out.ExposureCompensation = value20
-	value21 = (input.Get("exposureTime")).Float()
+	value21 = (value.Get("exposureTime")).Float()
 	out.ExposureTime = value21
-	value22 = (input.Get("colorTemperature")).Float()
+	value22 = (value.Get("colorTemperature")).Float()
 	out.ColorTemperature = value22
-	value23 = (input.Get("iso")).Float()
+	value23 = (value.Get("iso")).Float()
 	out.Iso = value23
-	value24 = (input.Get("brightness")).Float()
+	value24 = (value.Get("brightness")).Float()
 	out.Brightness = value24
-	value25 = (input.Get("contrast")).Float()
+	value25 = (value.Get("contrast")).Float()
 	out.Contrast = value25
-	value26 = (input.Get("saturation")).Float()
+	value26 = (value.Get("saturation")).Float()
 	out.Saturation = value26
-	value27 = (input.Get("sharpness")).Float()
+	value27 = (value.Get("sharpness")).Float()
 	out.Sharpness = value27
-	value28 = (input.Get("focusDistance")).Float()
+	value28 = (value.Get("focusDistance")).Float()
 	out.FocusDistance = value28
-	value29 = (input.Get("zoom")).Float()
+	value29 = (value.Get("zoom")).Float()
 	out.Zoom = value29
-	value30 = (input.Get("torch")).Bool()
+	value30 = (value.Get("torch")).Bool()
 	out.Torch = value30
-	value31 = (input.Get("videoKind")).String()
+	value31 = (value.Get("videoKind")).String()
 	out.VideoKind = value31
-	value32 = (input.Get("focalLengthX")).Float()
+	value32 = (value.Get("focalLengthX")).Float()
 	out.FocalLengthX = value32
-	value33 = (input.Get("focalLengthY")).Float()
+	value33 = (value.Get("focalLengthY")).Float()
 	out.FocalLengthY = value33
-	value34 = (input.Get("principalPointX")).Float()
+	value34 = (value.Get("principalPointX")).Float()
 	out.PrincipalPointX = value34
-	value35 = (input.Get("principalPointY")).Float()
+	value35 = (value.Get("principalPointY")).Float()
 	out.PrincipalPointY = value35
-	value36 = depth.DistortionCoefficientsFromJS(input.Get("deprojectionDistortionCoefficients"))
+	value36 = depth.DistortionCoefficientsFromJS(value.Get("deprojectionDistortionCoefficients"))
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = depth.DistortionCoefficientsFromJS(input.Get("projectionDistortionCoefficients"))
+	value37 = depth.DistortionCoefficientsFromJS(value.Get("projectionDistortionCoefficients"))
 	out.ProjectionDistortionCoefficients = value37
-	value38 = (input.Get("depthNear")).Float()
+	value38 = (value.Get("depthNear")).Float()
 	out.DepthNear = value38
-	value39 = (input.Get("depthFar")).Float()
+	value39 = (value.Get("depthFar")).Float()
 	out.DepthFar = value39
-	value40 = depth.TransformationFromJS(input.Get("depthToVideoTransform"))
+	value40 = depth.TransformationFromJS(value.Get("depthToVideoTransform"))
 	out.DepthToVideoTransform = value40
-	value41 = (input.Get("displaySurface")).String()
+	value41 = (value.Get("displaySurface")).String()
 	out.DisplaySurface = value41
-	value42 = (input.Get("logicalSurface")).Bool()
+	value42 = (value.Get("logicalSurface")).Bool()
 	out.LogicalSurface = value42
-	value43 = (input.Get("cursor")).String()
+	value43 = (value.Get("cursor")).String()
 	out.Cursor = value43
 	return &out
 }
@@ -2037,7 +2012,7 @@ type MediaTrackSupportedConstraints struct {
 	Cursor                             bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaTrackSupportedConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2133,10 +2108,8 @@ func (_this *MediaTrackSupportedConstraints) JSValue() js.Value {
 }
 
 // MediaTrackSupportedConstraintsFromJS is allocating a new
-// MediaTrackSupportedConstraints object and copy all values from
-// input javascript object
-func MediaTrackSupportedConstraintsFromJS(value js.Wrapper) *MediaTrackSupportedConstraints {
-	input := value.JSValue()
+// MediaTrackSupportedConstraints object and copy all values in the value javascript object.
+func MediaTrackSupportedConstraintsFromJS(value js.Value) *MediaTrackSupportedConstraints {
 	var out MediaTrackSupportedConstraints
 	var (
 		value0  bool // javascript: boolean {width Width width}
@@ -2184,93 +2157,93 @@ func MediaTrackSupportedConstraintsFromJS(value js.Wrapper) *MediaTrackSupported
 		value42 bool // javascript: boolean {logicalSurface LogicalSurface logicalSurface}
 		value43 bool // javascript: boolean {cursor Cursor cursor}
 	)
-	value0 = (input.Get("width")).Bool()
+	value0 = (value.Get("width")).Bool()
 	out.Width = value0
-	value1 = (input.Get("height")).Bool()
+	value1 = (value.Get("height")).Bool()
 	out.Height = value1
-	value2 = (input.Get("aspectRatio")).Bool()
+	value2 = (value.Get("aspectRatio")).Bool()
 	out.AspectRatio = value2
-	value3 = (input.Get("frameRate")).Bool()
+	value3 = (value.Get("frameRate")).Bool()
 	out.FrameRate = value3
-	value4 = (input.Get("facingMode")).Bool()
+	value4 = (value.Get("facingMode")).Bool()
 	out.FacingMode = value4
-	value5 = (input.Get("resizeMode")).Bool()
+	value5 = (value.Get("resizeMode")).Bool()
 	out.ResizeMode = value5
-	value6 = (input.Get("volume")).Bool()
+	value6 = (value.Get("volume")).Bool()
 	out.Volume = value6
-	value7 = (input.Get("sampleRate")).Bool()
+	value7 = (value.Get("sampleRate")).Bool()
 	out.SampleRate = value7
-	value8 = (input.Get("sampleSize")).Bool()
+	value8 = (value.Get("sampleSize")).Bool()
 	out.SampleSize = value8
-	value9 = (input.Get("echoCancellation")).Bool()
+	value9 = (value.Get("echoCancellation")).Bool()
 	out.EchoCancellation = value9
-	value10 = (input.Get("autoGainControl")).Bool()
+	value10 = (value.Get("autoGainControl")).Bool()
 	out.AutoGainControl = value10
-	value11 = (input.Get("noiseSuppression")).Bool()
+	value11 = (value.Get("noiseSuppression")).Bool()
 	out.NoiseSuppression = value11
-	value12 = (input.Get("latency")).Bool()
+	value12 = (value.Get("latency")).Bool()
 	out.Latency = value12
-	value13 = (input.Get("channelCount")).Bool()
+	value13 = (value.Get("channelCount")).Bool()
 	out.ChannelCount = value13
-	value14 = (input.Get("deviceId")).Bool()
+	value14 = (value.Get("deviceId")).Bool()
 	out.DeviceId = value14
-	value15 = (input.Get("groupId")).Bool()
+	value15 = (value.Get("groupId")).Bool()
 	out.GroupId = value15
-	value16 = (input.Get("whiteBalanceMode")).Bool()
+	value16 = (value.Get("whiteBalanceMode")).Bool()
 	out.WhiteBalanceMode = value16
-	value17 = (input.Get("exposureMode")).Bool()
+	value17 = (value.Get("exposureMode")).Bool()
 	out.ExposureMode = value17
-	value18 = (input.Get("focusMode")).Bool()
+	value18 = (value.Get("focusMode")).Bool()
 	out.FocusMode = value18
-	value19 = (input.Get("pointsOfInterest")).Bool()
+	value19 = (value.Get("pointsOfInterest")).Bool()
 	out.PointsOfInterest = value19
-	value20 = (input.Get("exposureCompensation")).Bool()
+	value20 = (value.Get("exposureCompensation")).Bool()
 	out.ExposureCompensation = value20
-	value21 = (input.Get("exposureTime")).Bool()
+	value21 = (value.Get("exposureTime")).Bool()
 	out.ExposureTime = value21
-	value22 = (input.Get("colorTemperature")).Bool()
+	value22 = (value.Get("colorTemperature")).Bool()
 	out.ColorTemperature = value22
-	value23 = (input.Get("iso")).Bool()
+	value23 = (value.Get("iso")).Bool()
 	out.Iso = value23
-	value24 = (input.Get("brightness")).Bool()
+	value24 = (value.Get("brightness")).Bool()
 	out.Brightness = value24
-	value25 = (input.Get("contrast")).Bool()
+	value25 = (value.Get("contrast")).Bool()
 	out.Contrast = value25
-	value26 = (input.Get("saturation")).Bool()
+	value26 = (value.Get("saturation")).Bool()
 	out.Saturation = value26
-	value27 = (input.Get("sharpness")).Bool()
+	value27 = (value.Get("sharpness")).Bool()
 	out.Sharpness = value27
-	value28 = (input.Get("focusDistance")).Bool()
+	value28 = (value.Get("focusDistance")).Bool()
 	out.FocusDistance = value28
-	value29 = (input.Get("zoom")).Bool()
+	value29 = (value.Get("zoom")).Bool()
 	out.Zoom = value29
-	value30 = (input.Get("torch")).Bool()
+	value30 = (value.Get("torch")).Bool()
 	out.Torch = value30
-	value31 = (input.Get("videoKind")).Bool()
+	value31 = (value.Get("videoKind")).Bool()
 	out.VideoKind = value31
-	value32 = (input.Get("focalLengthX")).Bool()
+	value32 = (value.Get("focalLengthX")).Bool()
 	out.FocalLengthX = value32
-	value33 = (input.Get("focalLengthY")).Bool()
+	value33 = (value.Get("focalLengthY")).Bool()
 	out.FocalLengthY = value33
-	value34 = (input.Get("principalPointX")).Bool()
+	value34 = (value.Get("principalPointX")).Bool()
 	out.PrincipalPointX = value34
-	value35 = (input.Get("principalPointY")).Bool()
+	value35 = (value.Get("principalPointY")).Bool()
 	out.PrincipalPointY = value35
-	value36 = (input.Get("deprojectionDistortionCoefficients")).Bool()
+	value36 = (value.Get("deprojectionDistortionCoefficients")).Bool()
 	out.DeprojectionDistortionCoefficients = value36
-	value37 = (input.Get("projectionDistortionCoefficients")).Bool()
+	value37 = (value.Get("projectionDistortionCoefficients")).Bool()
 	out.ProjectionDistortionCoefficients = value37
-	value38 = (input.Get("depthNear")).Bool()
+	value38 = (value.Get("depthNear")).Bool()
 	out.DepthNear = value38
-	value39 = (input.Get("depthFar")).Bool()
+	value39 = (value.Get("depthFar")).Bool()
 	out.DepthFar = value39
-	value40 = (input.Get("depthToVideoTransform")).Bool()
+	value40 = (value.Get("depthToVideoTransform")).Bool()
 	out.DepthToVideoTransform = value40
-	value41 = (input.Get("displaySurface")).Bool()
+	value41 = (value.Get("displaySurface")).Bool()
 	out.DisplaySurface = value41
-	value42 = (input.Get("logicalSurface")).Bool()
+	value42 = (value.Get("logicalSurface")).Bool()
 	out.LogicalSurface = value42
-	value43 = (input.Get("cursor")).Bool()
+	value43 = (value.Get("cursor")).Bool()
 	out.Cursor = value43
 	return &out
 }
@@ -2283,7 +2256,7 @@ type OverconstrainedErrorEventInit struct {
 	Error      *patch.OverconstrainedError
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OverconstrainedErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2299,10 +2272,8 @@ func (_this *OverconstrainedErrorEventInit) JSValue() js.Value {
 }
 
 // OverconstrainedErrorEventInitFromJS is allocating a new
-// OverconstrainedErrorEventInit object and copy all values from
-// input javascript object
-func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedErrorEventInit {
-	input := value.JSValue()
+// OverconstrainedErrorEventInit object and copy all values in the value javascript object.
+func OverconstrainedErrorEventInitFromJS(value js.Value) *OverconstrainedErrorEventInit {
 	var out OverconstrainedErrorEventInit
 	var (
 		value0 bool                        // javascript: boolean {bubbles Bubbles bubbles}
@@ -2310,14 +2281,14 @@ func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedError
 		value2 bool                        // javascript: boolean {composed Composed composed}
 		value3 *patch.OverconstrainedError // javascript: OverconstrainedError {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("error").Type() != js.TypeNull && input.Get("error").Type() != js.TypeUndefined {
-		value3 = patch.OverconstrainedErrorFromJS(input.Get("error"))
+	if value.Get("error").Type() != js.TypeNull && value.Get("error").Type() != js.TypeUndefined {
+		value3 = patch.OverconstrainedErrorFromJS(value.Get("error"))
 	}
 	out.Error = value3
 	return &out
@@ -2327,7 +2298,7 @@ func OverconstrainedErrorEventInitFromJS(value js.Wrapper) *OverconstrainedError
 type Settings struct {
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Settings) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2335,9 +2306,8 @@ func (_this *Settings) JSValue() js.Value {
 }
 
 // SettingsFromJS is allocating a new
-// Settings object and copy all values from
-// input javascript object
-func SettingsFromJS(value js.Wrapper) *Settings {
+// Settings object and copy all values in the value javascript object.
+func SettingsFromJS(value js.Value) *Settings {
 	var out Settings
 	var ()
 	return &out
@@ -2349,7 +2319,7 @@ type ULongRange struct {
 	Min uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ULongRange) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2361,18 +2331,16 @@ func (_this *ULongRange) JSValue() js.Value {
 }
 
 // ULongRangeFromJS is allocating a new
-// ULongRange object and copy all values from
-// input javascript object
-func ULongRangeFromJS(value js.Wrapper) *ULongRange {
-	input := value.JSValue()
+// ULongRange object and copy all values in the value javascript object.
+func ULongRangeFromJS(value js.Value) *ULongRange {
 	var out ULongRange
 	var (
 		value0 uint // javascript: unsigned long {max Max max}
 		value1 uint // javascript: unsigned long {min Min min}
 	)
-	value0 = (uint)((input.Get("max")).Int())
+	value0 = (uint)((value.Get("max")).Int())
 	out.Max = value0
-	value1 = (uint)((input.Get("min")).Int())
+	value1 = (uint)((value.Get("min")).Int())
 	out.Min = value1
 	return &out
 }
@@ -2387,15 +2355,19 @@ func (_this *ConstrainablePattern) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ConstrainablePatternFromJS is casting a js.Wrapper into ConstrainablePattern.
-func ConstrainablePatternFromJS(value js.Wrapper) *ConstrainablePattern {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConstrainablePatternFromJS is casting a js.Value into ConstrainablePattern.
+func ConstrainablePatternFromJS(value js.Value) *ConstrainablePattern {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConstrainablePattern{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConstrainablePatternFromJS is casting from something that holds a js.Value into ConstrainablePattern.
+func ConstrainablePatternFromWrapper(input core.Wrapper) *ConstrainablePattern {
+	return ConstrainablePatternFromJS(input.JSValue())
 }
 
 // OnOverConstrained returning attribute 'onoverconstrained' with
@@ -2505,15 +2477,19 @@ type InputDeviceInfo struct {
 	MediaDeviceInfo
 }
 
-// InputDeviceInfoFromJS is casting a js.Wrapper into InputDeviceInfo.
-func InputDeviceInfoFromJS(value js.Wrapper) *InputDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputDeviceInfoFromJS is casting a js.Value into InputDeviceInfo.
+func InputDeviceInfoFromJS(value js.Value) *InputDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputDeviceInfoFromJS is casting from something that holds a js.Value into InputDeviceInfo.
+func InputDeviceInfoFromWrapper(input core.Wrapper) *InputDeviceInfo {
+	return InputDeviceInfoFromJS(input.JSValue())
 }
 
 func (_this *InputDeviceInfo) GetCapabilities() (_result *MediaTrackCapabilities) {
@@ -2540,15 +2516,19 @@ func (_this *MediaDeviceInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaDeviceInfoFromJS is casting a js.Wrapper into MediaDeviceInfo.
-func MediaDeviceInfoFromJS(value js.Wrapper) *MediaDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaDeviceInfoFromJS is casting a js.Value into MediaDeviceInfo.
+func MediaDeviceInfoFromJS(value js.Value) *MediaDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaDeviceInfoFromJS is casting from something that holds a js.Value into MediaDeviceInfo.
+func MediaDeviceInfoFromWrapper(input core.Wrapper) *MediaDeviceInfo {
+	return MediaDeviceInfoFromJS(input.JSValue())
 }
 
 // DeviceId returning attribute 'deviceId' with
@@ -2606,15 +2586,19 @@ type MediaDevices struct {
 	domcore.EventTarget
 }
 
-// MediaDevicesFromJS is casting a js.Wrapper into MediaDevices.
-func MediaDevicesFromJS(value js.Wrapper) *MediaDevices {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaDevicesFromJS is casting a js.Value into MediaDevices.
+func MediaDevicesFromJS(value js.Value) *MediaDevices {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaDevices{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaDevicesFromJS is casting from something that holds a js.Value into MediaDevices.
+func MediaDevicesFromWrapper(input core.Wrapper) *MediaDevices {
+	return MediaDevicesFromJS(input.JSValue())
 }
 
 // OnDeviceChange returning attribute 'ondevicechange' with
@@ -2729,15 +2713,19 @@ type MediaStream struct {
 	domcore.EventTarget
 }
 
-// MediaStreamFromJS is casting a js.Wrapper into MediaStream.
-func MediaStreamFromJS(value js.Wrapper) *MediaStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamFromJS is casting a js.Value into MediaStream.
+func MediaStreamFromJS(value js.Value) *MediaStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamFromJS is casting from something that holds a js.Value into MediaStream.
+func MediaStreamFromWrapper(input core.Wrapper) *MediaStream {
+	return MediaStreamFromJS(input.JSValue())
 }
 
 func NewMediaStream(tracks []*MediaStreamTrack) (_result *MediaStream) {
@@ -2976,15 +2964,19 @@ type MediaStreamTrack struct {
 	domcore.EventTarget
 }
 
-// MediaStreamTrackFromJS is casting a js.Wrapper into MediaStreamTrack.
-func MediaStreamTrackFromJS(value js.Wrapper) *MediaStreamTrack {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackFromJS is casting a js.Value into MediaStreamTrack.
+func MediaStreamTrackFromJS(value js.Value) *MediaStreamTrack {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrack{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackFromJS is casting from something that holds a js.Value into MediaStreamTrack.
+func MediaStreamTrackFromWrapper(input core.Wrapper) *MediaStreamTrack {
+	return MediaStreamTrackFromJS(input.JSValue())
 }
 
 // Kind returning attribute 'kind' with
@@ -3275,15 +3267,19 @@ type MediaStreamTrackEvent struct {
 	domcore.Event
 }
 
-// MediaStreamTrackEventFromJS is casting a js.Wrapper into MediaStreamTrackEvent.
-func MediaStreamTrackEventFromJS(value js.Wrapper) *MediaStreamTrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaStreamTrackEventFromJS is casting a js.Value into MediaStreamTrackEvent.
+func MediaStreamTrackEventFromJS(value js.Value) *MediaStreamTrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaStreamTrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaStreamTrackEventFromJS is casting from something that holds a js.Value into MediaStreamTrackEvent.
+func MediaStreamTrackEventFromWrapper(input core.Wrapper) *MediaStreamTrackEvent {
+	return MediaStreamTrackEventFromJS(input.JSValue())
 }
 
 func NewMediaStreamTrackEvent(_type string, eventInitDict *MediaStreamTrackEventInit) (_result *MediaStreamTrackEvent) {
@@ -3321,15 +3317,19 @@ type OverconstrainedErrorEvent struct {
 	domcore.Event
 }
 
-// OverconstrainedErrorEventFromJS is casting a js.Wrapper into OverconstrainedErrorEvent.
-func OverconstrainedErrorEventFromJS(value js.Wrapper) *OverconstrainedErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OverconstrainedErrorEventFromJS is casting a js.Value into OverconstrainedErrorEvent.
+func OverconstrainedErrorEventFromJS(value js.Value) *OverconstrainedErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OverconstrainedErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OverconstrainedErrorEventFromJS is casting from something that holds a js.Value into OverconstrainedErrorEvent.
+func OverconstrainedErrorEventFromWrapper(input core.Wrapper) *OverconstrainedErrorEvent {
+	return OverconstrainedErrorEventFromJS(input.JSValue())
 }
 
 func NewOverconstrainedErrorEvent(_type string, eventInitDict *OverconstrainedErrorEventInit) (_result *OverconstrainedErrorEvent) {
@@ -3374,15 +3374,19 @@ func (_this *PromiseMediaStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaStreamFromJS is casting a js.Wrapper into PromiseMediaStream.
-func PromiseMediaStreamFromJS(value js.Wrapper) *PromiseMediaStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaStreamFromJS is casting a js.Value into PromiseMediaStream.
+func PromiseMediaStreamFromJS(value js.Value) *PromiseMediaStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaStreamFromJS is casting from something that holds a js.Value into PromiseMediaStream.
+func PromiseMediaStreamFromWrapper(input core.Wrapper) *PromiseMediaStream {
+	return PromiseMediaStreamFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaStream) Then(onFulfilled *PromiseMediaStreamOnFulfilled, onRejected *PromiseMediaStreamOnRejected) (_result *PromiseMediaStream) {
@@ -3479,15 +3483,19 @@ func (_this *PromiseSequenceMediaDeviceInfo) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceMediaDeviceInfoFromJS is casting a js.Wrapper into PromiseSequenceMediaDeviceInfo.
-func PromiseSequenceMediaDeviceInfoFromJS(value js.Wrapper) *PromiseSequenceMediaDeviceInfo {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceMediaDeviceInfoFromJS is casting a js.Value into PromiseSequenceMediaDeviceInfo.
+func PromiseSequenceMediaDeviceInfoFromJS(value js.Value) *PromiseSequenceMediaDeviceInfo {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceMediaDeviceInfo{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceMediaDeviceInfoFromJS is casting from something that holds a js.Value into PromiseSequenceMediaDeviceInfo.
+func PromiseSequenceMediaDeviceInfoFromWrapper(input core.Wrapper) *PromiseSequenceMediaDeviceInfo {
+	return PromiseSequenceMediaDeviceInfoFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceMediaDeviceInfo) Then(onFulfilled *PromiseSequenceMediaDeviceInfoOnFulfilled, onRejected *PromiseSequenceMediaDeviceInfoOnRejected) (_result *PromiseSequenceMediaDeviceInfo) {

--- a/media/capture/screen/screen.go
+++ b/media/capture/screen/screen.go
@@ -37,7 +37,7 @@ type DisplayMediaStreamConstraints struct {
 	Audio *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DisplayMediaStreamConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -49,18 +49,16 @@ func (_this *DisplayMediaStreamConstraints) JSValue() js.Value {
 }
 
 // DisplayMediaStreamConstraintsFromJS is allocating a new
-// DisplayMediaStreamConstraints object and copy all values from
-// input javascript object
-func DisplayMediaStreamConstraintsFromJS(value js.Wrapper) *DisplayMediaStreamConstraints {
-	input := value.JSValue()
+// DisplayMediaStreamConstraints object and copy all values in the value javascript object.
+func DisplayMediaStreamConstraintsFromJS(value js.Value) *DisplayMediaStreamConstraints {
 	var out DisplayMediaStreamConstraints
 	var (
 		value0 *Union // javascript: Union {video Video video}
 		value1 *Union // javascript: Union {audio Audio audio}
 	)
-	value0 = UnionFromJS(input.Get("video"))
+	value0 = UnionFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = UnionFromJS(input.Get("audio"))
+	value1 = UnionFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }

--- a/media/capture/screen/screen_js.go
+++ b/media/capture/screen/screen_js.go
@@ -35,7 +35,7 @@ type DisplayMediaStreamConstraints struct {
 	Audio *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DisplayMediaStreamConstraints) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -47,18 +47,16 @@ func (_this *DisplayMediaStreamConstraints) JSValue() js.Value {
 }
 
 // DisplayMediaStreamConstraintsFromJS is allocating a new
-// DisplayMediaStreamConstraints object and copy all values from
-// input javascript object
-func DisplayMediaStreamConstraintsFromJS(value js.Wrapper) *DisplayMediaStreamConstraints {
-	input := value.JSValue()
+// DisplayMediaStreamConstraints object and copy all values in the value javascript object.
+func DisplayMediaStreamConstraintsFromJS(value js.Value) *DisplayMediaStreamConstraints {
 	var out DisplayMediaStreamConstraints
 	var (
 		value0 *Union // javascript: Union {video Video video}
 		value1 *Union // javascript: Union {audio Audio audio}
 	)
-	value0 = UnionFromJS(input.Get("video"))
+	value0 = UnionFromJS(value.Get("video"))
 	out.Video = value0
-	value1 = UnionFromJS(input.Get("audio"))
+	value1 = UnionFromJS(value.Get("audio"))
 	out.Audio = value1
 	return &out
 }

--- a/media/encrypted/encrypted.go
+++ b/media/encrypted/encrypted.go
@@ -7,6 +7,7 @@ package encrypted
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -441,7 +442,7 @@ type MediaEncryptedEventInit struct {
 	InitData     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaEncryptedEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -459,10 +460,8 @@ func (_this *MediaEncryptedEventInit) JSValue() js.Value {
 }
 
 // MediaEncryptedEventInitFromJS is allocating a new
-// MediaEncryptedEventInit object and copy all values from
-// input javascript object
-func MediaEncryptedEventInitFromJS(value js.Wrapper) *MediaEncryptedEventInit {
-	input := value.JSValue()
+// MediaEncryptedEventInit object and copy all values in the value javascript object.
+func MediaEncryptedEventInitFromJS(value js.Value) *MediaEncryptedEventInit {
 	var out MediaEncryptedEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -471,16 +470,16 @@ func MediaEncryptedEventInitFromJS(value js.Wrapper) *MediaEncryptedEventInit {
 		value3 string                  // javascript: DOMString {initDataType InitDataType initDataType}
 		value4 *javascript.ArrayBuffer // javascript: ArrayBuffer {initData InitData initData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("initDataType")).String()
+	value3 = (value.Get("initDataType")).String()
 	out.InitDataType = value3
-	if input.Get("initData").Type() != js.TypeNull && input.Get("initData").Type() != js.TypeUndefined {
-		value4 = javascript.ArrayBufferFromJS(input.Get("initData"))
+	if value.Get("initData").Type() != js.TypeNull && value.Get("initData").Type() != js.TypeUndefined {
+		value4 = javascript.ArrayBufferFromJS(value.Get("initData"))
 	}
 	out.InitData = value4
 	return &out
@@ -495,7 +494,7 @@ type MediaKeyMessageEventInit struct {
 	Message     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyMessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -513,10 +512,8 @@ func (_this *MediaKeyMessageEventInit) JSValue() js.Value {
 }
 
 // MediaKeyMessageEventInitFromJS is allocating a new
-// MediaKeyMessageEventInit object and copy all values from
-// input javascript object
-func MediaKeyMessageEventInitFromJS(value js.Wrapper) *MediaKeyMessageEventInit {
-	input := value.JSValue()
+// MediaKeyMessageEventInit object and copy all values in the value javascript object.
+func MediaKeyMessageEventInitFromJS(value js.Value) *MediaKeyMessageEventInit {
 	var out MediaKeyMessageEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -525,15 +522,15 @@ func MediaKeyMessageEventInitFromJS(value js.Wrapper) *MediaKeyMessageEventInit 
 		value3 MediaKeyMessageType     // javascript: MediaKeyMessageType {messageType MessageType messageType}
 		value4 *javascript.ArrayBuffer // javascript: ArrayBuffer {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = MediaKeyMessageTypeFromJS(input.Get("messageType"))
+	value3 = MediaKeyMessageTypeFromJS(value.Get("messageType"))
 	out.MessageType = value3
-	value4 = javascript.ArrayBufferFromJS(input.Get("message"))
+	value4 = javascript.ArrayBufferFromJS(value.Get("message"))
 	out.Message = value4
 	return &out
 }
@@ -544,7 +541,7 @@ type MediaKeyStatusMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -560,26 +557,24 @@ func (_this *MediaKeyStatusMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapEntryIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapEntryIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapEntryIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapEntryIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapEntryIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapEntryIteratorValueFromJS(value js.Value) *MediaKeyStatusMapEntryIteratorValue {
 	var out MediaKeyStatusMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -590,7 +585,7 @@ type MediaKeyStatusMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -602,18 +597,16 @@ func (_this *MediaKeyStatusMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapKeyIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapKeyIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapKeyIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapKeyIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapKeyIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapKeyIteratorValueFromJS(value js.Value) *MediaKeyStatusMapKeyIteratorValue {
 	var out MediaKeyStatusMapKeyIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -624,7 +617,7 @@ type MediaKeyStatusMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -636,18 +629,16 @@ func (_this *MediaKeyStatusMapValueIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapValueIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapValueIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapValueIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapValueIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapValueIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapValueIteratorValueFromJS(value js.Value) *MediaKeyStatusMapValueIteratorValue {
 	var out MediaKeyStatusMapValueIteratorValue
 	var (
 		value0 MediaKeyStatus // javascript: MediaKeyStatus {value Value value}
 		value1 bool           // javascript: boolean {done Done done}
 	)
-	value0 = MediaKeyStatusFromJS(input.Get("value"))
+	value0 = MediaKeyStatusFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -663,7 +654,7 @@ type MediaKeySystemConfiguration struct {
 	SessionTypes          []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeySystemConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -701,10 +692,8 @@ func (_this *MediaKeySystemConfiguration) JSValue() js.Value {
 }
 
 // MediaKeySystemConfigurationFromJS is allocating a new
-// MediaKeySystemConfiguration object and copy all values from
-// input javascript object
-func MediaKeySystemConfigurationFromJS(value js.Wrapper) *MediaKeySystemConfiguration {
-	input := value.JSValue()
+// MediaKeySystemConfiguration object and copy all values in the value javascript object.
+func MediaKeySystemConfigurationFromJS(value js.Value) *MediaKeySystemConfiguration {
 	var out MediaKeySystemConfiguration
 	var (
 		value0 string                           // javascript: DOMString {label Label label}
@@ -715,47 +704,47 @@ func MediaKeySystemConfigurationFromJS(value js.Wrapper) *MediaKeySystemConfigur
 		value5 MediaKeysRequirement             // javascript: MediaKeysRequirement {persistentState PersistentState persistentState}
 		value6 []string                         // javascript: sequence<DOMString> {sessionTypes SessionTypes sessionTypes}
 	)
-	value0 = (input.Get("label")).String()
+	value0 = (value.Get("label")).String()
 	out.Label = value0
-	__length1 := input.Get("initDataTypes").Length()
+	__length1 := value.Get("initDataTypes").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("initDataTypes").Index(__idx1)
+		__seq_in1 := value.Get("initDataTypes").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.InitDataTypes = value1
-	__length2 := input.Get("audioCapabilities").Length()
+	__length2 := value.Get("audioCapabilities").Length()
 	__array2 := make([]*MediaKeySystemMediaCapability, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *MediaKeySystemMediaCapability
-		__seq_in2 := input.Get("audioCapabilities").Index(__idx2)
+		__seq_in2 := value.Get("audioCapabilities").Index(__idx2)
 		__seq_out2 = MediaKeySystemMediaCapabilityFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.AudioCapabilities = value2
-	__length3 := input.Get("videoCapabilities").Length()
+	__length3 := value.Get("videoCapabilities").Length()
 	__array3 := make([]*MediaKeySystemMediaCapability, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *MediaKeySystemMediaCapability
-		__seq_in3 := input.Get("videoCapabilities").Index(__idx3)
+		__seq_in3 := value.Get("videoCapabilities").Index(__idx3)
 		__seq_out3 = MediaKeySystemMediaCapabilityFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.VideoCapabilities = value3
-	value4 = MediaKeysRequirementFromJS(input.Get("distinctiveIdentifier"))
+	value4 = MediaKeysRequirementFromJS(value.Get("distinctiveIdentifier"))
 	out.DistinctiveIdentifier = value4
-	value5 = MediaKeysRequirementFromJS(input.Get("persistentState"))
+	value5 = MediaKeysRequirementFromJS(value.Get("persistentState"))
 	out.PersistentState = value5
-	__length6 := input.Get("sessionTypes").Length()
+	__length6 := value.Get("sessionTypes").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("sessionTypes").Index(__idx6)
+		__seq_in6 := value.Get("sessionTypes").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -770,7 +759,7 @@ type MediaKeySystemMediaCapability struct {
 	Robustness  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeySystemMediaCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -782,18 +771,16 @@ func (_this *MediaKeySystemMediaCapability) JSValue() js.Value {
 }
 
 // MediaKeySystemMediaCapabilityFromJS is allocating a new
-// MediaKeySystemMediaCapability object and copy all values from
-// input javascript object
-func MediaKeySystemMediaCapabilityFromJS(value js.Wrapper) *MediaKeySystemMediaCapability {
-	input := value.JSValue()
+// MediaKeySystemMediaCapability object and copy all values in the value javascript object.
+func MediaKeySystemMediaCapabilityFromJS(value js.Value) *MediaKeySystemMediaCapability {
 	var out MediaKeySystemMediaCapability
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
 		value1 string // javascript: DOMString {robustness Robustness robustness}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (input.Get("robustness")).String()
+	value1 = (value.Get("robustness")).String()
 	out.Robustness = value1
 	return &out
 }
@@ -803,15 +790,19 @@ type MediaEncryptedEvent struct {
 	domcore.Event
 }
 
-// MediaEncryptedEventFromJS is casting a js.Wrapper into MediaEncryptedEvent.
-func MediaEncryptedEventFromJS(value js.Wrapper) *MediaEncryptedEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaEncryptedEventFromJS is casting a js.Value into MediaEncryptedEvent.
+func MediaEncryptedEventFromJS(value js.Value) *MediaEncryptedEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaEncryptedEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaEncryptedEventFromJS is casting from something that holds a js.Value into MediaEncryptedEvent.
+func MediaEncryptedEventFromWrapper(input core.Wrapper) *MediaEncryptedEvent {
+	return MediaEncryptedEventFromJS(input.JSValue())
 }
 
 func NewMediaEncryptedEvent(_type string, eventInitDict *MediaEncryptedEventInit) (_result *MediaEncryptedEvent) {
@@ -862,15 +853,19 @@ type MediaKeyMessageEvent struct {
 	domcore.Event
 }
 
-// MediaKeyMessageEventFromJS is casting a js.Wrapper into MediaKeyMessageEvent.
-func MediaKeyMessageEventFromJS(value js.Wrapper) *MediaKeyMessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyMessageEventFromJS is casting a js.Value into MediaKeyMessageEvent.
+func MediaKeyMessageEventFromJS(value js.Value) *MediaKeyMessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyMessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyMessageEventFromJS is casting from something that holds a js.Value into MediaKeyMessageEvent.
+func MediaKeyMessageEventFromWrapper(input core.Wrapper) *MediaKeyMessageEvent {
+	return MediaKeyMessageEventFromJS(input.JSValue())
 }
 
 func NewMediaKeyMessageEvent(_type string, eventInitDict *MediaKeyMessageEventInit) (_result *MediaKeyMessageEvent) {
@@ -917,15 +912,19 @@ type MediaKeySession struct {
 	domcore.EventTarget
 }
 
-// MediaKeySessionFromJS is casting a js.Wrapper into MediaKeySession.
-func MediaKeySessionFromJS(value js.Wrapper) *MediaKeySession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeySessionFromJS is casting a js.Value into MediaKeySession.
+func MediaKeySessionFromJS(value js.Value) *MediaKeySession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeySession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeySessionFromJS is casting from something that holds a js.Value into MediaKeySession.
+func MediaKeySessionFromWrapper(input core.Wrapper) *MediaKeySession {
+	return MediaKeySessionFromJS(input.JSValue())
 }
 
 // SessionId returning attribute 'sessionId' with
@@ -1138,15 +1137,19 @@ func (_this *MediaKeyStatusMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapFromJS is casting a js.Wrapper into MediaKeyStatusMap.
-func MediaKeyStatusMapFromJS(value js.Wrapper) *MediaKeyStatusMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapFromJS is casting a js.Value into MediaKeyStatusMap.
+func MediaKeyStatusMapFromJS(value js.Value) *MediaKeyStatusMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapFromJS is casting from something that holds a js.Value into MediaKeyStatusMap.
+func MediaKeyStatusMapFromWrapper(input core.Wrapper) *MediaKeyStatusMap {
+	return MediaKeyStatusMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1268,15 +1271,19 @@ func (_this *MediaKeyStatusMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapEntryIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapEntryIterator.
-func MediaKeyStatusMapEntryIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapEntryIteratorFromJS is casting a js.Value into MediaKeyStatusMapEntryIterator.
+func MediaKeyStatusMapEntryIteratorFromJS(value js.Value) *MediaKeyStatusMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapEntryIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapEntryIterator.
+func MediaKeyStatusMapEntryIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapEntryIterator {
+	return MediaKeyStatusMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapEntryIterator) Next() (_result *MediaKeyStatusMapEntryIteratorValue) {
@@ -1303,15 +1310,19 @@ func (_this *MediaKeyStatusMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapKeyIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapKeyIterator.
-func MediaKeyStatusMapKeyIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapKeyIteratorFromJS is casting a js.Value into MediaKeyStatusMapKeyIterator.
+func MediaKeyStatusMapKeyIteratorFromJS(value js.Value) *MediaKeyStatusMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapKeyIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapKeyIterator.
+func MediaKeyStatusMapKeyIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapKeyIterator {
+	return MediaKeyStatusMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapKeyIterator) Next() (_result *MediaKeyStatusMapKeyIteratorValue) {
@@ -1338,15 +1349,19 @@ func (_this *MediaKeyStatusMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapValueIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapValueIterator.
-func MediaKeyStatusMapValueIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapValueIteratorFromJS is casting a js.Value into MediaKeyStatusMapValueIterator.
+func MediaKeyStatusMapValueIteratorFromJS(value js.Value) *MediaKeyStatusMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapValueIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapValueIterator.
+func MediaKeyStatusMapValueIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapValueIterator {
+	return MediaKeyStatusMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapValueIterator) Next() (_result *MediaKeyStatusMapValueIteratorValue) {
@@ -1373,15 +1388,19 @@ func (_this *MediaKeySystemAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeySystemAccessFromJS is casting a js.Wrapper into MediaKeySystemAccess.
-func MediaKeySystemAccessFromJS(value js.Wrapper) *MediaKeySystemAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeySystemAccessFromJS is casting a js.Value into MediaKeySystemAccess.
+func MediaKeySystemAccessFromJS(value js.Value) *MediaKeySystemAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeySystemAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeySystemAccessFromJS is casting from something that holds a js.Value into MediaKeySystemAccess.
+func MediaKeySystemAccessFromWrapper(input core.Wrapper) *MediaKeySystemAccess {
+	return MediaKeySystemAccessFromJS(input.JSValue())
 }
 
 // KeySystem returning attribute 'keySystem' with
@@ -1431,15 +1450,19 @@ func (_this *MediaKeys) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeysFromJS is casting a js.Wrapper into MediaKeys.
-func MediaKeysFromJS(value js.Wrapper) *MediaKeys {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeysFromJS is casting a js.Value into MediaKeys.
+func MediaKeysFromJS(value js.Value) *MediaKeys {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeys{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeysFromJS is casting from something that holds a js.Value into MediaKeys.
+func MediaKeysFromWrapper(input core.Wrapper) *MediaKeys {
+	return MediaKeysFromJS(input.JSValue())
 }
 
 func (_this *MediaKeys) CreateSession(sessionType *MediaKeySessionType) (_result *MediaKeySession) {
@@ -1488,15 +1511,19 @@ func (_this *PromiseMediaKeySystemAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaKeySystemAccessFromJS is casting a js.Wrapper into PromiseMediaKeySystemAccess.
-func PromiseMediaKeySystemAccessFromJS(value js.Wrapper) *PromiseMediaKeySystemAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaKeySystemAccessFromJS is casting a js.Value into PromiseMediaKeySystemAccess.
+func PromiseMediaKeySystemAccessFromJS(value js.Value) *PromiseMediaKeySystemAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaKeySystemAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaKeySystemAccessFromJS is casting from something that holds a js.Value into PromiseMediaKeySystemAccess.
+func PromiseMediaKeySystemAccessFromWrapper(input core.Wrapper) *PromiseMediaKeySystemAccess {
+	return PromiseMediaKeySystemAccessFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaKeySystemAccess) Then(onFulfilled *PromiseMediaKeySystemAccessOnFulfilled, onRejected *PromiseMediaKeySystemAccessOnRejected) (_result *PromiseMediaKeySystemAccess) {
@@ -1593,15 +1620,19 @@ func (_this *PromiseMediaKeys) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaKeysFromJS is casting a js.Wrapper into PromiseMediaKeys.
-func PromiseMediaKeysFromJS(value js.Wrapper) *PromiseMediaKeys {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaKeysFromJS is casting a js.Value into PromiseMediaKeys.
+func PromiseMediaKeysFromJS(value js.Value) *PromiseMediaKeys {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaKeys{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaKeysFromJS is casting from something that holds a js.Value into PromiseMediaKeys.
+func PromiseMediaKeysFromWrapper(input core.Wrapper) *PromiseMediaKeys {
+	return PromiseMediaKeysFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaKeys) Then(onFulfilled *PromiseMediaKeysOnFulfilled, onRejected *PromiseMediaKeysOnRejected) (_result *PromiseMediaKeys) {

--- a/media/encrypted/encrypted_js.go
+++ b/media/encrypted/encrypted_js.go
@@ -5,6 +5,7 @@ package encrypted
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -439,7 +440,7 @@ type MediaEncryptedEventInit struct {
 	InitData     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaEncryptedEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -457,10 +458,8 @@ func (_this *MediaEncryptedEventInit) JSValue() js.Value {
 }
 
 // MediaEncryptedEventInitFromJS is allocating a new
-// MediaEncryptedEventInit object and copy all values from
-// input javascript object
-func MediaEncryptedEventInitFromJS(value js.Wrapper) *MediaEncryptedEventInit {
-	input := value.JSValue()
+// MediaEncryptedEventInit object and copy all values in the value javascript object.
+func MediaEncryptedEventInitFromJS(value js.Value) *MediaEncryptedEventInit {
 	var out MediaEncryptedEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -469,16 +468,16 @@ func MediaEncryptedEventInitFromJS(value js.Wrapper) *MediaEncryptedEventInit {
 		value3 string                  // javascript: DOMString {initDataType InitDataType initDataType}
 		value4 *javascript.ArrayBuffer // javascript: ArrayBuffer {initData InitData initData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("initDataType")).String()
+	value3 = (value.Get("initDataType")).String()
 	out.InitDataType = value3
-	if input.Get("initData").Type() != js.TypeNull && input.Get("initData").Type() != js.TypeUndefined {
-		value4 = javascript.ArrayBufferFromJS(input.Get("initData"))
+	if value.Get("initData").Type() != js.TypeNull && value.Get("initData").Type() != js.TypeUndefined {
+		value4 = javascript.ArrayBufferFromJS(value.Get("initData"))
 	}
 	out.InitData = value4
 	return &out
@@ -493,7 +492,7 @@ type MediaKeyMessageEventInit struct {
 	Message     *javascript.ArrayBuffer
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyMessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -511,10 +510,8 @@ func (_this *MediaKeyMessageEventInit) JSValue() js.Value {
 }
 
 // MediaKeyMessageEventInitFromJS is allocating a new
-// MediaKeyMessageEventInit object and copy all values from
-// input javascript object
-func MediaKeyMessageEventInitFromJS(value js.Wrapper) *MediaKeyMessageEventInit {
-	input := value.JSValue()
+// MediaKeyMessageEventInit object and copy all values in the value javascript object.
+func MediaKeyMessageEventInitFromJS(value js.Value) *MediaKeyMessageEventInit {
 	var out MediaKeyMessageEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -523,15 +520,15 @@ func MediaKeyMessageEventInitFromJS(value js.Wrapper) *MediaKeyMessageEventInit 
 		value3 MediaKeyMessageType     // javascript: MediaKeyMessageType {messageType MessageType messageType}
 		value4 *javascript.ArrayBuffer // javascript: ArrayBuffer {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = MediaKeyMessageTypeFromJS(input.Get("messageType"))
+	value3 = MediaKeyMessageTypeFromJS(value.Get("messageType"))
 	out.MessageType = value3
-	value4 = javascript.ArrayBufferFromJS(input.Get("message"))
+	value4 = javascript.ArrayBufferFromJS(value.Get("message"))
 	out.Message = value4
 	return &out
 }
@@ -542,7 +539,7 @@ type MediaKeyStatusMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -558,26 +555,24 @@ func (_this *MediaKeyStatusMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapEntryIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapEntryIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapEntryIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapEntryIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapEntryIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapEntryIteratorValueFromJS(value js.Value) *MediaKeyStatusMapEntryIteratorValue {
 	var out MediaKeyStatusMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -588,7 +583,7 @@ type MediaKeyStatusMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -600,18 +595,16 @@ func (_this *MediaKeyStatusMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapKeyIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapKeyIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapKeyIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapKeyIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapKeyIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapKeyIteratorValueFromJS(value js.Value) *MediaKeyStatusMapKeyIteratorValue {
 	var out MediaKeyStatusMapKeyIteratorValue
 	var (
 		value0 *Union // javascript: Union {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = UnionFromJS(input.Get("value"))
+	value0 = UnionFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -622,7 +615,7 @@ type MediaKeyStatusMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeyStatusMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -634,18 +627,16 @@ func (_this *MediaKeyStatusMapValueIteratorValue) JSValue() js.Value {
 }
 
 // MediaKeyStatusMapValueIteratorValueFromJS is allocating a new
-// MediaKeyStatusMapValueIteratorValue object and copy all values from
-// input javascript object
-func MediaKeyStatusMapValueIteratorValueFromJS(value js.Wrapper) *MediaKeyStatusMapValueIteratorValue {
-	input := value.JSValue()
+// MediaKeyStatusMapValueIteratorValue object and copy all values in the value javascript object.
+func MediaKeyStatusMapValueIteratorValueFromJS(value js.Value) *MediaKeyStatusMapValueIteratorValue {
 	var out MediaKeyStatusMapValueIteratorValue
 	var (
 		value0 MediaKeyStatus // javascript: MediaKeyStatus {value Value value}
 		value1 bool           // javascript: boolean {done Done done}
 	)
-	value0 = MediaKeyStatusFromJS(input.Get("value"))
+	value0 = MediaKeyStatusFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -661,7 +652,7 @@ type MediaKeySystemConfiguration struct {
 	SessionTypes          []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeySystemConfiguration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -699,10 +690,8 @@ func (_this *MediaKeySystemConfiguration) JSValue() js.Value {
 }
 
 // MediaKeySystemConfigurationFromJS is allocating a new
-// MediaKeySystemConfiguration object and copy all values from
-// input javascript object
-func MediaKeySystemConfigurationFromJS(value js.Wrapper) *MediaKeySystemConfiguration {
-	input := value.JSValue()
+// MediaKeySystemConfiguration object and copy all values in the value javascript object.
+func MediaKeySystemConfigurationFromJS(value js.Value) *MediaKeySystemConfiguration {
 	var out MediaKeySystemConfiguration
 	var (
 		value0 string                           // javascript: DOMString {label Label label}
@@ -713,47 +702,47 @@ func MediaKeySystemConfigurationFromJS(value js.Wrapper) *MediaKeySystemConfigur
 		value5 MediaKeysRequirement             // javascript: MediaKeysRequirement {persistentState PersistentState persistentState}
 		value6 []string                         // javascript: sequence<DOMString> {sessionTypes SessionTypes sessionTypes}
 	)
-	value0 = (input.Get("label")).String()
+	value0 = (value.Get("label")).String()
 	out.Label = value0
-	__length1 := input.Get("initDataTypes").Length()
+	__length1 := value.Get("initDataTypes").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("initDataTypes").Index(__idx1)
+		__seq_in1 := value.Get("initDataTypes").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.InitDataTypes = value1
-	__length2 := input.Get("audioCapabilities").Length()
+	__length2 := value.Get("audioCapabilities").Length()
 	__array2 := make([]*MediaKeySystemMediaCapability, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *MediaKeySystemMediaCapability
-		__seq_in2 := input.Get("audioCapabilities").Index(__idx2)
+		__seq_in2 := value.Get("audioCapabilities").Index(__idx2)
 		__seq_out2 = MediaKeySystemMediaCapabilityFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.AudioCapabilities = value2
-	__length3 := input.Get("videoCapabilities").Length()
+	__length3 := value.Get("videoCapabilities").Length()
 	__array3 := make([]*MediaKeySystemMediaCapability, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *MediaKeySystemMediaCapability
-		__seq_in3 := input.Get("videoCapabilities").Index(__idx3)
+		__seq_in3 := value.Get("videoCapabilities").Index(__idx3)
 		__seq_out3 = MediaKeySystemMediaCapabilityFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
 	value3 = __array3
 	out.VideoCapabilities = value3
-	value4 = MediaKeysRequirementFromJS(input.Get("distinctiveIdentifier"))
+	value4 = MediaKeysRequirementFromJS(value.Get("distinctiveIdentifier"))
 	out.DistinctiveIdentifier = value4
-	value5 = MediaKeysRequirementFromJS(input.Get("persistentState"))
+	value5 = MediaKeysRequirementFromJS(value.Get("persistentState"))
 	out.PersistentState = value5
-	__length6 := input.Get("sessionTypes").Length()
+	__length6 := value.Get("sessionTypes").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("sessionTypes").Index(__idx6)
+		__seq_in6 := value.Get("sessionTypes").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -768,7 +757,7 @@ type MediaKeySystemMediaCapability struct {
 	Robustness  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaKeySystemMediaCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -780,18 +769,16 @@ func (_this *MediaKeySystemMediaCapability) JSValue() js.Value {
 }
 
 // MediaKeySystemMediaCapabilityFromJS is allocating a new
-// MediaKeySystemMediaCapability object and copy all values from
-// input javascript object
-func MediaKeySystemMediaCapabilityFromJS(value js.Wrapper) *MediaKeySystemMediaCapability {
-	input := value.JSValue()
+// MediaKeySystemMediaCapability object and copy all values in the value javascript object.
+func MediaKeySystemMediaCapabilityFromJS(value js.Value) *MediaKeySystemMediaCapability {
 	var out MediaKeySystemMediaCapability
 	var (
 		value0 string // javascript: DOMString {contentType ContentType contentType}
 		value1 string // javascript: DOMString {robustness Robustness robustness}
 	)
-	value0 = (input.Get("contentType")).String()
+	value0 = (value.Get("contentType")).String()
 	out.ContentType = value0
-	value1 = (input.Get("robustness")).String()
+	value1 = (value.Get("robustness")).String()
 	out.Robustness = value1
 	return &out
 }
@@ -801,15 +788,19 @@ type MediaEncryptedEvent struct {
 	domcore.Event
 }
 
-// MediaEncryptedEventFromJS is casting a js.Wrapper into MediaEncryptedEvent.
-func MediaEncryptedEventFromJS(value js.Wrapper) *MediaEncryptedEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaEncryptedEventFromJS is casting a js.Value into MediaEncryptedEvent.
+func MediaEncryptedEventFromJS(value js.Value) *MediaEncryptedEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaEncryptedEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaEncryptedEventFromJS is casting from something that holds a js.Value into MediaEncryptedEvent.
+func MediaEncryptedEventFromWrapper(input core.Wrapper) *MediaEncryptedEvent {
+	return MediaEncryptedEventFromJS(input.JSValue())
 }
 
 func NewMediaEncryptedEvent(_type string, eventInitDict *MediaEncryptedEventInit) (_result *MediaEncryptedEvent) {
@@ -860,15 +851,19 @@ type MediaKeyMessageEvent struct {
 	domcore.Event
 }
 
-// MediaKeyMessageEventFromJS is casting a js.Wrapper into MediaKeyMessageEvent.
-func MediaKeyMessageEventFromJS(value js.Wrapper) *MediaKeyMessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyMessageEventFromJS is casting a js.Value into MediaKeyMessageEvent.
+func MediaKeyMessageEventFromJS(value js.Value) *MediaKeyMessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyMessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyMessageEventFromJS is casting from something that holds a js.Value into MediaKeyMessageEvent.
+func MediaKeyMessageEventFromWrapper(input core.Wrapper) *MediaKeyMessageEvent {
+	return MediaKeyMessageEventFromJS(input.JSValue())
 }
 
 func NewMediaKeyMessageEvent(_type string, eventInitDict *MediaKeyMessageEventInit) (_result *MediaKeyMessageEvent) {
@@ -915,15 +910,19 @@ type MediaKeySession struct {
 	domcore.EventTarget
 }
 
-// MediaKeySessionFromJS is casting a js.Wrapper into MediaKeySession.
-func MediaKeySessionFromJS(value js.Wrapper) *MediaKeySession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeySessionFromJS is casting a js.Value into MediaKeySession.
+func MediaKeySessionFromJS(value js.Value) *MediaKeySession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeySession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeySessionFromJS is casting from something that holds a js.Value into MediaKeySession.
+func MediaKeySessionFromWrapper(input core.Wrapper) *MediaKeySession {
+	return MediaKeySessionFromJS(input.JSValue())
 }
 
 // SessionId returning attribute 'sessionId' with
@@ -1136,15 +1135,19 @@ func (_this *MediaKeyStatusMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapFromJS is casting a js.Wrapper into MediaKeyStatusMap.
-func MediaKeyStatusMapFromJS(value js.Wrapper) *MediaKeyStatusMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapFromJS is casting a js.Value into MediaKeyStatusMap.
+func MediaKeyStatusMapFromJS(value js.Value) *MediaKeyStatusMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapFromJS is casting from something that holds a js.Value into MediaKeyStatusMap.
+func MediaKeyStatusMapFromWrapper(input core.Wrapper) *MediaKeyStatusMap {
+	return MediaKeyStatusMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1266,15 +1269,19 @@ func (_this *MediaKeyStatusMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapEntryIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapEntryIterator.
-func MediaKeyStatusMapEntryIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapEntryIteratorFromJS is casting a js.Value into MediaKeyStatusMapEntryIterator.
+func MediaKeyStatusMapEntryIteratorFromJS(value js.Value) *MediaKeyStatusMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapEntryIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapEntryIterator.
+func MediaKeyStatusMapEntryIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapEntryIterator {
+	return MediaKeyStatusMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapEntryIterator) Next() (_result *MediaKeyStatusMapEntryIteratorValue) {
@@ -1301,15 +1308,19 @@ func (_this *MediaKeyStatusMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapKeyIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapKeyIterator.
-func MediaKeyStatusMapKeyIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapKeyIteratorFromJS is casting a js.Value into MediaKeyStatusMapKeyIterator.
+func MediaKeyStatusMapKeyIteratorFromJS(value js.Value) *MediaKeyStatusMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapKeyIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapKeyIterator.
+func MediaKeyStatusMapKeyIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapKeyIterator {
+	return MediaKeyStatusMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapKeyIterator) Next() (_result *MediaKeyStatusMapKeyIteratorValue) {
@@ -1336,15 +1347,19 @@ func (_this *MediaKeyStatusMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeyStatusMapValueIteratorFromJS is casting a js.Wrapper into MediaKeyStatusMapValueIterator.
-func MediaKeyStatusMapValueIteratorFromJS(value js.Wrapper) *MediaKeyStatusMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeyStatusMapValueIteratorFromJS is casting a js.Value into MediaKeyStatusMapValueIterator.
+func MediaKeyStatusMapValueIteratorFromJS(value js.Value) *MediaKeyStatusMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeyStatusMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeyStatusMapValueIteratorFromJS is casting from something that holds a js.Value into MediaKeyStatusMapValueIterator.
+func MediaKeyStatusMapValueIteratorFromWrapper(input core.Wrapper) *MediaKeyStatusMapValueIterator {
+	return MediaKeyStatusMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *MediaKeyStatusMapValueIterator) Next() (_result *MediaKeyStatusMapValueIteratorValue) {
@@ -1371,15 +1386,19 @@ func (_this *MediaKeySystemAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeySystemAccessFromJS is casting a js.Wrapper into MediaKeySystemAccess.
-func MediaKeySystemAccessFromJS(value js.Wrapper) *MediaKeySystemAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeySystemAccessFromJS is casting a js.Value into MediaKeySystemAccess.
+func MediaKeySystemAccessFromJS(value js.Value) *MediaKeySystemAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeySystemAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeySystemAccessFromJS is casting from something that holds a js.Value into MediaKeySystemAccess.
+func MediaKeySystemAccessFromWrapper(input core.Wrapper) *MediaKeySystemAccess {
+	return MediaKeySystemAccessFromJS(input.JSValue())
 }
 
 // KeySystem returning attribute 'keySystem' with
@@ -1429,15 +1448,19 @@ func (_this *MediaKeys) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaKeysFromJS is casting a js.Wrapper into MediaKeys.
-func MediaKeysFromJS(value js.Wrapper) *MediaKeys {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaKeysFromJS is casting a js.Value into MediaKeys.
+func MediaKeysFromJS(value js.Value) *MediaKeys {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaKeys{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaKeysFromJS is casting from something that holds a js.Value into MediaKeys.
+func MediaKeysFromWrapper(input core.Wrapper) *MediaKeys {
+	return MediaKeysFromJS(input.JSValue())
 }
 
 func (_this *MediaKeys) CreateSession(sessionType *MediaKeySessionType) (_result *MediaKeySession) {
@@ -1486,15 +1509,19 @@ func (_this *PromiseMediaKeySystemAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaKeySystemAccessFromJS is casting a js.Wrapper into PromiseMediaKeySystemAccess.
-func PromiseMediaKeySystemAccessFromJS(value js.Wrapper) *PromiseMediaKeySystemAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaKeySystemAccessFromJS is casting a js.Value into PromiseMediaKeySystemAccess.
+func PromiseMediaKeySystemAccessFromJS(value js.Value) *PromiseMediaKeySystemAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaKeySystemAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaKeySystemAccessFromJS is casting from something that holds a js.Value into PromiseMediaKeySystemAccess.
+func PromiseMediaKeySystemAccessFromWrapper(input core.Wrapper) *PromiseMediaKeySystemAccess {
+	return PromiseMediaKeySystemAccessFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaKeySystemAccess) Then(onFulfilled *PromiseMediaKeySystemAccessOnFulfilled, onRejected *PromiseMediaKeySystemAccessOnRejected) (_result *PromiseMediaKeySystemAccess) {
@@ -1591,15 +1618,19 @@ func (_this *PromiseMediaKeys) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseMediaKeysFromJS is casting a js.Wrapper into PromiseMediaKeys.
-func PromiseMediaKeysFromJS(value js.Wrapper) *PromiseMediaKeys {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseMediaKeysFromJS is casting a js.Value into PromiseMediaKeys.
+func PromiseMediaKeysFromJS(value js.Value) *PromiseMediaKeys {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseMediaKeys{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseMediaKeysFromJS is casting from something that holds a js.Value into PromiseMediaKeys.
+func PromiseMediaKeysFromWrapper(input core.Wrapper) *PromiseMediaKeys {
+	return PromiseMediaKeysFromJS(input.JSValue())
 }
 
 func (_this *PromiseMediaKeys) Then(onFulfilled *PromiseMediaKeysOnFulfilled, onRejected *PromiseMediaKeysOnRejected) (_result *PromiseMediaKeys) {

--- a/media/mediatype/mediatype.go
+++ b/media/mediatype/mediatype.go
@@ -6,6 +6,10 @@ package mediatype
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -37,7 +41,7 @@ type Point2D struct {
 	Y float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Point2D) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -49,18 +53,16 @@ func (_this *Point2D) JSValue() js.Value {
 }
 
 // Point2DFromJS is allocating a new
-// Point2D object and copy all values from
-// input javascript object
-func Point2DFromJS(value js.Wrapper) *Point2D {
-	input := value.JSValue()
+// Point2D object and copy all values in the value javascript object.
+func Point2DFromJS(value js.Value) *Point2D {
 	var out Point2D
 	var (
 		value0 float64 // javascript: double {x X x}
 		value1 float64 // javascript: double {y Y y}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
 	return &out
 }
@@ -75,15 +77,19 @@ func (_this *MediaSettingsRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaSettingsRangeFromJS is casting a js.Wrapper into MediaSettingsRange.
-func MediaSettingsRangeFromJS(value js.Wrapper) *MediaSettingsRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSettingsRangeFromJS is casting a js.Value into MediaSettingsRange.
+func MediaSettingsRangeFromJS(value js.Value) *MediaSettingsRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSettingsRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSettingsRangeFromJS is casting from something that holds a js.Value into MediaSettingsRange.
+func MediaSettingsRangeFromWrapper(input core.Wrapper) *MediaSettingsRange {
+	return MediaSettingsRangeFromJS(input.JSValue())
 }
 
 // Max returning attribute 'max' with

--- a/media/mediatype/mediatype_js.go
+++ b/media/mediatype/mediatype_js.go
@@ -4,6 +4,10 @@ package mediatype
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -35,7 +39,7 @@ type Point2D struct {
 	Y float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Point2D) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -47,18 +51,16 @@ func (_this *Point2D) JSValue() js.Value {
 }
 
 // Point2DFromJS is allocating a new
-// Point2D object and copy all values from
-// input javascript object
-func Point2DFromJS(value js.Wrapper) *Point2D {
-	input := value.JSValue()
+// Point2D object and copy all values in the value javascript object.
+func Point2DFromJS(value js.Value) *Point2D {
 	var out Point2D
 	var (
 		value0 float64 // javascript: double {x X x}
 		value1 float64 // javascript: double {y Y y}
 	)
-	value0 = (input.Get("x")).Float()
+	value0 = (value.Get("x")).Float()
 	out.X = value0
-	value1 = (input.Get("y")).Float()
+	value1 = (value.Get("y")).Float()
 	out.Y = value1
 	return &out
 }
@@ -73,15 +75,19 @@ func (_this *MediaSettingsRange) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaSettingsRangeFromJS is casting a js.Wrapper into MediaSettingsRange.
-func MediaSettingsRangeFromJS(value js.Wrapper) *MediaSettingsRange {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSettingsRangeFromJS is casting a js.Value into MediaSettingsRange.
+func MediaSettingsRangeFromJS(value js.Value) *MediaSettingsRange {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSettingsRange{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSettingsRangeFromJS is casting from something that holds a js.Value into MediaSettingsRange.
+func MediaSettingsRangeFromWrapper(input core.Wrapper) *MediaSettingsRange {
+	return MediaSettingsRangeFromJS(input.JSValue())
 }
 
 // Max returning attribute 'max' with

--- a/media/midi/midi.go
+++ b/media/midi/midi.go
@@ -7,6 +7,7 @@ package midi
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -438,7 +439,7 @@ type ConnectionEventInit struct {
 	Port       *Port
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -454,10 +455,8 @@ func (_this *ConnectionEventInit) JSValue() js.Value {
 }
 
 // ConnectionEventInitFromJS is allocating a new
-// ConnectionEventInit object and copy all values from
-// input javascript object
-func ConnectionEventInitFromJS(value js.Wrapper) *ConnectionEventInit {
-	input := value.JSValue()
+// ConnectionEventInit object and copy all values in the value javascript object.
+func ConnectionEventInitFromJS(value js.Value) *ConnectionEventInit {
 	var out ConnectionEventInit
 	var (
 		value0 bool  // javascript: boolean {bubbles Bubbles bubbles}
@@ -465,13 +464,13 @@ func ConnectionEventInitFromJS(value js.Wrapper) *ConnectionEventInit {
 		value2 bool  // javascript: boolean {composed Composed composed}
 		value3 *Port // javascript: MIDIPort {port Port port}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = PortFromJS(input.Get("port"))
+	value3 = PortFromJS(value.Get("port"))
 	out.Port = value3
 	return &out
 }
@@ -482,7 +481,7 @@ type InputMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -498,26 +497,24 @@ func (_this *InputMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // InputMapEntryIteratorValueFromJS is allocating a new
-// InputMapEntryIteratorValue object and copy all values from
-// input javascript object
-func InputMapEntryIteratorValueFromJS(value js.Wrapper) *InputMapEntryIteratorValue {
-	input := value.JSValue()
+// InputMapEntryIteratorValue object and copy all values in the value javascript object.
+func InputMapEntryIteratorValueFromJS(value js.Value) *InputMapEntryIteratorValue {
 	var out InputMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -528,7 +525,7 @@ type InputMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -540,18 +537,16 @@ func (_this *InputMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // InputMapKeyIteratorValueFromJS is allocating a new
-// InputMapKeyIteratorValue object and copy all values from
-// input javascript object
-func InputMapKeyIteratorValueFromJS(value js.Wrapper) *InputMapKeyIteratorValue {
-	input := value.JSValue()
+// InputMapKeyIteratorValue object and copy all values in the value javascript object.
+func InputMapKeyIteratorValueFromJS(value js.Value) *InputMapKeyIteratorValue {
 	var out InputMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -562,7 +557,7 @@ type InputMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -574,18 +569,16 @@ func (_this *InputMapValueIteratorValue) JSValue() js.Value {
 }
 
 // InputMapValueIteratorValueFromJS is allocating a new
-// InputMapValueIteratorValue object and copy all values from
-// input javascript object
-func InputMapValueIteratorValueFromJS(value js.Wrapper) *InputMapValueIteratorValue {
-	input := value.JSValue()
+// InputMapValueIteratorValue object and copy all values in the value javascript object.
+func InputMapValueIteratorValueFromJS(value js.Value) *InputMapValueIteratorValue {
 	var out InputMapValueIteratorValue
 	var (
 		value0 *Input // javascript: MIDIInput {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = InputFromJS(input.Get("value"))
+	value0 = InputFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -598,7 +591,7 @@ type MessageEventInit struct {
 	Data       *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -614,10 +607,8 @@ func (_this *MessageEventInit) JSValue() js.Value {
 }
 
 // MessageEventInitFromJS is allocating a new
-// MessageEventInit object and copy all values from
-// input javascript object
-func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
-	input := value.JSValue()
+// MessageEventInit object and copy all values in the value javascript object.
+func MessageEventInitFromJS(value js.Value) *MessageEventInit {
 	var out MessageEventInit
 	var (
 		value0 bool                   // javascript: boolean {bubbles Bubbles bubbles}
@@ -625,13 +616,13 @@ func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
 		value2 bool                   // javascript: boolean {composed Composed composed}
 		value3 *javascript.Uint8Array // javascript: Uint8Array {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = javascript.Uint8ArrayFromJS(input.Get("data"))
+	value3 = javascript.Uint8ArrayFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -642,7 +633,7 @@ type Options struct {
 	Software bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Options) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -654,18 +645,16 @@ func (_this *Options) JSValue() js.Value {
 }
 
 // OptionsFromJS is allocating a new
-// Options object and copy all values from
-// input javascript object
-func OptionsFromJS(value js.Wrapper) *Options {
-	input := value.JSValue()
+// Options object and copy all values in the value javascript object.
+func OptionsFromJS(value js.Value) *Options {
 	var out Options
 	var (
 		value0 bool // javascript: boolean {sysex Sysex sysex}
 		value1 bool // javascript: boolean {software Software software}
 	)
-	value0 = (input.Get("sysex")).Bool()
+	value0 = (value.Get("sysex")).Bool()
 	out.Sysex = value0
-	value1 = (input.Get("software")).Bool()
+	value1 = (value.Get("software")).Bool()
 	out.Software = value1
 	return &out
 }
@@ -676,7 +665,7 @@ type OutputMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -692,26 +681,24 @@ func (_this *OutputMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapEntryIteratorValueFromJS is allocating a new
-// OutputMapEntryIteratorValue object and copy all values from
-// input javascript object
-func OutputMapEntryIteratorValueFromJS(value js.Wrapper) *OutputMapEntryIteratorValue {
-	input := value.JSValue()
+// OutputMapEntryIteratorValue object and copy all values in the value javascript object.
+func OutputMapEntryIteratorValueFromJS(value js.Value) *OutputMapEntryIteratorValue {
 	var out OutputMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -722,7 +709,7 @@ type OutputMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -734,18 +721,16 @@ func (_this *OutputMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapKeyIteratorValueFromJS is allocating a new
-// OutputMapKeyIteratorValue object and copy all values from
-// input javascript object
-func OutputMapKeyIteratorValueFromJS(value js.Wrapper) *OutputMapKeyIteratorValue {
-	input := value.JSValue()
+// OutputMapKeyIteratorValue object and copy all values in the value javascript object.
+func OutputMapKeyIteratorValueFromJS(value js.Value) *OutputMapKeyIteratorValue {
 	var out OutputMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -756,7 +741,7 @@ type OutputMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -768,18 +753,16 @@ func (_this *OutputMapValueIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapValueIteratorValueFromJS is allocating a new
-// OutputMapValueIteratorValue object and copy all values from
-// input javascript object
-func OutputMapValueIteratorValueFromJS(value js.Wrapper) *OutputMapValueIteratorValue {
-	input := value.JSValue()
+// OutputMapValueIteratorValue object and copy all values in the value javascript object.
+func OutputMapValueIteratorValueFromJS(value js.Value) *OutputMapValueIteratorValue {
 	var out OutputMapValueIteratorValue
 	var (
 		value0 *Output // javascript: MIDIOutput {value Value value}
 		value1 bool    // javascript: boolean {done Done done}
 	)
-	value0 = OutputFromJS(input.Get("value"))
+	value0 = OutputFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -789,15 +772,19 @@ type Access struct {
 	domcore.EventTarget
 }
 
-// AccessFromJS is casting a js.Wrapper into Access.
-func AccessFromJS(value js.Wrapper) *Access {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AccessFromJS is casting a js.Value into Access.
+func AccessFromJS(value js.Value) *Access {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Access{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AccessFromJS is casting from something that holds a js.Value into Access.
+func AccessFromWrapper(input core.Wrapper) *Access {
+	return AccessFromJS(input.JSValue())
 }
 
 // Inputs returning attribute 'inputs' with
@@ -873,15 +860,19 @@ type ConnectionEvent struct {
 	domcore.Event
 }
 
-// ConnectionEventFromJS is casting a js.Wrapper into ConnectionEvent.
-func ConnectionEventFromJS(value js.Wrapper) *ConnectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionEventFromJS is casting a js.Value into ConnectionEvent.
+func ConnectionEventFromJS(value js.Value) *ConnectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionEventFromJS is casting from something that holds a js.Value into ConnectionEvent.
+func ConnectionEventFromWrapper(input core.Wrapper) *ConnectionEvent {
+	return ConnectionEventFromJS(input.JSValue())
 }
 
 func NewMIDIConnectionEvent(_type string, eventInitDict *ConnectionEventInit) (_result *ConnectionEvent) {
@@ -921,15 +912,19 @@ type Input struct {
 	Port
 }
 
-// InputFromJS is casting a js.Wrapper into Input.
-func InputFromJS(value js.Wrapper) *Input {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputFromJS is casting a js.Value into Input.
+func InputFromJS(value js.Value) *Input {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Input{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputFromJS is casting from something that holds a js.Value into Input.
+func InputFromWrapper(input core.Wrapper) *Input {
+	return InputFromJS(input.JSValue())
 }
 
 // OnMIDIMessage returning attribute 'onmidimessage' with
@@ -983,15 +978,19 @@ func (_this *InputMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapFromJS is casting a js.Wrapper into InputMap.
-func InputMapFromJS(value js.Wrapper) *InputMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapFromJS is casting a js.Value into InputMap.
+func InputMapFromJS(value js.Value) *InputMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapFromJS is casting from something that holds a js.Value into InputMap.
+func InputMapFromWrapper(input core.Wrapper) *InputMap {
+	return InputMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1115,15 +1114,19 @@ func (_this *InputMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapEntryIteratorFromJS is casting a js.Wrapper into InputMapEntryIterator.
-func InputMapEntryIteratorFromJS(value js.Wrapper) *InputMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapEntryIteratorFromJS is casting a js.Value into InputMapEntryIterator.
+func InputMapEntryIteratorFromJS(value js.Value) *InputMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapEntryIteratorFromJS is casting from something that holds a js.Value into InputMapEntryIterator.
+func InputMapEntryIteratorFromWrapper(input core.Wrapper) *InputMapEntryIterator {
+	return InputMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapEntryIterator) Next() (_result *InputMapEntryIteratorValue) {
@@ -1150,15 +1153,19 @@ func (_this *InputMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapKeyIteratorFromJS is casting a js.Wrapper into InputMapKeyIterator.
-func InputMapKeyIteratorFromJS(value js.Wrapper) *InputMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapKeyIteratorFromJS is casting a js.Value into InputMapKeyIterator.
+func InputMapKeyIteratorFromJS(value js.Value) *InputMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapKeyIteratorFromJS is casting from something that holds a js.Value into InputMapKeyIterator.
+func InputMapKeyIteratorFromWrapper(input core.Wrapper) *InputMapKeyIterator {
+	return InputMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapKeyIterator) Next() (_result *InputMapKeyIteratorValue) {
@@ -1185,15 +1192,19 @@ func (_this *InputMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapValueIteratorFromJS is casting a js.Wrapper into InputMapValueIterator.
-func InputMapValueIteratorFromJS(value js.Wrapper) *InputMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapValueIteratorFromJS is casting a js.Value into InputMapValueIterator.
+func InputMapValueIteratorFromJS(value js.Value) *InputMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapValueIteratorFromJS is casting from something that holds a js.Value into InputMapValueIterator.
+func InputMapValueIteratorFromWrapper(input core.Wrapper) *InputMapValueIterator {
+	return InputMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapValueIterator) Next() (_result *InputMapValueIteratorValue) {
@@ -1215,15 +1226,19 @@ type MessageEvent struct {
 	domcore.Event
 }
 
-// MessageEventFromJS is casting a js.Wrapper into MessageEvent.
-func MessageEventFromJS(value js.Wrapper) *MessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageEventFromJS is casting a js.Value into MessageEvent.
+func MessageEventFromJS(value js.Value) *MessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageEventFromJS is casting from something that holds a js.Value into MessageEvent.
+func MessageEventFromWrapper(input core.Wrapper) *MessageEvent {
+	return MessageEventFromJS(input.JSValue())
 }
 
 func NewMIDIMessageEvent(_type string, eventInitDict *MessageEventInit) (_result *MessageEvent) {
@@ -1263,15 +1278,19 @@ type Output struct {
 	Port
 }
 
-// OutputFromJS is casting a js.Wrapper into Output.
-func OutputFromJS(value js.Wrapper) *Output {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputFromJS is casting a js.Value into Output.
+func OutputFromJS(value js.Value) *Output {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Output{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputFromJS is casting from something that holds a js.Value into Output.
+func OutputFromWrapper(input core.Wrapper) *Output {
+	return OutputFromJS(input.JSValue())
 }
 
 func (_this *Output) Send(data []int, timestamp *float64) {
@@ -1320,15 +1339,19 @@ func (_this *OutputMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapFromJS is casting a js.Wrapper into OutputMap.
-func OutputMapFromJS(value js.Wrapper) *OutputMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapFromJS is casting a js.Value into OutputMap.
+func OutputMapFromJS(value js.Value) *OutputMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapFromJS is casting from something that holds a js.Value into OutputMap.
+func OutputMapFromWrapper(input core.Wrapper) *OutputMap {
+	return OutputMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1452,15 +1475,19 @@ func (_this *OutputMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapEntryIteratorFromJS is casting a js.Wrapper into OutputMapEntryIterator.
-func OutputMapEntryIteratorFromJS(value js.Wrapper) *OutputMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapEntryIteratorFromJS is casting a js.Value into OutputMapEntryIterator.
+func OutputMapEntryIteratorFromJS(value js.Value) *OutputMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapEntryIteratorFromJS is casting from something that holds a js.Value into OutputMapEntryIterator.
+func OutputMapEntryIteratorFromWrapper(input core.Wrapper) *OutputMapEntryIterator {
+	return OutputMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapEntryIterator) Next() (_result *OutputMapEntryIteratorValue) {
@@ -1487,15 +1514,19 @@ func (_this *OutputMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapKeyIteratorFromJS is casting a js.Wrapper into OutputMapKeyIterator.
-func OutputMapKeyIteratorFromJS(value js.Wrapper) *OutputMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapKeyIteratorFromJS is casting a js.Value into OutputMapKeyIterator.
+func OutputMapKeyIteratorFromJS(value js.Value) *OutputMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapKeyIteratorFromJS is casting from something that holds a js.Value into OutputMapKeyIterator.
+func OutputMapKeyIteratorFromWrapper(input core.Wrapper) *OutputMapKeyIterator {
+	return OutputMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapKeyIterator) Next() (_result *OutputMapKeyIteratorValue) {
@@ -1522,15 +1553,19 @@ func (_this *OutputMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapValueIteratorFromJS is casting a js.Wrapper into OutputMapValueIterator.
-func OutputMapValueIteratorFromJS(value js.Wrapper) *OutputMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapValueIteratorFromJS is casting a js.Value into OutputMapValueIterator.
+func OutputMapValueIteratorFromJS(value js.Value) *OutputMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapValueIteratorFromJS is casting from something that holds a js.Value into OutputMapValueIterator.
+func OutputMapValueIteratorFromWrapper(input core.Wrapper) *OutputMapValueIterator {
+	return OutputMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapValueIterator) Next() (_result *OutputMapValueIteratorValue) {
@@ -1552,15 +1587,19 @@ type Port struct {
 	domcore.EventTarget
 }
 
-// PortFromJS is casting a js.Wrapper into Port.
-func PortFromJS(value js.Wrapper) *Port {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PortFromJS is casting a js.Value into Port.
+func PortFromJS(value js.Value) *Port {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Port{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PortFromJS is casting from something that holds a js.Value into Port.
+func PortFromWrapper(input core.Wrapper) *Port {
+	return PortFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1714,15 +1753,19 @@ func (_this *PromiseAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAccessFromJS is casting a js.Wrapper into PromiseAccess.
-func PromiseAccessFromJS(value js.Wrapper) *PromiseAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAccessFromJS is casting a js.Value into PromiseAccess.
+func PromiseAccessFromJS(value js.Value) *PromiseAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAccessFromJS is casting from something that holds a js.Value into PromiseAccess.
+func PromiseAccessFromWrapper(input core.Wrapper) *PromiseAccess {
+	return PromiseAccessFromJS(input.JSValue())
 }
 
 func (_this *PromiseAccess) Then(onFulfilled *PromiseAccessOnFulfilled, onRejected *PromiseAccessOnRejected) (_result *PromiseAccess) {
@@ -1819,15 +1862,19 @@ func (_this *PromisePort) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePortFromJS is casting a js.Wrapper into PromisePort.
-func PromisePortFromJS(value js.Wrapper) *PromisePort {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePortFromJS is casting a js.Value into PromisePort.
+func PromisePortFromJS(value js.Value) *PromisePort {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePort{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePortFromJS is casting from something that holds a js.Value into PromisePort.
+func PromisePortFromWrapper(input core.Wrapper) *PromisePort {
+	return PromisePortFromJS(input.JSValue())
 }
 
 func (_this *PromisePort) Then(onFulfilled *PromisePortOnFulfilled, onRejected *PromisePortOnRejected) (_result *PromisePort) {

--- a/media/midi/midi_js.go
+++ b/media/midi/midi_js.go
@@ -5,6 +5,7 @@ package midi
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -436,7 +437,7 @@ type ConnectionEventInit struct {
 	Port       *Port
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ConnectionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -452,10 +453,8 @@ func (_this *ConnectionEventInit) JSValue() js.Value {
 }
 
 // ConnectionEventInitFromJS is allocating a new
-// ConnectionEventInit object and copy all values from
-// input javascript object
-func ConnectionEventInitFromJS(value js.Wrapper) *ConnectionEventInit {
-	input := value.JSValue()
+// ConnectionEventInit object and copy all values in the value javascript object.
+func ConnectionEventInitFromJS(value js.Value) *ConnectionEventInit {
 	var out ConnectionEventInit
 	var (
 		value0 bool  // javascript: boolean {bubbles Bubbles bubbles}
@@ -463,13 +462,13 @@ func ConnectionEventInitFromJS(value js.Wrapper) *ConnectionEventInit {
 		value2 bool  // javascript: boolean {composed Composed composed}
 		value3 *Port // javascript: MIDIPort {port Port port}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = PortFromJS(input.Get("port"))
+	value3 = PortFromJS(value.Get("port"))
 	out.Port = value3
 	return &out
 }
@@ -480,7 +479,7 @@ type InputMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -496,26 +495,24 @@ func (_this *InputMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // InputMapEntryIteratorValueFromJS is allocating a new
-// InputMapEntryIteratorValue object and copy all values from
-// input javascript object
-func InputMapEntryIteratorValueFromJS(value js.Wrapper) *InputMapEntryIteratorValue {
-	input := value.JSValue()
+// InputMapEntryIteratorValue object and copy all values in the value javascript object.
+func InputMapEntryIteratorValueFromJS(value js.Value) *InputMapEntryIteratorValue {
 	var out InputMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -526,7 +523,7 @@ type InputMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -538,18 +535,16 @@ func (_this *InputMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // InputMapKeyIteratorValueFromJS is allocating a new
-// InputMapKeyIteratorValue object and copy all values from
-// input javascript object
-func InputMapKeyIteratorValueFromJS(value js.Wrapper) *InputMapKeyIteratorValue {
-	input := value.JSValue()
+// InputMapKeyIteratorValue object and copy all values in the value javascript object.
+func InputMapKeyIteratorValueFromJS(value js.Value) *InputMapKeyIteratorValue {
 	var out InputMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -560,7 +555,7 @@ type InputMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InputMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -572,18 +567,16 @@ func (_this *InputMapValueIteratorValue) JSValue() js.Value {
 }
 
 // InputMapValueIteratorValueFromJS is allocating a new
-// InputMapValueIteratorValue object and copy all values from
-// input javascript object
-func InputMapValueIteratorValueFromJS(value js.Wrapper) *InputMapValueIteratorValue {
-	input := value.JSValue()
+// InputMapValueIteratorValue object and copy all values in the value javascript object.
+func InputMapValueIteratorValueFromJS(value js.Value) *InputMapValueIteratorValue {
 	var out InputMapValueIteratorValue
 	var (
 		value0 *Input // javascript: MIDIInput {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = InputFromJS(input.Get("value"))
+	value0 = InputFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -596,7 +589,7 @@ type MessageEventInit struct {
 	Data       *javascript.Uint8Array
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -612,10 +605,8 @@ func (_this *MessageEventInit) JSValue() js.Value {
 }
 
 // MessageEventInitFromJS is allocating a new
-// MessageEventInit object and copy all values from
-// input javascript object
-func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
-	input := value.JSValue()
+// MessageEventInit object and copy all values in the value javascript object.
+func MessageEventInitFromJS(value js.Value) *MessageEventInit {
 	var out MessageEventInit
 	var (
 		value0 bool                   // javascript: boolean {bubbles Bubbles bubbles}
@@ -623,13 +614,13 @@ func MessageEventInitFromJS(value js.Wrapper) *MessageEventInit {
 		value2 bool                   // javascript: boolean {composed Composed composed}
 		value3 *javascript.Uint8Array // javascript: Uint8Array {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = javascript.Uint8ArrayFromJS(input.Get("data"))
+	value3 = javascript.Uint8ArrayFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -640,7 +631,7 @@ type Options struct {
 	Software bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Options) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -652,18 +643,16 @@ func (_this *Options) JSValue() js.Value {
 }
 
 // OptionsFromJS is allocating a new
-// Options object and copy all values from
-// input javascript object
-func OptionsFromJS(value js.Wrapper) *Options {
-	input := value.JSValue()
+// Options object and copy all values in the value javascript object.
+func OptionsFromJS(value js.Value) *Options {
 	var out Options
 	var (
 		value0 bool // javascript: boolean {sysex Sysex sysex}
 		value1 bool // javascript: boolean {software Software software}
 	)
-	value0 = (input.Get("sysex")).Bool()
+	value0 = (value.Get("sysex")).Bool()
 	out.Sysex = value0
-	value1 = (input.Get("software")).Bool()
+	value1 = (value.Get("software")).Bool()
 	out.Software = value1
 	return &out
 }
@@ -674,7 +663,7 @@ type OutputMapEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -690,26 +679,24 @@ func (_this *OutputMapEntryIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapEntryIteratorValueFromJS is allocating a new
-// OutputMapEntryIteratorValue object and copy all values from
-// input javascript object
-func OutputMapEntryIteratorValueFromJS(value js.Wrapper) *OutputMapEntryIteratorValue {
-	input := value.JSValue()
+// OutputMapEntryIteratorValue object and copy all values in the value javascript object.
+func OutputMapEntryIteratorValueFromJS(value js.Value) *OutputMapEntryIteratorValue {
 	var out OutputMapEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -720,7 +707,7 @@ type OutputMapKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -732,18 +719,16 @@ func (_this *OutputMapKeyIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapKeyIteratorValueFromJS is allocating a new
-// OutputMapKeyIteratorValue object and copy all values from
-// input javascript object
-func OutputMapKeyIteratorValueFromJS(value js.Wrapper) *OutputMapKeyIteratorValue {
-	input := value.JSValue()
+// OutputMapKeyIteratorValue object and copy all values in the value javascript object.
+func OutputMapKeyIteratorValueFromJS(value js.Value) *OutputMapKeyIteratorValue {
 	var out OutputMapKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -754,7 +739,7 @@ type OutputMapValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutputMapValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -766,18 +751,16 @@ func (_this *OutputMapValueIteratorValue) JSValue() js.Value {
 }
 
 // OutputMapValueIteratorValueFromJS is allocating a new
-// OutputMapValueIteratorValue object and copy all values from
-// input javascript object
-func OutputMapValueIteratorValueFromJS(value js.Wrapper) *OutputMapValueIteratorValue {
-	input := value.JSValue()
+// OutputMapValueIteratorValue object and copy all values in the value javascript object.
+func OutputMapValueIteratorValueFromJS(value js.Value) *OutputMapValueIteratorValue {
 	var out OutputMapValueIteratorValue
 	var (
 		value0 *Output // javascript: MIDIOutput {value Value value}
 		value1 bool    // javascript: boolean {done Done done}
 	)
-	value0 = OutputFromJS(input.Get("value"))
+	value0 = OutputFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -787,15 +770,19 @@ type Access struct {
 	domcore.EventTarget
 }
 
-// AccessFromJS is casting a js.Wrapper into Access.
-func AccessFromJS(value js.Wrapper) *Access {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// AccessFromJS is casting a js.Value into Access.
+func AccessFromJS(value js.Value) *Access {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Access{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// AccessFromJS is casting from something that holds a js.Value into Access.
+func AccessFromWrapper(input core.Wrapper) *Access {
+	return AccessFromJS(input.JSValue())
 }
 
 // Inputs returning attribute 'inputs' with
@@ -871,15 +858,19 @@ type ConnectionEvent struct {
 	domcore.Event
 }
 
-// ConnectionEventFromJS is casting a js.Wrapper into ConnectionEvent.
-func ConnectionEventFromJS(value js.Wrapper) *ConnectionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ConnectionEventFromJS is casting a js.Value into ConnectionEvent.
+func ConnectionEventFromJS(value js.Value) *ConnectionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ConnectionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ConnectionEventFromJS is casting from something that holds a js.Value into ConnectionEvent.
+func ConnectionEventFromWrapper(input core.Wrapper) *ConnectionEvent {
+	return ConnectionEventFromJS(input.JSValue())
 }
 
 func NewMIDIConnectionEvent(_type string, eventInitDict *ConnectionEventInit) (_result *ConnectionEvent) {
@@ -919,15 +910,19 @@ type Input struct {
 	Port
 }
 
-// InputFromJS is casting a js.Wrapper into Input.
-func InputFromJS(value js.Wrapper) *Input {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputFromJS is casting a js.Value into Input.
+func InputFromJS(value js.Value) *Input {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Input{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputFromJS is casting from something that holds a js.Value into Input.
+func InputFromWrapper(input core.Wrapper) *Input {
+	return InputFromJS(input.JSValue())
 }
 
 // OnMIDIMessage returning attribute 'onmidimessage' with
@@ -981,15 +976,19 @@ func (_this *InputMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapFromJS is casting a js.Wrapper into InputMap.
-func InputMapFromJS(value js.Wrapper) *InputMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapFromJS is casting a js.Value into InputMap.
+func InputMapFromJS(value js.Value) *InputMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapFromJS is casting from something that holds a js.Value into InputMap.
+func InputMapFromWrapper(input core.Wrapper) *InputMap {
+	return InputMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1113,15 +1112,19 @@ func (_this *InputMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapEntryIteratorFromJS is casting a js.Wrapper into InputMapEntryIterator.
-func InputMapEntryIteratorFromJS(value js.Wrapper) *InputMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapEntryIteratorFromJS is casting a js.Value into InputMapEntryIterator.
+func InputMapEntryIteratorFromJS(value js.Value) *InputMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapEntryIteratorFromJS is casting from something that holds a js.Value into InputMapEntryIterator.
+func InputMapEntryIteratorFromWrapper(input core.Wrapper) *InputMapEntryIterator {
+	return InputMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapEntryIterator) Next() (_result *InputMapEntryIteratorValue) {
@@ -1148,15 +1151,19 @@ func (_this *InputMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapKeyIteratorFromJS is casting a js.Wrapper into InputMapKeyIterator.
-func InputMapKeyIteratorFromJS(value js.Wrapper) *InputMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapKeyIteratorFromJS is casting a js.Value into InputMapKeyIterator.
+func InputMapKeyIteratorFromJS(value js.Value) *InputMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapKeyIteratorFromJS is casting from something that holds a js.Value into InputMapKeyIterator.
+func InputMapKeyIteratorFromWrapper(input core.Wrapper) *InputMapKeyIterator {
+	return InputMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapKeyIterator) Next() (_result *InputMapKeyIteratorValue) {
@@ -1183,15 +1190,19 @@ func (_this *InputMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// InputMapValueIteratorFromJS is casting a js.Wrapper into InputMapValueIterator.
-func InputMapValueIteratorFromJS(value js.Wrapper) *InputMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InputMapValueIteratorFromJS is casting a js.Value into InputMapValueIterator.
+func InputMapValueIteratorFromJS(value js.Value) *InputMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InputMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InputMapValueIteratorFromJS is casting from something that holds a js.Value into InputMapValueIterator.
+func InputMapValueIteratorFromWrapper(input core.Wrapper) *InputMapValueIterator {
+	return InputMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *InputMapValueIterator) Next() (_result *InputMapValueIteratorValue) {
@@ -1213,15 +1224,19 @@ type MessageEvent struct {
 	domcore.Event
 }
 
-// MessageEventFromJS is casting a js.Wrapper into MessageEvent.
-func MessageEventFromJS(value js.Wrapper) *MessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageEventFromJS is casting a js.Value into MessageEvent.
+func MessageEventFromJS(value js.Value) *MessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageEventFromJS is casting from something that holds a js.Value into MessageEvent.
+func MessageEventFromWrapper(input core.Wrapper) *MessageEvent {
+	return MessageEventFromJS(input.JSValue())
 }
 
 func NewMIDIMessageEvent(_type string, eventInitDict *MessageEventInit) (_result *MessageEvent) {
@@ -1261,15 +1276,19 @@ type Output struct {
 	Port
 }
 
-// OutputFromJS is casting a js.Wrapper into Output.
-func OutputFromJS(value js.Wrapper) *Output {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputFromJS is casting a js.Value into Output.
+func OutputFromJS(value js.Value) *Output {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Output{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputFromJS is casting from something that holds a js.Value into Output.
+func OutputFromWrapper(input core.Wrapper) *Output {
+	return OutputFromJS(input.JSValue())
 }
 
 func (_this *Output) Send(data []int, timestamp *float64) {
@@ -1318,15 +1337,19 @@ func (_this *OutputMap) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapFromJS is casting a js.Wrapper into OutputMap.
-func OutputMapFromJS(value js.Wrapper) *OutputMap {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapFromJS is casting a js.Value into OutputMap.
+func OutputMapFromJS(value js.Value) *OutputMap {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMap{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapFromJS is casting from something that holds a js.Value into OutputMap.
+func OutputMapFromWrapper(input core.Wrapper) *OutputMap {
+	return OutputMapFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -1450,15 +1473,19 @@ func (_this *OutputMapEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapEntryIteratorFromJS is casting a js.Wrapper into OutputMapEntryIterator.
-func OutputMapEntryIteratorFromJS(value js.Wrapper) *OutputMapEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapEntryIteratorFromJS is casting a js.Value into OutputMapEntryIterator.
+func OutputMapEntryIteratorFromJS(value js.Value) *OutputMapEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapEntryIteratorFromJS is casting from something that holds a js.Value into OutputMapEntryIterator.
+func OutputMapEntryIteratorFromWrapper(input core.Wrapper) *OutputMapEntryIterator {
+	return OutputMapEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapEntryIterator) Next() (_result *OutputMapEntryIteratorValue) {
@@ -1485,15 +1512,19 @@ func (_this *OutputMapKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapKeyIteratorFromJS is casting a js.Wrapper into OutputMapKeyIterator.
-func OutputMapKeyIteratorFromJS(value js.Wrapper) *OutputMapKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapKeyIteratorFromJS is casting a js.Value into OutputMapKeyIterator.
+func OutputMapKeyIteratorFromJS(value js.Value) *OutputMapKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapKeyIteratorFromJS is casting from something that holds a js.Value into OutputMapKeyIterator.
+func OutputMapKeyIteratorFromWrapper(input core.Wrapper) *OutputMapKeyIterator {
+	return OutputMapKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapKeyIterator) Next() (_result *OutputMapKeyIteratorValue) {
@@ -1520,15 +1551,19 @@ func (_this *OutputMapValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OutputMapValueIteratorFromJS is casting a js.Wrapper into OutputMapValueIterator.
-func OutputMapValueIteratorFromJS(value js.Wrapper) *OutputMapValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OutputMapValueIteratorFromJS is casting a js.Value into OutputMapValueIterator.
+func OutputMapValueIteratorFromJS(value js.Value) *OutputMapValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OutputMapValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OutputMapValueIteratorFromJS is casting from something that holds a js.Value into OutputMapValueIterator.
+func OutputMapValueIteratorFromWrapper(input core.Wrapper) *OutputMapValueIterator {
+	return OutputMapValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *OutputMapValueIterator) Next() (_result *OutputMapValueIteratorValue) {
@@ -1550,15 +1585,19 @@ type Port struct {
 	domcore.EventTarget
 }
 
-// PortFromJS is casting a js.Wrapper into Port.
-func PortFromJS(value js.Wrapper) *Port {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PortFromJS is casting a js.Value into Port.
+func PortFromJS(value js.Value) *Port {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Port{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PortFromJS is casting from something that holds a js.Value into Port.
+func PortFromWrapper(input core.Wrapper) *Port {
+	return PortFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1712,15 +1751,19 @@ func (_this *PromiseAccess) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseAccessFromJS is casting a js.Wrapper into PromiseAccess.
-func PromiseAccessFromJS(value js.Wrapper) *PromiseAccess {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseAccessFromJS is casting a js.Value into PromiseAccess.
+func PromiseAccessFromJS(value js.Value) *PromiseAccess {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseAccess{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseAccessFromJS is casting from something that holds a js.Value into PromiseAccess.
+func PromiseAccessFromWrapper(input core.Wrapper) *PromiseAccess {
+	return PromiseAccessFromJS(input.JSValue())
 }
 
 func (_this *PromiseAccess) Then(onFulfilled *PromiseAccessOnFulfilled, onRejected *PromiseAccessOnRejected) (_result *PromiseAccess) {
@@ -1817,15 +1860,19 @@ func (_this *PromisePort) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePortFromJS is casting a js.Wrapper into PromisePort.
-func PromisePortFromJS(value js.Wrapper) *PromisePort {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePortFromJS is casting a js.Value into PromisePort.
+func PromisePortFromJS(value js.Value) *PromisePort {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePort{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePortFromJS is casting from something that holds a js.Value into PromisePort.
+func PromisePortFromWrapper(input core.Wrapper) *PromisePort {
+	return PromisePortFromJS(input.JSValue())
 }
 
 func (_this *PromisePort) Then(onFulfilled *PromisePortOnFulfilled, onRejected *PromisePortOnRejected) (_result *PromisePort) {

--- a/media/orientation/orientation.go
+++ b/media/orientation/orientation.go
@@ -7,6 +7,7 @@ package orientation
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -137,15 +138,19 @@ type ScreenOrientation struct {
 	domcore.EventTarget
 }
 
-// ScreenOrientationFromJS is casting a js.Wrapper into ScreenOrientation.
-func ScreenOrientationFromJS(value js.Wrapper) *ScreenOrientation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenOrientationFromJS is casting a js.Value into ScreenOrientation.
+func ScreenOrientationFromJS(value js.Value) *ScreenOrientation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScreenOrientation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenOrientationFromJS is casting from something that holds a js.Value into ScreenOrientation.
+func ScreenOrientationFromWrapper(input core.Wrapper) *ScreenOrientation {
+	return ScreenOrientationFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with

--- a/media/orientation/orientation_js.go
+++ b/media/orientation/orientation_js.go
@@ -5,6 +5,7 @@ package orientation
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -135,15 +136,19 @@ type ScreenOrientation struct {
 	domcore.EventTarget
 }
 
-// ScreenOrientationFromJS is casting a js.Wrapper into ScreenOrientation.
-func ScreenOrientationFromJS(value js.Wrapper) *ScreenOrientation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ScreenOrientationFromJS is casting a js.Value into ScreenOrientation.
+func ScreenOrientationFromJS(value js.Value) *ScreenOrientation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ScreenOrientation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ScreenOrientationFromJS is casting from something that holds a js.Value into ScreenOrientation.
+func ScreenOrientationFromWrapper(input core.Wrapper) *ScreenOrientation {
+	return ScreenOrientationFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with

--- a/media/pictureinpicture/pictureinpicture.go
+++ b/media/pictureinpicture/pictureinpicture.go
@@ -7,6 +7,7 @@ package pictureinpicture
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -130,7 +131,7 @@ type EnterPictureInPictureEventInit struct {
 	PictureInPictureWindow *PictureInPictureWindow
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EnterPictureInPictureEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -146,10 +147,8 @@ func (_this *EnterPictureInPictureEventInit) JSValue() js.Value {
 }
 
 // EnterPictureInPictureEventInitFromJS is allocating a new
-// EnterPictureInPictureEventInit object and copy all values from
-// input javascript object
-func EnterPictureInPictureEventInitFromJS(value js.Wrapper) *EnterPictureInPictureEventInit {
-	input := value.JSValue()
+// EnterPictureInPictureEventInit object and copy all values in the value javascript object.
+func EnterPictureInPictureEventInitFromJS(value js.Value) *EnterPictureInPictureEventInit {
 	var out EnterPictureInPictureEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -157,13 +156,13 @@ func EnterPictureInPictureEventInitFromJS(value js.Wrapper) *EnterPictureInPictu
 		value2 bool                    // javascript: boolean {composed Composed composed}
 		value3 *PictureInPictureWindow // javascript: PictureInPictureWindow {pictureInPictureWindow PictureInPictureWindow pictureInPictureWindow}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = PictureInPictureWindowFromJS(input.Get("pictureInPictureWindow"))
+	value3 = PictureInPictureWindowFromJS(value.Get("pictureInPictureWindow"))
 	out.PictureInPictureWindow = value3
 	return &out
 }
@@ -173,15 +172,19 @@ type EnterPictureInPictureEvent struct {
 	domcore.Event
 }
 
-// EnterPictureInPictureEventFromJS is casting a js.Wrapper into EnterPictureInPictureEvent.
-func EnterPictureInPictureEventFromJS(value js.Wrapper) *EnterPictureInPictureEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EnterPictureInPictureEventFromJS is casting a js.Value into EnterPictureInPictureEvent.
+func EnterPictureInPictureEventFromJS(value js.Value) *EnterPictureInPictureEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EnterPictureInPictureEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EnterPictureInPictureEventFromJS is casting from something that holds a js.Value into EnterPictureInPictureEvent.
+func EnterPictureInPictureEventFromWrapper(input core.Wrapper) *EnterPictureInPictureEvent {
+	return EnterPictureInPictureEventFromJS(input.JSValue())
 }
 
 func NewEnterPictureInPictureEvent(_type string, eventInitDict *EnterPictureInPictureEventInit) (_result *EnterPictureInPictureEvent) {
@@ -219,15 +222,19 @@ type PictureInPictureWindow struct {
 	domcore.EventTarget
 }
 
-// PictureInPictureWindowFromJS is casting a js.Wrapper into PictureInPictureWindow.
-func PictureInPictureWindowFromJS(value js.Wrapper) *PictureInPictureWindow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PictureInPictureWindowFromJS is casting a js.Value into PictureInPictureWindow.
+func PictureInPictureWindowFromJS(value js.Value) *PictureInPictureWindow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PictureInPictureWindow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PictureInPictureWindowFromJS is casting from something that holds a js.Value into PictureInPictureWindow.
+func PictureInPictureWindowFromWrapper(input core.Wrapper) *PictureInPictureWindow {
+	return PictureInPictureWindowFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -299,15 +306,19 @@ func (_this *PromisePictureInPictureWindow) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePictureInPictureWindowFromJS is casting a js.Wrapper into PromisePictureInPictureWindow.
-func PromisePictureInPictureWindowFromJS(value js.Wrapper) *PromisePictureInPictureWindow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePictureInPictureWindowFromJS is casting a js.Value into PromisePictureInPictureWindow.
+func PromisePictureInPictureWindowFromJS(value js.Value) *PromisePictureInPictureWindow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePictureInPictureWindow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePictureInPictureWindowFromJS is casting from something that holds a js.Value into PromisePictureInPictureWindow.
+func PromisePictureInPictureWindowFromWrapper(input core.Wrapper) *PromisePictureInPictureWindow {
+	return PromisePictureInPictureWindowFromJS(input.JSValue())
 }
 
 func (_this *PromisePictureInPictureWindow) Then(onFulfilled *PromisePictureInPictureWindowOnFulfilled, onRejected *PromisePictureInPictureWindowOnRejected) (_result *PromisePictureInPictureWindow) {

--- a/media/pictureinpicture/pictureinpicture_js.go
+++ b/media/pictureinpicture/pictureinpicture_js.go
@@ -5,6 +5,7 @@ package pictureinpicture
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -128,7 +129,7 @@ type EnterPictureInPictureEventInit struct {
 	PictureInPictureWindow *PictureInPictureWindow
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EnterPictureInPictureEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -144,10 +145,8 @@ func (_this *EnterPictureInPictureEventInit) JSValue() js.Value {
 }
 
 // EnterPictureInPictureEventInitFromJS is allocating a new
-// EnterPictureInPictureEventInit object and copy all values from
-// input javascript object
-func EnterPictureInPictureEventInitFromJS(value js.Wrapper) *EnterPictureInPictureEventInit {
-	input := value.JSValue()
+// EnterPictureInPictureEventInit object and copy all values in the value javascript object.
+func EnterPictureInPictureEventInitFromJS(value js.Value) *EnterPictureInPictureEventInit {
 	var out EnterPictureInPictureEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -155,13 +154,13 @@ func EnterPictureInPictureEventInitFromJS(value js.Wrapper) *EnterPictureInPictu
 		value2 bool                    // javascript: boolean {composed Composed composed}
 		value3 *PictureInPictureWindow // javascript: PictureInPictureWindow {pictureInPictureWindow PictureInPictureWindow pictureInPictureWindow}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = PictureInPictureWindowFromJS(input.Get("pictureInPictureWindow"))
+	value3 = PictureInPictureWindowFromJS(value.Get("pictureInPictureWindow"))
 	out.PictureInPictureWindow = value3
 	return &out
 }
@@ -171,15 +170,19 @@ type EnterPictureInPictureEvent struct {
 	domcore.Event
 }
 
-// EnterPictureInPictureEventFromJS is casting a js.Wrapper into EnterPictureInPictureEvent.
-func EnterPictureInPictureEventFromJS(value js.Wrapper) *EnterPictureInPictureEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EnterPictureInPictureEventFromJS is casting a js.Value into EnterPictureInPictureEvent.
+func EnterPictureInPictureEventFromJS(value js.Value) *EnterPictureInPictureEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EnterPictureInPictureEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EnterPictureInPictureEventFromJS is casting from something that holds a js.Value into EnterPictureInPictureEvent.
+func EnterPictureInPictureEventFromWrapper(input core.Wrapper) *EnterPictureInPictureEvent {
+	return EnterPictureInPictureEventFromJS(input.JSValue())
 }
 
 func NewEnterPictureInPictureEvent(_type string, eventInitDict *EnterPictureInPictureEventInit) (_result *EnterPictureInPictureEvent) {
@@ -217,15 +220,19 @@ type PictureInPictureWindow struct {
 	domcore.EventTarget
 }
 
-// PictureInPictureWindowFromJS is casting a js.Wrapper into PictureInPictureWindow.
-func PictureInPictureWindowFromJS(value js.Wrapper) *PictureInPictureWindow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PictureInPictureWindowFromJS is casting a js.Value into PictureInPictureWindow.
+func PictureInPictureWindowFromJS(value js.Value) *PictureInPictureWindow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PictureInPictureWindow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PictureInPictureWindowFromJS is casting from something that holds a js.Value into PictureInPictureWindow.
+func PictureInPictureWindowFromWrapper(input core.Wrapper) *PictureInPictureWindow {
+	return PictureInPictureWindowFromJS(input.JSValue())
 }
 
 // Width returning attribute 'width' with
@@ -297,15 +304,19 @@ func (_this *PromisePictureInPictureWindow) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePictureInPictureWindowFromJS is casting a js.Wrapper into PromisePictureInPictureWindow.
-func PromisePictureInPictureWindowFromJS(value js.Wrapper) *PromisePictureInPictureWindow {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePictureInPictureWindowFromJS is casting a js.Value into PromisePictureInPictureWindow.
+func PromisePictureInPictureWindowFromJS(value js.Value) *PromisePictureInPictureWindow {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePictureInPictureWindow{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePictureInPictureWindowFromJS is casting from something that holds a js.Value into PromisePictureInPictureWindow.
+func PromisePictureInPictureWindowFromWrapper(input core.Wrapper) *PromisePictureInPictureWindow {
+	return PromisePictureInPictureWindowFromJS(input.JSValue())
 }
 
 func (_this *PromisePictureInPictureWindow) Then(onFulfilled *PromisePictureInPictureWindowOnFulfilled, onRejected *PromisePictureInPictureWindowOnRejected) (_result *PromisePictureInPictureWindow) {

--- a/media/remoteplayback/remoteplayback.go
+++ b/media/remoteplayback/remoteplayback.go
@@ -7,6 +7,7 @@ package remoteplayback
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -129,15 +130,19 @@ type RemotePlayback struct {
 	domcore.EventTarget
 }
 
-// RemotePlaybackFromJS is casting a js.Wrapper into RemotePlayback.
-func RemotePlaybackFromJS(value js.Wrapper) *RemotePlayback {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemotePlaybackFromJS is casting a js.Value into RemotePlayback.
+func RemotePlaybackFromJS(value js.Value) *RemotePlayback {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemotePlayback{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemotePlaybackFromJS is casting from something that holds a js.Value into RemotePlayback.
+func RemotePlaybackFromWrapper(input core.Wrapper) *RemotePlayback {
+	return RemotePlaybackFromJS(input.JSValue())
 }
 
 // State returning attribute 'state' with

--- a/media/remoteplayback/remoteplayback_js.go
+++ b/media/remoteplayback/remoteplayback_js.go
@@ -5,6 +5,7 @@ package remoteplayback
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -127,15 +128,19 @@ type RemotePlayback struct {
 	domcore.EventTarget
 }
 
-// RemotePlaybackFromJS is casting a js.Wrapper into RemotePlayback.
-func RemotePlaybackFromJS(value js.Wrapper) *RemotePlayback {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RemotePlaybackFromJS is casting a js.Value into RemotePlayback.
+func RemotePlaybackFromJS(value js.Value) *RemotePlayback {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RemotePlayback{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RemotePlaybackFromJS is casting from something that holds a js.Value into RemotePlayback.
+func RemotePlaybackFromWrapper(input core.Wrapper) *RemotePlayback {
+	return RemotePlaybackFromJS(input.JSValue())
 }
 
 // State returning attribute 'state' with

--- a/media/session/session.go
+++ b/media/session/session.go
@@ -7,6 +7,7 @@ package session
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -167,7 +168,7 @@ type MediaImage struct {
 	Type  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaImage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -181,21 +182,19 @@ func (_this *MediaImage) JSValue() js.Value {
 }
 
 // MediaImageFromJS is allocating a new
-// MediaImage object and copy all values from
-// input javascript object
-func MediaImageFromJS(value js.Wrapper) *MediaImage {
-	input := value.JSValue()
+// MediaImage object and copy all values in the value javascript object.
+func MediaImageFromJS(value js.Value) *MediaImage {
 	var out MediaImage
 	var (
 		value0 string // javascript: USVString {src Src src}
 		value1 string // javascript: DOMString {sizes Sizes sizes}
 		value2 string // javascript: DOMString {type Type _type}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
 	return &out
 }
@@ -208,7 +207,7 @@ type MediaMetadataInit struct {
 	Artwork []*MediaImage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaMetadataInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -228,10 +227,8 @@ func (_this *MediaMetadataInit) JSValue() js.Value {
 }
 
 // MediaMetadataInitFromJS is allocating a new
-// MediaMetadataInit object and copy all values from
-// input javascript object
-func MediaMetadataInitFromJS(value js.Wrapper) *MediaMetadataInit {
-	input := value.JSValue()
+// MediaMetadataInit object and copy all values in the value javascript object.
+func MediaMetadataInitFromJS(value js.Value) *MediaMetadataInit {
 	var out MediaMetadataInit
 	var (
 		value0 string        // javascript: DOMString {title Title title}
@@ -239,17 +236,17 @@ func MediaMetadataInitFromJS(value js.Wrapper) *MediaMetadataInit {
 		value2 string        // javascript: DOMString {album Album album}
 		value3 []*MediaImage // javascript: sequence<MediaImage> {artwork Artwork artwork}
 	)
-	value0 = (input.Get("title")).String()
+	value0 = (value.Get("title")).String()
 	out.Title = value0
-	value1 = (input.Get("artist")).String()
+	value1 = (value.Get("artist")).String()
 	out.Artist = value1
-	value2 = (input.Get("album")).String()
+	value2 = (value.Get("album")).String()
 	out.Album = value2
-	__length3 := input.Get("artwork").Length()
+	__length3 := value.Get("artwork").Length()
 	__array3 := make([]*MediaImage, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *MediaImage
-		__seq_in3 := input.Get("artwork").Index(__idx3)
+		__seq_in3 := value.Get("artwork").Index(__idx3)
 		__seq_out3 = MediaImageFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -268,15 +265,19 @@ func (_this *MediaMetadata) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaMetadataFromJS is casting a js.Wrapper into MediaMetadata.
-func MediaMetadataFromJS(value js.Wrapper) *MediaMetadata {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaMetadataFromJS is casting a js.Value into MediaMetadata.
+func MediaMetadataFromJS(value js.Value) *MediaMetadata {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaMetadata{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaMetadataFromJS is casting from something that holds a js.Value into MediaMetadata.
+func MediaMetadataFromWrapper(input core.Wrapper) *MediaMetadata {
+	return MediaMetadataFromJS(input.JSValue())
 }
 
 func NewMediaMetadata(init *MediaMetadataInit) (_result *MediaMetadata) {
@@ -373,15 +374,19 @@ func (_this *MediaSession) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaSessionFromJS is casting a js.Wrapper into MediaSession.
-func MediaSessionFromJS(value js.Wrapper) *MediaSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSessionFromJS is casting a js.Value into MediaSession.
+func MediaSessionFromJS(value js.Value) *MediaSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSessionFromJS is casting from something that holds a js.Value into MediaSession.
+func MediaSessionFromWrapper(input core.Wrapper) *MediaSession {
+	return MediaSessionFromJS(input.JSValue())
 }
 
 // Metadata returning attribute 'metadata' with

--- a/media/session/session_js.go
+++ b/media/session/session_js.go
@@ -5,6 +5,7 @@ package session
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -165,7 +166,7 @@ type MediaImage struct {
 	Type  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaImage) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -179,21 +180,19 @@ func (_this *MediaImage) JSValue() js.Value {
 }
 
 // MediaImageFromJS is allocating a new
-// MediaImage object and copy all values from
-// input javascript object
-func MediaImageFromJS(value js.Wrapper) *MediaImage {
-	input := value.JSValue()
+// MediaImage object and copy all values in the value javascript object.
+func MediaImageFromJS(value js.Value) *MediaImage {
 	var out MediaImage
 	var (
 		value0 string // javascript: USVString {src Src src}
 		value1 string // javascript: DOMString {sizes Sizes sizes}
 		value2 string // javascript: DOMString {type Type _type}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
 	return &out
 }
@@ -206,7 +205,7 @@ type MediaMetadataInit struct {
 	Artwork []*MediaImage
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaMetadataInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -226,10 +225,8 @@ func (_this *MediaMetadataInit) JSValue() js.Value {
 }
 
 // MediaMetadataInitFromJS is allocating a new
-// MediaMetadataInit object and copy all values from
-// input javascript object
-func MediaMetadataInitFromJS(value js.Wrapper) *MediaMetadataInit {
-	input := value.JSValue()
+// MediaMetadataInit object and copy all values in the value javascript object.
+func MediaMetadataInitFromJS(value js.Value) *MediaMetadataInit {
 	var out MediaMetadataInit
 	var (
 		value0 string        // javascript: DOMString {title Title title}
@@ -237,17 +234,17 @@ func MediaMetadataInitFromJS(value js.Wrapper) *MediaMetadataInit {
 		value2 string        // javascript: DOMString {album Album album}
 		value3 []*MediaImage // javascript: sequence<MediaImage> {artwork Artwork artwork}
 	)
-	value0 = (input.Get("title")).String()
+	value0 = (value.Get("title")).String()
 	out.Title = value0
-	value1 = (input.Get("artist")).String()
+	value1 = (value.Get("artist")).String()
 	out.Artist = value1
-	value2 = (input.Get("album")).String()
+	value2 = (value.Get("album")).String()
 	out.Album = value2
-	__length3 := input.Get("artwork").Length()
+	__length3 := value.Get("artwork").Length()
 	__array3 := make([]*MediaImage, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *MediaImage
-		__seq_in3 := input.Get("artwork").Index(__idx3)
+		__seq_in3 := value.Get("artwork").Index(__idx3)
 		__seq_out3 = MediaImageFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -266,15 +263,19 @@ func (_this *MediaMetadata) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaMetadataFromJS is casting a js.Wrapper into MediaMetadata.
-func MediaMetadataFromJS(value js.Wrapper) *MediaMetadata {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaMetadataFromJS is casting a js.Value into MediaMetadata.
+func MediaMetadataFromJS(value js.Value) *MediaMetadata {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaMetadata{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaMetadataFromJS is casting from something that holds a js.Value into MediaMetadata.
+func MediaMetadataFromWrapper(input core.Wrapper) *MediaMetadata {
+	return MediaMetadataFromJS(input.JSValue())
 }
 
 func NewMediaMetadata(init *MediaMetadataInit) (_result *MediaMetadata) {
@@ -371,15 +372,19 @@ func (_this *MediaSession) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MediaSessionFromJS is casting a js.Wrapper into MediaSession.
-func MediaSessionFromJS(value js.Wrapper) *MediaSession {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaSessionFromJS is casting a js.Value into MediaSession.
+func MediaSessionFromJS(value js.Value) *MediaSession {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaSession{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaSessionFromJS is casting from something that holds a js.Value into MediaSession.
+func MediaSessionFromWrapper(input core.Wrapper) *MediaSession {
+	return MediaSessionFromJS(input.JSValue())
 }
 
 // Metadata returning attribute 'metadata' with

--- a/media/speech/speech.go
+++ b/media/speech/speech.go
@@ -7,6 +7,7 @@ package speech
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -147,7 +148,7 @@ type SpeechRecognitionErrorEventInit struct {
 	Message    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechRecognitionErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -165,10 +166,8 @@ func (_this *SpeechRecognitionErrorEventInit) JSValue() js.Value {
 }
 
 // SpeechRecognitionErrorEventInitFromJS is allocating a new
-// SpeechRecognitionErrorEventInit object and copy all values from
-// input javascript object
-func SpeechRecognitionErrorEventInitFromJS(value js.Wrapper) *SpeechRecognitionErrorEventInit {
-	input := value.JSValue()
+// SpeechRecognitionErrorEventInit object and copy all values in the value javascript object.
+func SpeechRecognitionErrorEventInitFromJS(value js.Value) *SpeechRecognitionErrorEventInit {
 	var out SpeechRecognitionErrorEventInit
 	var (
 		value0 bool                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -177,15 +176,15 @@ func SpeechRecognitionErrorEventInitFromJS(value js.Wrapper) *SpeechRecognitionE
 		value3 SpeechRecognitionErrorCode // javascript: SpeechRecognitionErrorCode {error Error _error}
 		value4 string                     // javascript: DOMString {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechRecognitionErrorCodeFromJS(input.Get("error"))
+	value3 = SpeechRecognitionErrorCodeFromJS(value.Get("error"))
 	out.Error = value3
-	value4 = (input.Get("message")).String()
+	value4 = (value.Get("message")).String()
 	out.Message = value4
 	return &out
 }
@@ -201,7 +200,7 @@ type SpeechRecognitionEventInit struct {
 	Emma           js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechRecognitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -223,10 +222,8 @@ func (_this *SpeechRecognitionEventInit) JSValue() js.Value {
 }
 
 // SpeechRecognitionEventInitFromJS is allocating a new
-// SpeechRecognitionEventInit object and copy all values from
-// input javascript object
-func SpeechRecognitionEventInitFromJS(value js.Wrapper) *SpeechRecognitionEventInit {
-	input := value.JSValue()
+// SpeechRecognitionEventInit object and copy all values in the value javascript object.
+func SpeechRecognitionEventInitFromJS(value js.Value) *SpeechRecognitionEventInit {
 	var out SpeechRecognitionEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -237,19 +234,19 @@ func SpeechRecognitionEventInitFromJS(value js.Wrapper) *SpeechRecognitionEventI
 		value5 js.Value                     // javascript: any {interpretation Interpretation interpretation}
 		value6 js.Value                     // javascript: Document {emma Emma emma}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (uint)((input.Get("resultIndex")).Int())
+	value3 = (uint)((value.Get("resultIndex")).Int())
 	out.ResultIndex = value3
-	value4 = SpeechRecognitionResultListFromJS(input.Get("results"))
+	value4 = SpeechRecognitionResultListFromJS(value.Get("results"))
 	out.Results = value4
-	value5 = input.Get("interpretation")
+	value5 = value.Get("interpretation")
 	out.Interpretation = value5
-	value6 = input.Get("emma")
+	value6 = value.Get("emma")
 	out.Emma = value6
 	return &out
 }
@@ -266,7 +263,7 @@ type SpeechSynthesisErrorEventInit struct {
 	Error       SpeechSynthesisErrorCode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechSynthesisErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -290,10 +287,8 @@ func (_this *SpeechSynthesisErrorEventInit) JSValue() js.Value {
 }
 
 // SpeechSynthesisErrorEventInitFromJS is allocating a new
-// SpeechSynthesisErrorEventInit object and copy all values from
-// input javascript object
-func SpeechSynthesisErrorEventInitFromJS(value js.Wrapper) *SpeechSynthesisErrorEventInit {
-	input := value.JSValue()
+// SpeechSynthesisErrorEventInit object and copy all values in the value javascript object.
+func SpeechSynthesisErrorEventInitFromJS(value js.Value) *SpeechSynthesisErrorEventInit {
 	var out SpeechSynthesisErrorEventInit
 	var (
 		value0 bool                      // javascript: boolean {bubbles Bubbles bubbles}
@@ -305,21 +300,21 @@ func SpeechSynthesisErrorEventInitFromJS(value js.Wrapper) *SpeechSynthesisError
 		value6 string                    // javascript: DOMString {name Name name}
 		value7 SpeechSynthesisErrorCode  // javascript: SpeechSynthesisErrorCode {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechSynthesisUtteranceFromJS(input.Get("utterance"))
+	value3 = SpeechSynthesisUtteranceFromJS(value.Get("utterance"))
 	out.Utterance = value3
-	value4 = (uint)((input.Get("charIndex")).Int())
+	value4 = (uint)((value.Get("charIndex")).Int())
 	out.CharIndex = value4
-	value5 = (float32)((input.Get("elapsedTime")).Float())
+	value5 = (float32)((value.Get("elapsedTime")).Float())
 	out.ElapsedTime = value5
-	value6 = (input.Get("name")).String()
+	value6 = (value.Get("name")).String()
 	out.Name = value6
-	value7 = SpeechSynthesisErrorCodeFromJS(input.Get("error"))
+	value7 = SpeechSynthesisErrorCodeFromJS(value.Get("error"))
 	out.Error = value7
 	return &out
 }
@@ -335,7 +330,7 @@ type SpeechSynthesisEventInit struct {
 	Name        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechSynthesisEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -357,10 +352,8 @@ func (_this *SpeechSynthesisEventInit) JSValue() js.Value {
 }
 
 // SpeechSynthesisEventInitFromJS is allocating a new
-// SpeechSynthesisEventInit object and copy all values from
-// input javascript object
-func SpeechSynthesisEventInitFromJS(value js.Wrapper) *SpeechSynthesisEventInit {
-	input := value.JSValue()
+// SpeechSynthesisEventInit object and copy all values in the value javascript object.
+func SpeechSynthesisEventInitFromJS(value js.Value) *SpeechSynthesisEventInit {
 	var out SpeechSynthesisEventInit
 	var (
 		value0 bool                      // javascript: boolean {bubbles Bubbles bubbles}
@@ -371,19 +364,19 @@ func SpeechSynthesisEventInitFromJS(value js.Wrapper) *SpeechSynthesisEventInit 
 		value5 float32                   // javascript: float {elapsedTime ElapsedTime elapsedTime}
 		value6 string                    // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechSynthesisUtteranceFromJS(input.Get("utterance"))
+	value3 = SpeechSynthesisUtteranceFromJS(value.Get("utterance"))
 	out.Utterance = value3
-	value4 = (uint)((input.Get("charIndex")).Int())
+	value4 = (uint)((value.Get("charIndex")).Int())
 	out.CharIndex = value4
-	value5 = (float32)((input.Get("elapsedTime")).Float())
+	value5 = (float32)((value.Get("elapsedTime")).Float())
 	out.ElapsedTime = value5
-	value6 = (input.Get("name")).String()
+	value6 = (value.Get("name")).String()
 	out.Name = value6
 	return &out
 }
@@ -398,15 +391,19 @@ func (_this *SpeechGrammar) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechGrammarFromJS is casting a js.Wrapper into SpeechGrammar.
-func SpeechGrammarFromJS(value js.Wrapper) *SpeechGrammar {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechGrammarFromJS is casting a js.Value into SpeechGrammar.
+func SpeechGrammarFromJS(value js.Value) *SpeechGrammar {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechGrammar{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechGrammarFromJS is casting from something that holds a js.Value into SpeechGrammar.
+func SpeechGrammarFromWrapper(input core.Wrapper) *SpeechGrammar {
+	return SpeechGrammarFromJS(input.JSValue())
 }
 
 func NewSpeechGrammar() (_result *SpeechGrammar) {
@@ -466,15 +463,19 @@ func (_this *SpeechGrammarList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechGrammarListFromJS is casting a js.Wrapper into SpeechGrammarList.
-func SpeechGrammarListFromJS(value js.Wrapper) *SpeechGrammarList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechGrammarListFromJS is casting a js.Value into SpeechGrammarList.
+func SpeechGrammarListFromJS(value js.Value) *SpeechGrammarList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechGrammarList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechGrammarListFromJS is casting from something that holds a js.Value into SpeechGrammarList.
+func SpeechGrammarListFromWrapper(input core.Wrapper) *SpeechGrammarList {
+	return SpeechGrammarListFromJS(input.JSValue())
 }
 
 func NewSpeechGrammarList() (_result *SpeechGrammarList) {
@@ -586,15 +587,19 @@ type SpeechRecognition struct {
 	domcore.EventTarget
 }
 
-// SpeechRecognitionFromJS is casting a js.Wrapper into SpeechRecognition.
-func SpeechRecognitionFromJS(value js.Wrapper) *SpeechRecognition {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionFromJS is casting a js.Value into SpeechRecognition.
+func SpeechRecognitionFromJS(value js.Value) *SpeechRecognition {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognition{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionFromJS is casting from something that holds a js.Value into SpeechRecognition.
+func SpeechRecognitionFromWrapper(input core.Wrapper) *SpeechRecognition {
+	return SpeechRecognitionFromJS(input.JSValue())
 }
 
 func NewSpeechRecognition() (_result *SpeechRecognition) {
@@ -1084,15 +1089,19 @@ func (_this *SpeechRecognitionAlternative) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionAlternativeFromJS is casting a js.Wrapper into SpeechRecognitionAlternative.
-func SpeechRecognitionAlternativeFromJS(value js.Wrapper) *SpeechRecognitionAlternative {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionAlternativeFromJS is casting a js.Value into SpeechRecognitionAlternative.
+func SpeechRecognitionAlternativeFromJS(value js.Value) *SpeechRecognitionAlternative {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionAlternative{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionAlternativeFromJS is casting from something that holds a js.Value into SpeechRecognitionAlternative.
+func SpeechRecognitionAlternativeFromWrapper(input core.Wrapper) *SpeechRecognitionAlternative {
+	return SpeechRecognitionAlternativeFromJS(input.JSValue())
 }
 
 // Transcript returning attribute 'transcript' with
@@ -1118,15 +1127,19 @@ type SpeechRecognitionErrorEvent struct {
 	domcore.Event
 }
 
-// SpeechRecognitionErrorEventFromJS is casting a js.Wrapper into SpeechRecognitionErrorEvent.
-func SpeechRecognitionErrorEventFromJS(value js.Wrapper) *SpeechRecognitionErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionErrorEventFromJS is casting a js.Value into SpeechRecognitionErrorEvent.
+func SpeechRecognitionErrorEventFromJS(value js.Value) *SpeechRecognitionErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionErrorEventFromJS is casting from something that holds a js.Value into SpeechRecognitionErrorEvent.
+func SpeechRecognitionErrorEventFromWrapper(input core.Wrapper) *SpeechRecognitionErrorEvent {
+	return SpeechRecognitionErrorEventFromJS(input.JSValue())
 }
 
 func NewSpeechRecognitionErrorEvent(_type string, eventInitDict *SpeechRecognitionErrorEventInit) (_result *SpeechRecognitionErrorEvent) {
@@ -1173,15 +1186,19 @@ type SpeechRecognitionEvent struct {
 	domcore.Event
 }
 
-// SpeechRecognitionEventFromJS is casting a js.Wrapper into SpeechRecognitionEvent.
-func SpeechRecognitionEventFromJS(value js.Wrapper) *SpeechRecognitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionEventFromJS is casting a js.Value into SpeechRecognitionEvent.
+func SpeechRecognitionEventFromJS(value js.Value) *SpeechRecognitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionEventFromJS is casting from something that holds a js.Value into SpeechRecognitionEvent.
+func SpeechRecognitionEventFromWrapper(input core.Wrapper) *SpeechRecognitionEvent {
+	return SpeechRecognitionEventFromJS(input.JSValue())
 }
 
 func NewSpeechRecognitionEvent(_type string, eventInitDict *SpeechRecognitionEventInit) (_result *SpeechRecognitionEvent) {
@@ -1251,15 +1268,19 @@ func (_this *SpeechRecognitionResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionResultFromJS is casting a js.Wrapper into SpeechRecognitionResult.
-func SpeechRecognitionResultFromJS(value js.Wrapper) *SpeechRecognitionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionResultFromJS is casting a js.Value into SpeechRecognitionResult.
+func SpeechRecognitionResultFromJS(value js.Value) *SpeechRecognitionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionResultFromJS is casting from something that holds a js.Value into SpeechRecognitionResult.
+func SpeechRecognitionResultFromWrapper(input core.Wrapper) *SpeechRecognitionResult {
+	return SpeechRecognitionResultFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1324,15 +1345,19 @@ func (_this *SpeechRecognitionResultList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionResultListFromJS is casting a js.Wrapper into SpeechRecognitionResultList.
-func SpeechRecognitionResultListFromJS(value js.Wrapper) *SpeechRecognitionResultList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionResultListFromJS is casting a js.Value into SpeechRecognitionResultList.
+func SpeechRecognitionResultListFromJS(value js.Value) *SpeechRecognitionResultList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionResultList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionResultListFromJS is casting from something that holds a js.Value into SpeechRecognitionResultList.
+func SpeechRecognitionResultListFromWrapper(input core.Wrapper) *SpeechRecognitionResultList {
+	return SpeechRecognitionResultListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1383,15 +1408,19 @@ type SpeechSynthesis struct {
 	domcore.EventTarget
 }
 
-// SpeechSynthesisFromJS is casting a js.Wrapper into SpeechSynthesis.
-func SpeechSynthesisFromJS(value js.Wrapper) *SpeechSynthesis {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisFromJS is casting a js.Value into SpeechSynthesis.
+func SpeechSynthesisFromJS(value js.Value) *SpeechSynthesis {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesis{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisFromJS is casting from something that holds a js.Value into SpeechSynthesis.
+func SpeechSynthesisFromWrapper(input core.Wrapper) *SpeechSynthesis {
+	return SpeechSynthesisFromJS(input.JSValue())
 }
 
 // Pending returning attribute 'pending' with
@@ -1528,15 +1557,19 @@ type SpeechSynthesisErrorEvent struct {
 	SpeechSynthesisEvent
 }
 
-// SpeechSynthesisErrorEventFromJS is casting a js.Wrapper into SpeechSynthesisErrorEvent.
-func SpeechSynthesisErrorEventFromJS(value js.Wrapper) *SpeechSynthesisErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisErrorEventFromJS is casting a js.Value into SpeechSynthesisErrorEvent.
+func SpeechSynthesisErrorEventFromJS(value js.Value) *SpeechSynthesisErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisErrorEventFromJS is casting from something that holds a js.Value into SpeechSynthesisErrorEvent.
+func SpeechSynthesisErrorEventFromWrapper(input core.Wrapper) *SpeechSynthesisErrorEvent {
+	return SpeechSynthesisErrorEventFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisErrorEvent(_type string, eventInitDict *SpeechSynthesisErrorEventInit) (_result *SpeechSynthesisErrorEvent) {
@@ -1574,15 +1607,19 @@ type SpeechSynthesisEvent struct {
 	domcore.Event
 }
 
-// SpeechSynthesisEventFromJS is casting a js.Wrapper into SpeechSynthesisEvent.
-func SpeechSynthesisEventFromJS(value js.Wrapper) *SpeechSynthesisEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisEventFromJS is casting a js.Value into SpeechSynthesisEvent.
+func SpeechSynthesisEventFromJS(value js.Value) *SpeechSynthesisEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisEventFromJS is casting from something that holds a js.Value into SpeechSynthesisEvent.
+func SpeechSynthesisEventFromWrapper(input core.Wrapper) *SpeechSynthesisEvent {
+	return SpeechSynthesisEventFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisEvent(_type string, eventInitDict *SpeechSynthesisEventInit) (_result *SpeechSynthesisEvent) {
@@ -1647,15 +1684,19 @@ type SpeechSynthesisUtterance struct {
 	domcore.EventTarget
 }
 
-// SpeechSynthesisUtteranceFromJS is casting a js.Wrapper into SpeechSynthesisUtterance.
-func SpeechSynthesisUtteranceFromJS(value js.Wrapper) *SpeechSynthesisUtterance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisUtteranceFromJS is casting a js.Value into SpeechSynthesisUtterance.
+func SpeechSynthesisUtteranceFromJS(value js.Value) *SpeechSynthesisUtterance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisUtterance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisUtteranceFromJS is casting from something that holds a js.Value into SpeechSynthesisUtterance.
+func SpeechSynthesisUtteranceFromWrapper(input core.Wrapper) *SpeechSynthesisUtterance {
+	return SpeechSynthesisUtteranceFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisUtterance(text *string) (_result *SpeechSynthesisUtterance) {
@@ -2009,15 +2050,19 @@ func (_this *SpeechSynthesisVoice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechSynthesisVoiceFromJS is casting a js.Wrapper into SpeechSynthesisVoice.
-func SpeechSynthesisVoiceFromJS(value js.Wrapper) *SpeechSynthesisVoice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisVoiceFromJS is casting a js.Value into SpeechSynthesisVoice.
+func SpeechSynthesisVoiceFromJS(value js.Value) *SpeechSynthesisVoice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisVoice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisVoiceFromJS is casting from something that holds a js.Value into SpeechSynthesisVoice.
+func SpeechSynthesisVoiceFromWrapper(input core.Wrapper) *SpeechSynthesisVoice {
+	return SpeechSynthesisVoiceFromJS(input.JSValue())
 }
 
 // VoiceURI returning attribute 'voiceURI' with

--- a/media/speech/speech_js.go
+++ b/media/speech/speech_js.go
@@ -5,6 +5,7 @@ package speech
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 )
 
@@ -145,7 +146,7 @@ type SpeechRecognitionErrorEventInit struct {
 	Message    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechRecognitionErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -163,10 +164,8 @@ func (_this *SpeechRecognitionErrorEventInit) JSValue() js.Value {
 }
 
 // SpeechRecognitionErrorEventInitFromJS is allocating a new
-// SpeechRecognitionErrorEventInit object and copy all values from
-// input javascript object
-func SpeechRecognitionErrorEventInitFromJS(value js.Wrapper) *SpeechRecognitionErrorEventInit {
-	input := value.JSValue()
+// SpeechRecognitionErrorEventInit object and copy all values in the value javascript object.
+func SpeechRecognitionErrorEventInitFromJS(value js.Value) *SpeechRecognitionErrorEventInit {
 	var out SpeechRecognitionErrorEventInit
 	var (
 		value0 bool                       // javascript: boolean {bubbles Bubbles bubbles}
@@ -175,15 +174,15 @@ func SpeechRecognitionErrorEventInitFromJS(value js.Wrapper) *SpeechRecognitionE
 		value3 SpeechRecognitionErrorCode // javascript: SpeechRecognitionErrorCode {error Error _error}
 		value4 string                     // javascript: DOMString {message Message message}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechRecognitionErrorCodeFromJS(input.Get("error"))
+	value3 = SpeechRecognitionErrorCodeFromJS(value.Get("error"))
 	out.Error = value3
-	value4 = (input.Get("message")).String()
+	value4 = (value.Get("message")).String()
 	out.Message = value4
 	return &out
 }
@@ -199,7 +198,7 @@ type SpeechRecognitionEventInit struct {
 	Emma           js.Value
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechRecognitionEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -221,10 +220,8 @@ func (_this *SpeechRecognitionEventInit) JSValue() js.Value {
 }
 
 // SpeechRecognitionEventInitFromJS is allocating a new
-// SpeechRecognitionEventInit object and copy all values from
-// input javascript object
-func SpeechRecognitionEventInitFromJS(value js.Wrapper) *SpeechRecognitionEventInit {
-	input := value.JSValue()
+// SpeechRecognitionEventInit object and copy all values in the value javascript object.
+func SpeechRecognitionEventInitFromJS(value js.Value) *SpeechRecognitionEventInit {
 	var out SpeechRecognitionEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -235,19 +232,19 @@ func SpeechRecognitionEventInitFromJS(value js.Wrapper) *SpeechRecognitionEventI
 		value5 js.Value                     // javascript: any {interpretation Interpretation interpretation}
 		value6 js.Value                     // javascript: Document {emma Emma emma}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (uint)((input.Get("resultIndex")).Int())
+	value3 = (uint)((value.Get("resultIndex")).Int())
 	out.ResultIndex = value3
-	value4 = SpeechRecognitionResultListFromJS(input.Get("results"))
+	value4 = SpeechRecognitionResultListFromJS(value.Get("results"))
 	out.Results = value4
-	value5 = input.Get("interpretation")
+	value5 = value.Get("interpretation")
 	out.Interpretation = value5
-	value6 = input.Get("emma")
+	value6 = value.Get("emma")
 	out.Emma = value6
 	return &out
 }
@@ -264,7 +261,7 @@ type SpeechSynthesisErrorEventInit struct {
 	Error       SpeechSynthesisErrorCode
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechSynthesisErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -288,10 +285,8 @@ func (_this *SpeechSynthesisErrorEventInit) JSValue() js.Value {
 }
 
 // SpeechSynthesisErrorEventInitFromJS is allocating a new
-// SpeechSynthesisErrorEventInit object and copy all values from
-// input javascript object
-func SpeechSynthesisErrorEventInitFromJS(value js.Wrapper) *SpeechSynthesisErrorEventInit {
-	input := value.JSValue()
+// SpeechSynthesisErrorEventInit object and copy all values in the value javascript object.
+func SpeechSynthesisErrorEventInitFromJS(value js.Value) *SpeechSynthesisErrorEventInit {
 	var out SpeechSynthesisErrorEventInit
 	var (
 		value0 bool                      // javascript: boolean {bubbles Bubbles bubbles}
@@ -303,21 +298,21 @@ func SpeechSynthesisErrorEventInitFromJS(value js.Wrapper) *SpeechSynthesisError
 		value6 string                    // javascript: DOMString {name Name name}
 		value7 SpeechSynthesisErrorCode  // javascript: SpeechSynthesisErrorCode {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechSynthesisUtteranceFromJS(input.Get("utterance"))
+	value3 = SpeechSynthesisUtteranceFromJS(value.Get("utterance"))
 	out.Utterance = value3
-	value4 = (uint)((input.Get("charIndex")).Int())
+	value4 = (uint)((value.Get("charIndex")).Int())
 	out.CharIndex = value4
-	value5 = (float32)((input.Get("elapsedTime")).Float())
+	value5 = (float32)((value.Get("elapsedTime")).Float())
 	out.ElapsedTime = value5
-	value6 = (input.Get("name")).String()
+	value6 = (value.Get("name")).String()
 	out.Name = value6
-	value7 = SpeechSynthesisErrorCodeFromJS(input.Get("error"))
+	value7 = SpeechSynthesisErrorCodeFromJS(value.Get("error"))
 	out.Error = value7
 	return &out
 }
@@ -333,7 +328,7 @@ type SpeechSynthesisEventInit struct {
 	Name        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SpeechSynthesisEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -355,10 +350,8 @@ func (_this *SpeechSynthesisEventInit) JSValue() js.Value {
 }
 
 // SpeechSynthesisEventInitFromJS is allocating a new
-// SpeechSynthesisEventInit object and copy all values from
-// input javascript object
-func SpeechSynthesisEventInitFromJS(value js.Wrapper) *SpeechSynthesisEventInit {
-	input := value.JSValue()
+// SpeechSynthesisEventInit object and copy all values in the value javascript object.
+func SpeechSynthesisEventInitFromJS(value js.Value) *SpeechSynthesisEventInit {
 	var out SpeechSynthesisEventInit
 	var (
 		value0 bool                      // javascript: boolean {bubbles Bubbles bubbles}
@@ -369,19 +362,19 @@ func SpeechSynthesisEventInitFromJS(value js.Wrapper) *SpeechSynthesisEventInit 
 		value5 float32                   // javascript: float {elapsedTime ElapsedTime elapsedTime}
 		value6 string                    // javascript: DOMString {name Name name}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SpeechSynthesisUtteranceFromJS(input.Get("utterance"))
+	value3 = SpeechSynthesisUtteranceFromJS(value.Get("utterance"))
 	out.Utterance = value3
-	value4 = (uint)((input.Get("charIndex")).Int())
+	value4 = (uint)((value.Get("charIndex")).Int())
 	out.CharIndex = value4
-	value5 = (float32)((input.Get("elapsedTime")).Float())
+	value5 = (float32)((value.Get("elapsedTime")).Float())
 	out.ElapsedTime = value5
-	value6 = (input.Get("name")).String()
+	value6 = (value.Get("name")).String()
 	out.Name = value6
 	return &out
 }
@@ -396,15 +389,19 @@ func (_this *SpeechGrammar) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechGrammarFromJS is casting a js.Wrapper into SpeechGrammar.
-func SpeechGrammarFromJS(value js.Wrapper) *SpeechGrammar {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechGrammarFromJS is casting a js.Value into SpeechGrammar.
+func SpeechGrammarFromJS(value js.Value) *SpeechGrammar {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechGrammar{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechGrammarFromJS is casting from something that holds a js.Value into SpeechGrammar.
+func SpeechGrammarFromWrapper(input core.Wrapper) *SpeechGrammar {
+	return SpeechGrammarFromJS(input.JSValue())
 }
 
 func NewSpeechGrammar() (_result *SpeechGrammar) {
@@ -464,15 +461,19 @@ func (_this *SpeechGrammarList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechGrammarListFromJS is casting a js.Wrapper into SpeechGrammarList.
-func SpeechGrammarListFromJS(value js.Wrapper) *SpeechGrammarList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechGrammarListFromJS is casting a js.Value into SpeechGrammarList.
+func SpeechGrammarListFromJS(value js.Value) *SpeechGrammarList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechGrammarList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechGrammarListFromJS is casting from something that holds a js.Value into SpeechGrammarList.
+func SpeechGrammarListFromWrapper(input core.Wrapper) *SpeechGrammarList {
+	return SpeechGrammarListFromJS(input.JSValue())
 }
 
 func NewSpeechGrammarList() (_result *SpeechGrammarList) {
@@ -584,15 +585,19 @@ type SpeechRecognition struct {
 	domcore.EventTarget
 }
 
-// SpeechRecognitionFromJS is casting a js.Wrapper into SpeechRecognition.
-func SpeechRecognitionFromJS(value js.Wrapper) *SpeechRecognition {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionFromJS is casting a js.Value into SpeechRecognition.
+func SpeechRecognitionFromJS(value js.Value) *SpeechRecognition {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognition{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionFromJS is casting from something that holds a js.Value into SpeechRecognition.
+func SpeechRecognitionFromWrapper(input core.Wrapper) *SpeechRecognition {
+	return SpeechRecognitionFromJS(input.JSValue())
 }
 
 func NewSpeechRecognition() (_result *SpeechRecognition) {
@@ -1082,15 +1087,19 @@ func (_this *SpeechRecognitionAlternative) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionAlternativeFromJS is casting a js.Wrapper into SpeechRecognitionAlternative.
-func SpeechRecognitionAlternativeFromJS(value js.Wrapper) *SpeechRecognitionAlternative {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionAlternativeFromJS is casting a js.Value into SpeechRecognitionAlternative.
+func SpeechRecognitionAlternativeFromJS(value js.Value) *SpeechRecognitionAlternative {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionAlternative{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionAlternativeFromJS is casting from something that holds a js.Value into SpeechRecognitionAlternative.
+func SpeechRecognitionAlternativeFromWrapper(input core.Wrapper) *SpeechRecognitionAlternative {
+	return SpeechRecognitionAlternativeFromJS(input.JSValue())
 }
 
 // Transcript returning attribute 'transcript' with
@@ -1116,15 +1125,19 @@ type SpeechRecognitionErrorEvent struct {
 	domcore.Event
 }
 
-// SpeechRecognitionErrorEventFromJS is casting a js.Wrapper into SpeechRecognitionErrorEvent.
-func SpeechRecognitionErrorEventFromJS(value js.Wrapper) *SpeechRecognitionErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionErrorEventFromJS is casting a js.Value into SpeechRecognitionErrorEvent.
+func SpeechRecognitionErrorEventFromJS(value js.Value) *SpeechRecognitionErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionErrorEventFromJS is casting from something that holds a js.Value into SpeechRecognitionErrorEvent.
+func SpeechRecognitionErrorEventFromWrapper(input core.Wrapper) *SpeechRecognitionErrorEvent {
+	return SpeechRecognitionErrorEventFromJS(input.JSValue())
 }
 
 func NewSpeechRecognitionErrorEvent(_type string, eventInitDict *SpeechRecognitionErrorEventInit) (_result *SpeechRecognitionErrorEvent) {
@@ -1171,15 +1184,19 @@ type SpeechRecognitionEvent struct {
 	domcore.Event
 }
 
-// SpeechRecognitionEventFromJS is casting a js.Wrapper into SpeechRecognitionEvent.
-func SpeechRecognitionEventFromJS(value js.Wrapper) *SpeechRecognitionEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionEventFromJS is casting a js.Value into SpeechRecognitionEvent.
+func SpeechRecognitionEventFromJS(value js.Value) *SpeechRecognitionEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionEventFromJS is casting from something that holds a js.Value into SpeechRecognitionEvent.
+func SpeechRecognitionEventFromWrapper(input core.Wrapper) *SpeechRecognitionEvent {
+	return SpeechRecognitionEventFromJS(input.JSValue())
 }
 
 func NewSpeechRecognitionEvent(_type string, eventInitDict *SpeechRecognitionEventInit) (_result *SpeechRecognitionEvent) {
@@ -1249,15 +1266,19 @@ func (_this *SpeechRecognitionResult) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionResultFromJS is casting a js.Wrapper into SpeechRecognitionResult.
-func SpeechRecognitionResultFromJS(value js.Wrapper) *SpeechRecognitionResult {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionResultFromJS is casting a js.Value into SpeechRecognitionResult.
+func SpeechRecognitionResultFromJS(value js.Value) *SpeechRecognitionResult {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionResult{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionResultFromJS is casting from something that holds a js.Value into SpeechRecognitionResult.
+func SpeechRecognitionResultFromWrapper(input core.Wrapper) *SpeechRecognitionResult {
+	return SpeechRecognitionResultFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1322,15 +1343,19 @@ func (_this *SpeechRecognitionResultList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechRecognitionResultListFromJS is casting a js.Wrapper into SpeechRecognitionResultList.
-func SpeechRecognitionResultListFromJS(value js.Wrapper) *SpeechRecognitionResultList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechRecognitionResultListFromJS is casting a js.Value into SpeechRecognitionResultList.
+func SpeechRecognitionResultListFromJS(value js.Value) *SpeechRecognitionResultList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechRecognitionResultList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechRecognitionResultListFromJS is casting from something that holds a js.Value into SpeechRecognitionResultList.
+func SpeechRecognitionResultListFromWrapper(input core.Wrapper) *SpeechRecognitionResultList {
+	return SpeechRecognitionResultListFromJS(input.JSValue())
 }
 
 // Length returning attribute 'length' with
@@ -1381,15 +1406,19 @@ type SpeechSynthesis struct {
 	domcore.EventTarget
 }
 
-// SpeechSynthesisFromJS is casting a js.Wrapper into SpeechSynthesis.
-func SpeechSynthesisFromJS(value js.Wrapper) *SpeechSynthesis {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisFromJS is casting a js.Value into SpeechSynthesis.
+func SpeechSynthesisFromJS(value js.Value) *SpeechSynthesis {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesis{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisFromJS is casting from something that holds a js.Value into SpeechSynthesis.
+func SpeechSynthesisFromWrapper(input core.Wrapper) *SpeechSynthesis {
+	return SpeechSynthesisFromJS(input.JSValue())
 }
 
 // Pending returning attribute 'pending' with
@@ -1526,15 +1555,19 @@ type SpeechSynthesisErrorEvent struct {
 	SpeechSynthesisEvent
 }
 
-// SpeechSynthesisErrorEventFromJS is casting a js.Wrapper into SpeechSynthesisErrorEvent.
-func SpeechSynthesisErrorEventFromJS(value js.Wrapper) *SpeechSynthesisErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisErrorEventFromJS is casting a js.Value into SpeechSynthesisErrorEvent.
+func SpeechSynthesisErrorEventFromJS(value js.Value) *SpeechSynthesisErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisErrorEventFromJS is casting from something that holds a js.Value into SpeechSynthesisErrorEvent.
+func SpeechSynthesisErrorEventFromWrapper(input core.Wrapper) *SpeechSynthesisErrorEvent {
+	return SpeechSynthesisErrorEventFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisErrorEvent(_type string, eventInitDict *SpeechSynthesisErrorEventInit) (_result *SpeechSynthesisErrorEvent) {
@@ -1572,15 +1605,19 @@ type SpeechSynthesisEvent struct {
 	domcore.Event
 }
 
-// SpeechSynthesisEventFromJS is casting a js.Wrapper into SpeechSynthesisEvent.
-func SpeechSynthesisEventFromJS(value js.Wrapper) *SpeechSynthesisEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisEventFromJS is casting a js.Value into SpeechSynthesisEvent.
+func SpeechSynthesisEventFromJS(value js.Value) *SpeechSynthesisEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisEventFromJS is casting from something that holds a js.Value into SpeechSynthesisEvent.
+func SpeechSynthesisEventFromWrapper(input core.Wrapper) *SpeechSynthesisEvent {
+	return SpeechSynthesisEventFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisEvent(_type string, eventInitDict *SpeechSynthesisEventInit) (_result *SpeechSynthesisEvent) {
@@ -1645,15 +1682,19 @@ type SpeechSynthesisUtterance struct {
 	domcore.EventTarget
 }
 
-// SpeechSynthesisUtteranceFromJS is casting a js.Wrapper into SpeechSynthesisUtterance.
-func SpeechSynthesisUtteranceFromJS(value js.Wrapper) *SpeechSynthesisUtterance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisUtteranceFromJS is casting a js.Value into SpeechSynthesisUtterance.
+func SpeechSynthesisUtteranceFromJS(value js.Value) *SpeechSynthesisUtterance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisUtterance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisUtteranceFromJS is casting from something that holds a js.Value into SpeechSynthesisUtterance.
+func SpeechSynthesisUtteranceFromWrapper(input core.Wrapper) *SpeechSynthesisUtterance {
+	return SpeechSynthesisUtteranceFromJS(input.JSValue())
 }
 
 func NewSpeechSynthesisUtterance(text *string) (_result *SpeechSynthesisUtterance) {
@@ -2007,15 +2048,19 @@ func (_this *SpeechSynthesisVoice) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SpeechSynthesisVoiceFromJS is casting a js.Wrapper into SpeechSynthesisVoice.
-func SpeechSynthesisVoiceFromJS(value js.Wrapper) *SpeechSynthesisVoice {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SpeechSynthesisVoiceFromJS is casting a js.Value into SpeechSynthesisVoice.
+func SpeechSynthesisVoiceFromJS(value js.Value) *SpeechSynthesisVoice {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SpeechSynthesisVoice{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SpeechSynthesisVoiceFromJS is casting from something that holds a js.Value into SpeechSynthesisVoice.
+func SpeechSynthesisVoiceFromWrapper(input core.Wrapper) *SpeechSynthesisVoice {
+	return SpeechSynthesisVoiceFromJS(input.JSValue())
 }
 
 // VoiceURI returning attribute 'voiceURI' with

--- a/media/stream/recording/recording.go
+++ b/media/stream/recording/recording.go
@@ -7,6 +7,7 @@ package recording
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/media/capture/local"
@@ -92,7 +93,7 @@ type BlobEventInit struct {
 	Timecode float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BlobEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -104,18 +105,16 @@ func (_this *BlobEventInit) JSValue() js.Value {
 }
 
 // BlobEventInitFromJS is allocating a new
-// BlobEventInit object and copy all values from
-// input javascript object
-func BlobEventInitFromJS(value js.Wrapper) *BlobEventInit {
-	input := value.JSValue()
+// BlobEventInit object and copy all values in the value javascript object.
+func BlobEventInitFromJS(value js.Value) *BlobEventInit {
 	var out BlobEventInit
 	var (
 		value0 *file.Blob // javascript: Blob {data Data data}
 		value1 float64    // javascript: double {timecode Timecode timecode}
 	)
-	value0 = file.BlobFromJS(input.Get("data"))
+	value0 = file.BlobFromJS(value.Get("data"))
 	out.Data = value0
-	value1 = (input.Get("timecode")).Float()
+	value1 = (value.Get("timecode")).Float()
 	out.Timecode = value1
 	return &out
 }
@@ -128,7 +127,7 @@ type MediaRecorderErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaRecorderErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -144,10 +143,8 @@ func (_this *MediaRecorderErrorEventInit) JSValue() js.Value {
 }
 
 // MediaRecorderErrorEventInitFromJS is allocating a new
-// MediaRecorderErrorEventInit object and copy all values from
-// input javascript object
-func MediaRecorderErrorEventInitFromJS(value js.Wrapper) *MediaRecorderErrorEventInit {
-	input := value.JSValue()
+// MediaRecorderErrorEventInit object and copy all values in the value javascript object.
+func MediaRecorderErrorEventInitFromJS(value js.Value) *MediaRecorderErrorEventInit {
 	var out MediaRecorderErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -155,13 +152,13 @@ func MediaRecorderErrorEventInitFromJS(value js.Wrapper) *MediaRecorderErrorEven
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -174,7 +171,7 @@ type MediaRecorderOptions struct {
 	BitsPerSecond      uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaRecorderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -190,10 +187,8 @@ func (_this *MediaRecorderOptions) JSValue() js.Value {
 }
 
 // MediaRecorderOptionsFromJS is allocating a new
-// MediaRecorderOptions object and copy all values from
-// input javascript object
-func MediaRecorderOptionsFromJS(value js.Wrapper) *MediaRecorderOptions {
-	input := value.JSValue()
+// MediaRecorderOptions object and copy all values in the value javascript object.
+func MediaRecorderOptionsFromJS(value js.Value) *MediaRecorderOptions {
 	var out MediaRecorderOptions
 	var (
 		value0 string // javascript: DOMString {mimeType MimeType mimeType}
@@ -201,13 +196,13 @@ func MediaRecorderOptionsFromJS(value js.Wrapper) *MediaRecorderOptions {
 		value2 uint   // javascript: unsigned long {videoBitsPerSecond VideoBitsPerSecond videoBitsPerSecond}
 		value3 uint   // javascript: unsigned long {bitsPerSecond BitsPerSecond bitsPerSecond}
 	)
-	value0 = (input.Get("mimeType")).String()
+	value0 = (value.Get("mimeType")).String()
 	out.MimeType = value0
-	value1 = (uint)((input.Get("audioBitsPerSecond")).Int())
+	value1 = (uint)((value.Get("audioBitsPerSecond")).Int())
 	out.AudioBitsPerSecond = value1
-	value2 = (uint)((input.Get("videoBitsPerSecond")).Int())
+	value2 = (uint)((value.Get("videoBitsPerSecond")).Int())
 	out.VideoBitsPerSecond = value2
-	value3 = (uint)((input.Get("bitsPerSecond")).Int())
+	value3 = (uint)((value.Get("bitsPerSecond")).Int())
 	out.BitsPerSecond = value3
 	return &out
 }
@@ -217,15 +212,19 @@ type BlobEvent struct {
 	domcore.Event
 }
 
-// BlobEventFromJS is casting a js.Wrapper into BlobEvent.
-func BlobEventFromJS(value js.Wrapper) *BlobEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BlobEventFromJS is casting a js.Value into BlobEvent.
+func BlobEventFromJS(value js.Value) *BlobEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BlobEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BlobEventFromJS is casting from something that holds a js.Value into BlobEvent.
+func BlobEventFromWrapper(input core.Wrapper) *BlobEvent {
+	return BlobEventFromJS(input.JSValue())
 }
 
 func NewBlobEvent(_type string, eventInitDict *BlobEventInit) (_result *BlobEvent) {
@@ -272,15 +271,19 @@ type MediaRecorder struct {
 	domcore.EventTarget
 }
 
-// MediaRecorderFromJS is casting a js.Wrapper into MediaRecorder.
-func MediaRecorderFromJS(value js.Wrapper) *MediaRecorder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaRecorderFromJS is casting a js.Value into MediaRecorder.
+func MediaRecorderFromJS(value js.Value) *MediaRecorder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaRecorder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaRecorderFromJS is casting from something that holds a js.Value into MediaRecorder.
+func MediaRecorderFromWrapper(input core.Wrapper) *MediaRecorder {
+	return MediaRecorderFromJS(input.JSValue())
 }
 
 func IsTypeSupported(_type string) (_result bool) {
@@ -635,15 +638,19 @@ type MediaRecorderErrorEvent struct {
 	domcore.Event
 }
 
-// MediaRecorderErrorEventFromJS is casting a js.Wrapper into MediaRecorderErrorEvent.
-func MediaRecorderErrorEventFromJS(value js.Wrapper) *MediaRecorderErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaRecorderErrorEventFromJS is casting a js.Value into MediaRecorderErrorEvent.
+func MediaRecorderErrorEventFromJS(value js.Value) *MediaRecorderErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaRecorderErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaRecorderErrorEventFromJS is casting from something that holds a js.Value into MediaRecorderErrorEvent.
+func MediaRecorderErrorEventFromWrapper(input core.Wrapper) *MediaRecorderErrorEvent {
+	return MediaRecorderErrorEventFromJS(input.JSValue())
 }
 
 func NewMediaRecorderErrorEvent(_type string, eventInitDict *MediaRecorderErrorEventInit) (_result *MediaRecorderErrorEvent) {

--- a/media/stream/recording/recording_js.go
+++ b/media/stream/recording/recording_js.go
@@ -5,6 +5,7 @@ package recording
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/media/capture/local"
@@ -90,7 +91,7 @@ type BlobEventInit struct {
 	Timecode float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BlobEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -102,18 +103,16 @@ func (_this *BlobEventInit) JSValue() js.Value {
 }
 
 // BlobEventInitFromJS is allocating a new
-// BlobEventInit object and copy all values from
-// input javascript object
-func BlobEventInitFromJS(value js.Wrapper) *BlobEventInit {
-	input := value.JSValue()
+// BlobEventInit object and copy all values in the value javascript object.
+func BlobEventInitFromJS(value js.Value) *BlobEventInit {
 	var out BlobEventInit
 	var (
 		value0 *file.Blob // javascript: Blob {data Data data}
 		value1 float64    // javascript: double {timecode Timecode timecode}
 	)
-	value0 = file.BlobFromJS(input.Get("data"))
+	value0 = file.BlobFromJS(value.Get("data"))
 	out.Data = value0
-	value1 = (input.Get("timecode")).Float()
+	value1 = (value.Get("timecode")).Float()
 	out.Timecode = value1
 	return &out
 }
@@ -126,7 +125,7 @@ type MediaRecorderErrorEventInit struct {
 	Error      *domcore.DOMException
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaRecorderErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -142,10 +141,8 @@ func (_this *MediaRecorderErrorEventInit) JSValue() js.Value {
 }
 
 // MediaRecorderErrorEventInitFromJS is allocating a new
-// MediaRecorderErrorEventInit object and copy all values from
-// input javascript object
-func MediaRecorderErrorEventInitFromJS(value js.Wrapper) *MediaRecorderErrorEventInit {
-	input := value.JSValue()
+// MediaRecorderErrorEventInit object and copy all values in the value javascript object.
+func MediaRecorderErrorEventInitFromJS(value js.Value) *MediaRecorderErrorEventInit {
 	var out MediaRecorderErrorEventInit
 	var (
 		value0 bool                  // javascript: boolean {bubbles Bubbles bubbles}
@@ -153,13 +150,13 @@ func MediaRecorderErrorEventInitFromJS(value js.Wrapper) *MediaRecorderErrorEven
 		value2 bool                  // javascript: boolean {composed Composed composed}
 		value3 *domcore.DOMException // javascript: DOMException {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = domcore.DOMExceptionFromJS(input.Get("error"))
+	value3 = domcore.DOMExceptionFromJS(value.Get("error"))
 	out.Error = value3
 	return &out
 }
@@ -172,7 +169,7 @@ type MediaRecorderOptions struct {
 	BitsPerSecond      uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaRecorderOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -188,10 +185,8 @@ func (_this *MediaRecorderOptions) JSValue() js.Value {
 }
 
 // MediaRecorderOptionsFromJS is allocating a new
-// MediaRecorderOptions object and copy all values from
-// input javascript object
-func MediaRecorderOptionsFromJS(value js.Wrapper) *MediaRecorderOptions {
-	input := value.JSValue()
+// MediaRecorderOptions object and copy all values in the value javascript object.
+func MediaRecorderOptionsFromJS(value js.Value) *MediaRecorderOptions {
 	var out MediaRecorderOptions
 	var (
 		value0 string // javascript: DOMString {mimeType MimeType mimeType}
@@ -199,13 +194,13 @@ func MediaRecorderOptionsFromJS(value js.Wrapper) *MediaRecorderOptions {
 		value2 uint   // javascript: unsigned long {videoBitsPerSecond VideoBitsPerSecond videoBitsPerSecond}
 		value3 uint   // javascript: unsigned long {bitsPerSecond BitsPerSecond bitsPerSecond}
 	)
-	value0 = (input.Get("mimeType")).String()
+	value0 = (value.Get("mimeType")).String()
 	out.MimeType = value0
-	value1 = (uint)((input.Get("audioBitsPerSecond")).Int())
+	value1 = (uint)((value.Get("audioBitsPerSecond")).Int())
 	out.AudioBitsPerSecond = value1
-	value2 = (uint)((input.Get("videoBitsPerSecond")).Int())
+	value2 = (uint)((value.Get("videoBitsPerSecond")).Int())
 	out.VideoBitsPerSecond = value2
-	value3 = (uint)((input.Get("bitsPerSecond")).Int())
+	value3 = (uint)((value.Get("bitsPerSecond")).Int())
 	out.BitsPerSecond = value3
 	return &out
 }
@@ -215,15 +210,19 @@ type BlobEvent struct {
 	domcore.Event
 }
 
-// BlobEventFromJS is casting a js.Wrapper into BlobEvent.
-func BlobEventFromJS(value js.Wrapper) *BlobEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BlobEventFromJS is casting a js.Value into BlobEvent.
+func BlobEventFromJS(value js.Value) *BlobEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BlobEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BlobEventFromJS is casting from something that holds a js.Value into BlobEvent.
+func BlobEventFromWrapper(input core.Wrapper) *BlobEvent {
+	return BlobEventFromJS(input.JSValue())
 }
 
 func NewBlobEvent(_type string, eventInitDict *BlobEventInit) (_result *BlobEvent) {
@@ -270,15 +269,19 @@ type MediaRecorder struct {
 	domcore.EventTarget
 }
 
-// MediaRecorderFromJS is casting a js.Wrapper into MediaRecorder.
-func MediaRecorderFromJS(value js.Wrapper) *MediaRecorder {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaRecorderFromJS is casting a js.Value into MediaRecorder.
+func MediaRecorderFromJS(value js.Value) *MediaRecorder {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaRecorder{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaRecorderFromJS is casting from something that holds a js.Value into MediaRecorder.
+func MediaRecorderFromWrapper(input core.Wrapper) *MediaRecorder {
+	return MediaRecorderFromJS(input.JSValue())
 }
 
 func IsTypeSupported(_type string) (_result bool) {
@@ -633,15 +636,19 @@ type MediaRecorderErrorEvent struct {
 	domcore.Event
 }
 
-// MediaRecorderErrorEventFromJS is casting a js.Wrapper into MediaRecorderErrorEvent.
-func MediaRecorderErrorEventFromJS(value js.Wrapper) *MediaRecorderErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MediaRecorderErrorEventFromJS is casting a js.Value into MediaRecorderErrorEvent.
+func MediaRecorderErrorEventFromJS(value js.Value) *MediaRecorderErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MediaRecorderErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MediaRecorderErrorEventFromJS is casting from something that holds a js.Value into MediaRecorderErrorEvent.
+func MediaRecorderErrorEventFromWrapper(input core.Wrapper) *MediaRecorderErrorEvent {
+	return MediaRecorderErrorEventFromJS(input.JSValue())
 }
 
 func NewMediaRecorderErrorEvent(_type string, eventInitDict *MediaRecorderErrorEventInit) (_result *MediaRecorderErrorEvent) {

--- a/media/webrtc/stats/stats.go
+++ b/media/webrtc/stats/stats.go
@@ -235,7 +235,7 @@ type AudioHandlerStats struct {
 	TotalSamplesDuration float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -267,10 +267,8 @@ func (_this *AudioHandlerStats) JSValue() js.Value {
 }
 
 // AudioHandlerStatsFromJS is allocating a new
-// AudioHandlerStats object and copy all values from
-// input javascript object
-func AudioHandlerStatsFromJS(value js.Wrapper) *AudioHandlerStats {
-	input := value.JSValue()
+// AudioHandlerStats object and copy all values in the value javascript object.
+func AudioHandlerStatsFromJS(value js.Value) *AudioHandlerStats {
 	var out AudioHandlerStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -286,29 +284,29 @@ func AudioHandlerStatsFromJS(value js.Wrapper) *AudioHandlerStats {
 		value10 bool                // javascript: boolean {voiceActivityFlag VoiceActivityFlag voiceActivityFlag}
 		value11 float64             // javascript: double {totalSamplesDuration TotalSamplesDuration totalSamplesDuration}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
 	return &out
 }
@@ -335,7 +333,7 @@ type AudioReceiverStats struct {
 	ConcealmentEvents         int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioReceiverStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -379,10 +377,8 @@ func (_this *AudioReceiverStats) JSValue() js.Value {
 }
 
 // AudioReceiverStatsFromJS is allocating a new
-// AudioReceiverStats object and copy all values from
-// input javascript object
-func AudioReceiverStatsFromJS(value js.Wrapper) *AudioReceiverStats {
-	input := value.JSValue()
+// AudioReceiverStats object and copy all values in the value javascript object.
+func AudioReceiverStatsFromJS(value js.Value) *AudioReceiverStats {
 	var out AudioReceiverStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -404,41 +400,41 @@ func AudioReceiverStatsFromJS(value js.Wrapper) *AudioReceiverStats {
 		value16 int                 // javascript: unsigned long long {concealedSamples ConcealedSamples concealedSamples}
 		value17 int                 // javascript: unsigned long long {concealmentEvents ConcealmentEvents concealmentEvents}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("estimatedPlayoutTimestamp")).Float()
+	value12 = (value.Get("estimatedPlayoutTimestamp")).Float()
 	out.EstimatedPlayoutTimestamp = value12
-	value13 = (input.Get("jitterBufferDelay")).Float()
+	value13 = (value.Get("jitterBufferDelay")).Float()
 	out.JitterBufferDelay = value13
-	value14 = (input.Get("jitterBufferEmittedCount")).Int()
+	value14 = (value.Get("jitterBufferEmittedCount")).Int()
 	out.JitterBufferEmittedCount = value14
-	value15 = (input.Get("totalSamplesReceived")).Int()
+	value15 = (value.Get("totalSamplesReceived")).Int()
 	out.TotalSamplesReceived = value15
-	value16 = (input.Get("concealedSamples")).Int()
+	value16 = (value.Get("concealedSamples")).Int()
 	out.ConcealedSamples = value16
-	value17 = (input.Get("concealmentEvents")).Int()
+	value17 = (value.Get("concealmentEvents")).Int()
 	out.ConcealmentEvents = value17
 	return &out
 }
@@ -462,7 +458,7 @@ type AudioSenderStats struct {
 	TotalSamplesSent          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioSenderStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -500,10 +496,8 @@ func (_this *AudioSenderStats) JSValue() js.Value {
 }
 
 // AudioSenderStatsFromJS is allocating a new
-// AudioSenderStats object and copy all values from
-// input javascript object
-func AudioSenderStatsFromJS(value js.Wrapper) *AudioSenderStats {
-	input := value.JSValue()
+// AudioSenderStats object and copy all values in the value javascript object.
+func AudioSenderStatsFromJS(value js.Value) *AudioSenderStats {
 	var out AudioSenderStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -522,35 +516,35 @@ func AudioSenderStatsFromJS(value js.Wrapper) *AudioSenderStats {
 		value13 float64             // javascript: double {echoReturnLossEnhancement EchoReturnLossEnhancement echoReturnLossEnhancement}
 		value14 int                 // javascript: unsigned long long {totalSamplesSent TotalSamplesSent totalSamplesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("echoReturnLoss")).Float()
+	value12 = (value.Get("echoReturnLoss")).Float()
 	out.EchoReturnLoss = value12
-	value13 = (input.Get("echoReturnLossEnhancement")).Float()
+	value13 = (value.Get("echoReturnLossEnhancement")).Float()
 	out.EchoReturnLossEnhancement = value13
-	value14 = (input.Get("totalSamplesSent")).Int()
+	value14 = (value.Get("totalSamplesSent")).Int()
 	out.TotalSamplesSent = value14
 	return &out
 }
@@ -566,7 +560,7 @@ type CertificateStats struct {
 	IssuerCertificateId  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CertificateStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -588,10 +582,8 @@ func (_this *CertificateStats) JSValue() js.Value {
 }
 
 // CertificateStatsFromJS is allocating a new
-// CertificateStats object and copy all values from
-// input javascript object
-func CertificateStatsFromJS(value js.Wrapper) *CertificateStats {
-	input := value.JSValue()
+// CertificateStats object and copy all values in the value javascript object.
+func CertificateStatsFromJS(value js.Value) *CertificateStats {
 	var out CertificateStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -602,19 +594,19 @@ func CertificateStatsFromJS(value js.Wrapper) *CertificateStats {
 		value5 string           // javascript: DOMString {base64Certificate Base64Certificate base64Certificate}
 		value6 string           // javascript: DOMString {issuerCertificateId IssuerCertificateId issuerCertificateId}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("fingerprint")).String()
+	value3 = (value.Get("fingerprint")).String()
 	out.Fingerprint = value3
-	value4 = (input.Get("fingerprintAlgorithm")).String()
+	value4 = (value.Get("fingerprintAlgorithm")).String()
 	out.FingerprintAlgorithm = value4
-	value5 = (input.Get("base64Certificate")).String()
+	value5 = (value.Get("base64Certificate")).String()
 	out.Base64Certificate = value5
-	value6 = (input.Get("issuerCertificateId")).String()
+	value6 = (value.Get("issuerCertificateId")).String()
 	out.IssuerCertificateId = value6
 	return &out
 }
@@ -634,7 +626,7 @@ type CodecStats struct {
 	Implementation string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CodecStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -664,10 +656,8 @@ func (_this *CodecStats) JSValue() js.Value {
 }
 
 // CodecStatsFromJS is allocating a new
-// CodecStats object and copy all values from
-// input javascript object
-func CodecStatsFromJS(value js.Wrapper) *CodecStats {
-	input := value.JSValue()
+// CodecStats object and copy all values in the value javascript object.
+func CodecStatsFromJS(value js.Value) *CodecStats {
 	var out CodecStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -682,27 +672,27 @@ func CodecStatsFromJS(value js.Wrapper) *CodecStats {
 		value9  string           // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 		value10 string           // javascript: DOMString {implementation Implementation implementation}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("payloadType")).Int())
+	value3 = (uint)((value.Get("payloadType")).Int())
 	out.PayloadType = value3
-	value4 = CodecTypeFromJS(input.Get("codecType"))
+	value4 = CodecTypeFromJS(value.Get("codecType"))
 	out.CodecType = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("mimeType")).String()
+	value6 = (value.Get("mimeType")).String()
 	out.MimeType = value6
-	value7 = (uint)((input.Get("clockRate")).Int())
+	value7 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value7
-	value8 = (uint)((input.Get("channels")).Int())
+	value8 = (uint)((value.Get("channels")).Int())
 	out.Channels = value8
-	value9 = (input.Get("sdpFmtpLine")).String()
+	value9 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value9
-	value10 = (input.Get("implementation")).String()
+	value10 = (value.Get("implementation")).String()
 	out.Implementation = value10
 	return &out
 }
@@ -723,7 +713,7 @@ type DataChannelStats struct {
 	BytesReceived         int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -755,10 +745,8 @@ func (_this *DataChannelStats) JSValue() js.Value {
 }
 
 // DataChannelStatsFromJS is allocating a new
-// DataChannelStats object and copy all values from
-// input javascript object
-func DataChannelStatsFromJS(value js.Wrapper) *DataChannelStats {
-	input := value.JSValue()
+// DataChannelStats object and copy all values in the value javascript object.
+func DataChannelStatsFromJS(value js.Value) *DataChannelStats {
 	var out DataChannelStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -774,29 +762,29 @@ func DataChannelStatsFromJS(value js.Wrapper) *DataChannelStats {
 		value10 uint                    // javascript: unsigned long {messagesReceived MessagesReceived messagesReceived}
 		value11 int                     // javascript: unsigned long long {bytesReceived BytesReceived bytesReceived}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("label")).String()
+	value3 = (value.Get("label")).String()
 	out.Label = value3
-	value4 = (input.Get("protocol")).String()
+	value4 = (value.Get("protocol")).String()
 	out.Protocol = value4
-	value5 = (input.Get("dataChannelIdentifier")).Int()
+	value5 = (value.Get("dataChannelIdentifier")).Int()
 	out.DataChannelIdentifier = value5
-	value6 = (input.Get("transportId")).String()
+	value6 = (value.Get("transportId")).String()
 	out.TransportId = value6
-	value7 = webrtc.DataChannelStateFromJS(input.Get("state"))
+	value7 = webrtc.DataChannelStateFromJS(value.Get("state"))
 	out.State = value7
-	value8 = (uint)((input.Get("messagesSent")).Int())
+	value8 = (uint)((value.Get("messagesSent")).Int())
 	out.MessagesSent = value8
-	value9 = (input.Get("bytesSent")).Int()
+	value9 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value9
-	value10 = (uint)((input.Get("messagesReceived")).Int())
+	value10 = (uint)((value.Get("messagesReceived")).Int())
 	out.MessagesReceived = value10
-	value11 = (input.Get("bytesReceived")).Int()
+	value11 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value11
 	return &out
 }
@@ -838,7 +826,7 @@ type IceCandidatePairStats struct {
 	Priority                    int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidatePairStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -912,10 +900,8 @@ func (_this *IceCandidatePairStats) JSValue() js.Value {
 }
 
 // IceCandidatePairStatsFromJS is allocating a new
-// IceCandidatePairStats object and copy all values from
-// input javascript object
-func IceCandidatePairStatsFromJS(value js.Wrapper) *IceCandidatePairStats {
-	input := value.JSValue()
+// IceCandidatePairStats object and copy all values in the value javascript object.
+func IceCandidatePairStatsFromJS(value js.Value) *IceCandidatePairStats {
 	var out IceCandidatePairStats
 	var (
 		value0  float64                    // javascript: double {timestamp Timestamp timestamp}
@@ -952,71 +938,71 @@ func IceCandidatePairStatsFromJS(value js.Wrapper) *IceCandidatePairStats {
 		value31 float64                    // javascript: double {currentRtt CurrentRtt currentRtt}
 		value32 int                        // javascript: unsigned long long {priority Priority priority}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("transportId")).String()
+	value3 = (value.Get("transportId")).String()
 	out.TransportId = value3
-	value4 = (input.Get("localCandidateId")).String()
+	value4 = (value.Get("localCandidateId")).String()
 	out.LocalCandidateId = value4
-	value5 = (input.Get("remoteCandidateId")).String()
+	value5 = (value.Get("remoteCandidateId")).String()
 	out.RemoteCandidateId = value5
-	value6 = StatsIceCandidatePairStateFromJS(input.Get("state"))
+	value6 = StatsIceCandidatePairStateFromJS(value.Get("state"))
 	out.State = value6
-	value7 = (input.Get("nominated")).Bool()
+	value7 = (value.Get("nominated")).Bool()
 	out.Nominated = value7
-	value8 = (uint)((input.Get("packetsSent")).Int())
+	value8 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value8
-	value9 = (uint)((input.Get("packetsReceived")).Int())
+	value9 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value9
-	value10 = (input.Get("bytesSent")).Int()
+	value10 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value10
-	value11 = (input.Get("bytesReceived")).Int()
+	value11 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value11
-	value12 = (input.Get("lastPacketSentTimestamp")).Float()
+	value12 = (value.Get("lastPacketSentTimestamp")).Float()
 	out.LastPacketSentTimestamp = value12
-	value13 = (input.Get("lastPacketReceivedTimestamp")).Float()
+	value13 = (value.Get("lastPacketReceivedTimestamp")).Float()
 	out.LastPacketReceivedTimestamp = value13
-	value14 = (input.Get("firstRequestTimestamp")).Float()
+	value14 = (value.Get("firstRequestTimestamp")).Float()
 	out.FirstRequestTimestamp = value14
-	value15 = (input.Get("lastRequestTimestamp")).Float()
+	value15 = (value.Get("lastRequestTimestamp")).Float()
 	out.LastRequestTimestamp = value15
-	value16 = (input.Get("lastResponseTimestamp")).Float()
+	value16 = (value.Get("lastResponseTimestamp")).Float()
 	out.LastResponseTimestamp = value16
-	value17 = (input.Get("totalRoundTripTime")).Float()
+	value17 = (value.Get("totalRoundTripTime")).Float()
 	out.TotalRoundTripTime = value17
-	value18 = (input.Get("currentRoundTripTime")).Float()
+	value18 = (value.Get("currentRoundTripTime")).Float()
 	out.CurrentRoundTripTime = value18
-	value19 = (input.Get("availableOutgoingBitrate")).Float()
+	value19 = (value.Get("availableOutgoingBitrate")).Float()
 	out.AvailableOutgoingBitrate = value19
-	value20 = (input.Get("availableIncomingBitrate")).Float()
+	value20 = (value.Get("availableIncomingBitrate")).Float()
 	out.AvailableIncomingBitrate = value20
-	value21 = (uint)((input.Get("circuitBreakerTriggerCount")).Int())
+	value21 = (uint)((value.Get("circuitBreakerTriggerCount")).Int())
 	out.CircuitBreakerTriggerCount = value21
-	value22 = (input.Get("requestsReceived")).Int()
+	value22 = (value.Get("requestsReceived")).Int()
 	out.RequestsReceived = value22
-	value23 = (input.Get("requestsSent")).Int()
+	value23 = (value.Get("requestsSent")).Int()
 	out.RequestsSent = value23
-	value24 = (input.Get("responsesReceived")).Int()
+	value24 = (value.Get("responsesReceived")).Int()
 	out.ResponsesReceived = value24
-	value25 = (input.Get("responsesSent")).Int()
+	value25 = (value.Get("responsesSent")).Int()
 	out.ResponsesSent = value25
-	value26 = (input.Get("retransmissionsReceived")).Int()
+	value26 = (value.Get("retransmissionsReceived")).Int()
 	out.RetransmissionsReceived = value26
-	value27 = (input.Get("retransmissionsSent")).Int()
+	value27 = (value.Get("retransmissionsSent")).Int()
 	out.RetransmissionsSent = value27
-	value28 = (input.Get("consentRequestsSent")).Int()
+	value28 = (value.Get("consentRequestsSent")).Int()
 	out.ConsentRequestsSent = value28
-	value29 = (input.Get("consentExpiredTimestamp")).Float()
+	value29 = (value.Get("consentExpiredTimestamp")).Float()
 	out.ConsentExpiredTimestamp = value29
-	value30 = (input.Get("totalRtt")).Float()
+	value30 = (value.Get("totalRtt")).Float()
 	out.TotalRtt = value30
-	value31 = (input.Get("currentRtt")).Float()
+	value31 = (value.Get("currentRtt")).Float()
 	out.CurrentRtt = value31
-	value32 = (input.Get("priority")).Int()
+	value32 = (value.Get("priority")).Int()
 	out.Priority = value32
 	return &out
 }
@@ -1039,7 +1025,7 @@ type IceCandidateStats struct {
 	IsRemote      bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidateStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1081,10 +1067,8 @@ func (_this *IceCandidateStats) JSValue() js.Value {
 }
 
 // IceCandidateStatsFromJS is allocating a new
-// IceCandidateStats object and copy all values from
-// input javascript object
-func IceCandidateStatsFromJS(value js.Wrapper) *IceCandidateStats {
-	input := value.JSValue()
+// IceCandidateStats object and copy all values in the value javascript object.
+func IceCandidateStatsFromJS(value js.Value) *IceCandidateStats {
 	var out IceCandidateStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -1102,36 +1086,36 @@ func IceCandidateStatsFromJS(value js.Wrapper) *IceCandidateStats {
 		value12 bool                    // javascript: boolean {deleted Deleted deleted}
 		value13 bool                    // javascript: boolean {isRemote IsRemote isRemote}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("transportId")).String()
+	value3 = (value.Get("transportId")).String()
 	out.TransportId = value3
-	value4 = NetworkTypeFromJS(input.Get("networkType"))
+	value4 = NetworkTypeFromJS(value.Get("networkType"))
 	out.NetworkType = value4
-	if input.Get("address").Type() != js.TypeNull && input.Get("address").Type() != js.TypeUndefined {
-		__tmp := (input.Get("address")).String()
+	if value.Get("address").Type() != js.TypeNull && value.Get("address").Type() != js.TypeUndefined {
+		__tmp := (value.Get("address")).String()
 		value5 = &__tmp
 	}
 	out.Address = value5
-	value6 = (input.Get("port")).Int()
+	value6 = (value.Get("port")).Int()
 	out.Port = value6
-	value7 = (input.Get("protocol")).String()
+	value7 = (value.Get("protocol")).String()
 	out.Protocol = value7
-	value8 = webrtc.IceCandidateTypeFromJS(input.Get("candidateType"))
+	value8 = webrtc.IceCandidateTypeFromJS(value.Get("candidateType"))
 	out.CandidateType = value8
-	value9 = (input.Get("priority")).Int()
+	value9 = (value.Get("priority")).Int()
 	out.Priority = value9
-	value10 = (input.Get("url")).String()
+	value10 = (value.Get("url")).String()
 	out.Url = value10
-	value11 = (input.Get("relayProtocol")).String()
+	value11 = (value.Get("relayProtocol")).String()
 	out.RelayProtocol = value11
-	value12 = (input.Get("deleted")).Bool()
+	value12 = (value.Get("deleted")).Bool()
 	out.Deleted = value12
-	value13 = (input.Get("isRemote")).Bool()
+	value13 = (value.Get("isRemote")).Bool()
 	out.IsRemote = value13
 	return &out
 }
@@ -1177,7 +1161,7 @@ type InboundRtpStreamStats struct {
 	PacketsDuplicated           uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1259,10 +1243,8 @@ func (_this *InboundRtpStreamStats) JSValue() js.Value {
 }
 
 // InboundRtpStreamStatsFromJS is allocating a new
-// InboundRtpStreamStats object and copy all values from
-// input javascript object
-func InboundRtpStreamStatsFromJS(value js.Wrapper) *InboundRtpStreamStats {
-	input := value.JSValue()
+// InboundRtpStreamStats object and copy all values in the value javascript object.
+func InboundRtpStreamStatsFromJS(value js.Value) *InboundRtpStreamStats {
 	var out InboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1303,79 +1285,79 @@ func InboundRtpStreamStatsFromJS(value js.Wrapper) *InboundRtpStreamStats {
 		value35 uint             // javascript: unsigned long {packetsFailedDecryption PacketsFailedDecryption packetsFailedDecryption}
 		value36 uint             // javascript: unsigned long {packetsDuplicated PacketsDuplicated packetsDuplicated}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
-	value27 = (input.Get("trackId")).String()
+	value27 = (value.Get("trackId")).String()
 	out.TrackId = value27
-	value28 = (input.Get("receiverId")).String()
+	value28 = (value.Get("receiverId")).String()
 	out.ReceiverId = value28
-	value29 = (input.Get("remoteId")).String()
+	value29 = (value.Get("remoteId")).String()
 	out.RemoteId = value29
-	value30 = (uint)((input.Get("framesDecoded")).Int())
+	value30 = (uint)((value.Get("framesDecoded")).Int())
 	out.FramesDecoded = value30
-	value31 = (input.Get("lastPacketReceivedTimestamp")).Float()
+	value31 = (value.Get("lastPacketReceivedTimestamp")).Float()
 	out.LastPacketReceivedTimestamp = value31
-	value32 = (input.Get("averageRtcpInterval")).Float()
+	value32 = (value.Get("averageRtcpInterval")).Float()
 	out.AverageRtcpInterval = value32
-	value33 = (uint)((input.Get("fecPacketsReceived")).Int())
+	value33 = (uint)((value.Get("fecPacketsReceived")).Int())
 	out.FecPacketsReceived = value33
-	value34 = (input.Get("bytesReceived")).Int()
+	value34 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value34
-	value35 = (uint)((input.Get("packetsFailedDecryption")).Int())
+	value35 = (uint)((value.Get("packetsFailedDecryption")).Int())
 	out.PacketsFailedDecryption = value35
-	value36 = (uint)((input.Get("packetsDuplicated")).Int())
+	value36 = (uint)((value.Get("packetsDuplicated")).Int())
 	out.PacketsDuplicated = value36
 	return &out
 }
@@ -1392,7 +1374,7 @@ type MediaHandlerStats struct {
 	Priority        webrtc.PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1416,10 +1398,8 @@ func (_this *MediaHandlerStats) JSValue() js.Value {
 }
 
 // MediaHandlerStatsFromJS is allocating a new
-// MediaHandlerStats object and copy all values from
-// input javascript object
-func MediaHandlerStatsFromJS(value js.Wrapper) *MediaHandlerStats {
-	input := value.JSValue()
+// MediaHandlerStats object and copy all values in the value javascript object.
+func MediaHandlerStatsFromJS(value js.Value) *MediaHandlerStats {
 	var out MediaHandlerStats
 	var (
 		value0 float64             // javascript: double {timestamp Timestamp timestamp}
@@ -1431,21 +1411,21 @@ func MediaHandlerStatsFromJS(value js.Wrapper) *MediaHandlerStats {
 		value6 string              // javascript: DOMString {kind Kind kind}
 		value7 webrtc.PriorityType // javascript: RTCPriorityType {priority Priority priority}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
 	return &out
 }
@@ -1459,7 +1439,7 @@ type MediaStreamStats struct {
 	TrackIds         []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1481,10 +1461,8 @@ func (_this *MediaStreamStats) JSValue() js.Value {
 }
 
 // MediaStreamStatsFromJS is allocating a new
-// MediaStreamStats object and copy all values from
-// input javascript object
-func MediaStreamStatsFromJS(value js.Wrapper) *MediaStreamStats {
-	input := value.JSValue()
+// MediaStreamStats object and copy all values in the value javascript object.
+func MediaStreamStatsFromJS(value js.Value) *MediaStreamStats {
 	var out MediaStreamStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1493,19 +1471,19 @@ func MediaStreamStatsFromJS(value js.Wrapper) *MediaStreamStats {
 		value3 string           // javascript: DOMString {streamIdentifier StreamIdentifier streamIdentifier}
 		value4 []string         // javascript: sequence<DOMString> {trackIds TrackIds trackIds}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("streamIdentifier")).String()
+	value3 = (value.Get("streamIdentifier")).String()
 	out.StreamIdentifier = value3
-	__length4 := input.Get("trackIds").Length()
+	__length4 := value.Get("trackIds").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("trackIds").Index(__idx4)
+		__seq_in4 := value.Get("trackIds").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
@@ -1546,7 +1524,7 @@ type OutboundRtpStreamStats struct {
 	QualityLimitationReason QualityLimitationReason
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1610,10 +1588,8 @@ func (_this *OutboundRtpStreamStats) JSValue() js.Value {
 }
 
 // OutboundRtpStreamStatsFromJS is allocating a new
-// OutboundRtpStreamStats object and copy all values from
-// input javascript object
-func OutboundRtpStreamStatsFromJS(value js.Wrapper) *OutboundRtpStreamStats {
-	input := value.JSValue()
+// OutboundRtpStreamStats object and copy all values in the value javascript object.
+func OutboundRtpStreamStatsFromJS(value js.Value) *OutboundRtpStreamStats {
 	var out OutboundRtpStreamStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -1645,61 +1621,61 @@ func OutboundRtpStreamStatsFromJS(value js.Wrapper) *OutboundRtpStreamStats {
 		value26 float64                 // javascript: double {averageRtcpInterval AverageRtcpInterval averageRtcpInterval}
 		value27 QualityLimitationReason // javascript: RTCQualityLimitationReason {qualityLimitationReason QualityLimitationReason qualityLimitationReason}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
-	value19 = (input.Get("trackId")).String()
+	value19 = (value.Get("trackId")).String()
 	out.TrackId = value19
-	value20 = (input.Get("senderId")).String()
+	value20 = (value.Get("senderId")).String()
 	out.SenderId = value20
-	value21 = (input.Get("remoteId")).String()
+	value21 = (value.Get("remoteId")).String()
 	out.RemoteId = value21
-	value22 = (input.Get("lastPacketSentTimestamp")).Float()
+	value22 = (value.Get("lastPacketSentTimestamp")).Float()
 	out.LastPacketSentTimestamp = value22
-	value23 = (input.Get("targetBitrate")).Float()
+	value23 = (value.Get("targetBitrate")).Float()
 	out.TargetBitrate = value23
-	value24 = (uint)((input.Get("framesEncoded")).Int())
+	value24 = (uint)((value.Get("framesEncoded")).Int())
 	out.FramesEncoded = value24
-	value25 = (input.Get("totalEncodeTime")).Float()
+	value25 = (value.Get("totalEncodeTime")).Float()
 	out.TotalEncodeTime = value25
-	value26 = (input.Get("averageRtcpInterval")).Float()
+	value26 = (value.Get("averageRtcpInterval")).Float()
 	out.AverageRtcpInterval = value26
-	value27 = QualityLimitationReasonFromJS(input.Get("qualityLimitationReason"))
+	value27 = QualityLimitationReasonFromJS(value.Get("qualityLimitationReason"))
 	out.QualityLimitationReason = value27
 	return &out
 }
@@ -1715,7 +1691,7 @@ type PeerConnectionStats struct {
 	DataChannelsAccepted  uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1737,10 +1713,8 @@ func (_this *PeerConnectionStats) JSValue() js.Value {
 }
 
 // PeerConnectionStatsFromJS is allocating a new
-// PeerConnectionStats object and copy all values from
-// input javascript object
-func PeerConnectionStatsFromJS(value js.Wrapper) *PeerConnectionStats {
-	input := value.JSValue()
+// PeerConnectionStats object and copy all values in the value javascript object.
+func PeerConnectionStatsFromJS(value js.Value) *PeerConnectionStats {
 	var out PeerConnectionStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1751,19 +1725,19 @@ func PeerConnectionStatsFromJS(value js.Wrapper) *PeerConnectionStats {
 		value5 uint             // javascript: unsigned long {dataChannelsRequested DataChannelsRequested dataChannelsRequested}
 		value6 uint             // javascript: unsigned long {dataChannelsAccepted DataChannelsAccepted dataChannelsAccepted}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("dataChannelsOpened")).Int())
+	value3 = (uint)((value.Get("dataChannelsOpened")).Int())
 	out.DataChannelsOpened = value3
-	value4 = (uint)((input.Get("dataChannelsClosed")).Int())
+	value4 = (uint)((value.Get("dataChannelsClosed")).Int())
 	out.DataChannelsClosed = value4
-	value5 = (uint)((input.Get("dataChannelsRequested")).Int())
+	value5 = (uint)((value.Get("dataChannelsRequested")).Int())
 	out.DataChannelsRequested = value5
-	value6 = (uint)((input.Get("dataChannelsAccepted")).Int())
+	value6 = (uint)((value.Get("dataChannelsAccepted")).Int())
 	out.DataChannelsAccepted = value6
 	return &out
 }
@@ -1799,7 +1773,7 @@ type ReceivedRtpStreamStats struct {
 	GapDiscardRate        float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReceivedRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1861,10 +1835,8 @@ func (_this *ReceivedRtpStreamStats) JSValue() js.Value {
 }
 
 // ReceivedRtpStreamStatsFromJS is allocating a new
-// ReceivedRtpStreamStats object and copy all values from
-// input javascript object
-func ReceivedRtpStreamStatsFromJS(value js.Wrapper) *ReceivedRtpStreamStats {
-	input := value.JSValue()
+// ReceivedRtpStreamStats object and copy all values in the value javascript object.
+func ReceivedRtpStreamStatsFromJS(value js.Value) *ReceivedRtpStreamStats {
 	var out ReceivedRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1895,59 +1867,59 @@ func ReceivedRtpStreamStatsFromJS(value js.Wrapper) *ReceivedRtpStreamStats {
 		value25 float64          // javascript: double {gapLossRate GapLossRate gapLossRate}
 		value26 float64          // javascript: double {gapDiscardRate GapDiscardRate gapDiscardRate}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
 	return &out
 }
@@ -1986,7 +1958,7 @@ type RemoteInboundRtpStreamStats struct {
 	FractionLost          float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RemoteInboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2054,10 +2026,8 @@ func (_this *RemoteInboundRtpStreamStats) JSValue() js.Value {
 }
 
 // RemoteInboundRtpStreamStatsFromJS is allocating a new
-// RemoteInboundRtpStreamStats object and copy all values from
-// input javascript object
-func RemoteInboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteInboundRtpStreamStats {
-	input := value.JSValue()
+// RemoteInboundRtpStreamStats object and copy all values in the value javascript object.
+func RemoteInboundRtpStreamStatsFromJS(value js.Value) *RemoteInboundRtpStreamStats {
 	var out RemoteInboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2091,65 +2061,65 @@ func RemoteInboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteInboundRtpStream
 		value28 float64          // javascript: double {roundTripTime RoundTripTime roundTripTime}
 		value29 float64          // javascript: double {fractionLost FractionLost fractionLost}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
-	value27 = (input.Get("localId")).String()
+	value27 = (value.Get("localId")).String()
 	out.LocalId = value27
-	value28 = (input.Get("roundTripTime")).Float()
+	value28 = (value.Get("roundTripTime")).Float()
 	out.RoundTripTime = value28
-	value29 = (input.Get("fractionLost")).Float()
+	value29 = (value.Get("fractionLost")).Float()
 	out.FractionLost = value29
 	return &out
 }
@@ -2179,7 +2149,7 @@ type RemoteOutboundRtpStreamStats struct {
 	RemoteTimestamp        float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RemoteOutboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2229,10 +2199,8 @@ func (_this *RemoteOutboundRtpStreamStats) JSValue() js.Value {
 }
 
 // RemoteOutboundRtpStreamStatsFromJS is allocating a new
-// RemoteOutboundRtpStreamStats object and copy all values from
-// input javascript object
-func RemoteOutboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteOutboundRtpStreamStats {
-	input := value.JSValue()
+// RemoteOutboundRtpStreamStats object and copy all values in the value javascript object.
+func RemoteOutboundRtpStreamStatsFromJS(value js.Value) *RemoteOutboundRtpStreamStats {
 	var out RemoteOutboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2257,47 +2225,47 @@ func RemoteOutboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteOutboundRtpStre
 		value19 string           // javascript: DOMString {localId LocalId localId}
 		value20 float64          // javascript: double {remoteTimestamp RemoteTimestamp remoteTimestamp}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
-	value19 = (input.Get("localId")).String()
+	value19 = (value.Get("localId")).String()
 	out.LocalId = value19
-	value20 = (input.Get("remoteTimestamp")).Float()
+	value20 = (value.Get("remoteTimestamp")).Float()
 	out.RemoteTimestamp = value20
 	return &out
 }
@@ -2313,7 +2281,7 @@ type RtpContributingSourceStats struct {
 	AudioLevel           float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpContributingSourceStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2335,10 +2303,8 @@ func (_this *RtpContributingSourceStats) JSValue() js.Value {
 }
 
 // RtpContributingSourceStatsFromJS is allocating a new
-// RtpContributingSourceStats object and copy all values from
-// input javascript object
-func RtpContributingSourceStatsFromJS(value js.Wrapper) *RtpContributingSourceStats {
-	input := value.JSValue()
+// RtpContributingSourceStats object and copy all values in the value javascript object.
+func RtpContributingSourceStatsFromJS(value js.Value) *RtpContributingSourceStats {
 	var out RtpContributingSourceStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2349,19 +2315,19 @@ func RtpContributingSourceStatsFromJS(value js.Wrapper) *RtpContributingSourceSt
 		value5 uint             // javascript: unsigned long {packetsContributedTo PacketsContributedTo packetsContributedTo}
 		value6 float64          // javascript: double {audioLevel AudioLevel audioLevel}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("contributorSsrc")).Int())
+	value3 = (uint)((value.Get("contributorSsrc")).Int())
 	out.ContributorSsrc = value3
-	value4 = (input.Get("inboundRtpStreamId")).String()
+	value4 = (value.Get("inboundRtpStreamId")).String()
 	out.InboundRtpStreamId = value4
-	value5 = (uint)((input.Get("packetsContributedTo")).Int())
+	value5 = (uint)((value.Get("packetsContributedTo")).Int())
 	out.PacketsContributedTo = value5
-	value6 = (input.Get("audioLevel")).Float()
+	value6 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value6
 	return &out
 }
@@ -2384,7 +2350,7 @@ type RtpStreamStats struct {
 	AverageRTCPInterval float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2420,10 +2386,8 @@ func (_this *RtpStreamStats) JSValue() js.Value {
 }
 
 // RtpStreamStatsFromJS is allocating a new
-// RtpStreamStats object and copy all values from
-// input javascript object
-func RtpStreamStatsFromJS(value js.Wrapper) *RtpStreamStats {
-	input := value.JSValue()
+// RtpStreamStats object and copy all values in the value javascript object.
+func RtpStreamStatsFromJS(value js.Value) *RtpStreamStats {
 	var out RtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2441,33 +2405,33 @@ func RtpStreamStatsFromJS(value js.Wrapper) *RtpStreamStats {
 		value12 string           // javascript: DOMString {mediaType MediaType mediaType}
 		value13 float64          // javascript: double {averageRTCPInterval AverageRTCPInterval averageRTCPInterval}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
 	return &out
 }
@@ -2491,7 +2455,7 @@ type SenderAudioTrackAttachmentStats struct {
 	TotalSamplesSent          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SenderAudioTrackAttachmentStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2529,10 +2493,8 @@ func (_this *SenderAudioTrackAttachmentStats) JSValue() js.Value {
 }
 
 // SenderAudioTrackAttachmentStatsFromJS is allocating a new
-// SenderAudioTrackAttachmentStats object and copy all values from
-// input javascript object
-func SenderAudioTrackAttachmentStatsFromJS(value js.Wrapper) *SenderAudioTrackAttachmentStats {
-	input := value.JSValue()
+// SenderAudioTrackAttachmentStats object and copy all values in the value javascript object.
+func SenderAudioTrackAttachmentStatsFromJS(value js.Value) *SenderAudioTrackAttachmentStats {
 	var out SenderAudioTrackAttachmentStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -2551,35 +2513,35 @@ func SenderAudioTrackAttachmentStatsFromJS(value js.Wrapper) *SenderAudioTrackAt
 		value13 float64             // javascript: double {echoReturnLossEnhancement EchoReturnLossEnhancement echoReturnLossEnhancement}
 		value14 int                 // javascript: unsigned long long {totalSamplesSent TotalSamplesSent totalSamplesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("echoReturnLoss")).Float()
+	value12 = (value.Get("echoReturnLoss")).Float()
 	out.EchoReturnLoss = value12
-	value13 = (input.Get("echoReturnLossEnhancement")).Float()
+	value13 = (value.Get("echoReturnLossEnhancement")).Float()
 	out.EchoReturnLossEnhancement = value13
-	value14 = (input.Get("totalSamplesSent")).Int()
+	value14 = (value.Get("totalSamplesSent")).Int()
 	out.TotalSamplesSent = value14
 	return &out
 }
@@ -2603,7 +2565,7 @@ type SenderVideoTrackAttachmentStats struct {
 	KeyFramesSent   uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SenderVideoTrackAttachmentStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2641,10 +2603,8 @@ func (_this *SenderVideoTrackAttachmentStats) JSValue() js.Value {
 }
 
 // SenderVideoTrackAttachmentStatsFromJS is allocating a new
-// SenderVideoTrackAttachmentStats object and copy all values from
-// input javascript object
-func SenderVideoTrackAttachmentStatsFromJS(value js.Wrapper) *SenderVideoTrackAttachmentStats {
-	input := value.JSValue()
+// SenderVideoTrackAttachmentStats object and copy all values in the value javascript object.
+func SenderVideoTrackAttachmentStatsFromJS(value js.Value) *SenderVideoTrackAttachmentStats {
 	var out SenderVideoTrackAttachmentStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -2663,35 +2623,35 @@ func SenderVideoTrackAttachmentStatsFromJS(value js.Wrapper) *SenderVideoTrackAt
 		value13 uint                // javascript: unsigned long {hugeFramesSent HugeFramesSent hugeFramesSent}
 		value14 uint                // javascript: unsigned long {keyFramesSent KeyFramesSent keyFramesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (uint)((input.Get("framesCaptured")).Int())
+	value11 = (uint)((value.Get("framesCaptured")).Int())
 	out.FramesCaptured = value11
-	value12 = (uint)((input.Get("framesSent")).Int())
+	value12 = (uint)((value.Get("framesSent")).Int())
 	out.FramesSent = value12
-	value13 = (uint)((input.Get("hugeFramesSent")).Int())
+	value13 = (uint)((value.Get("hugeFramesSent")).Int())
 	out.HugeFramesSent = value13
-	value14 = (uint)((input.Get("keyFramesSent")).Int())
+	value14 = (uint)((value.Get("keyFramesSent")).Int())
 	out.KeyFramesSent = value14
 	return &out
 }
@@ -2719,7 +2679,7 @@ type SentRtpStreamStats struct {
 	BytesDiscardedOnSend   int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SentRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2765,10 +2725,8 @@ func (_this *SentRtpStreamStats) JSValue() js.Value {
 }
 
 // SentRtpStreamStatsFromJS is allocating a new
-// SentRtpStreamStats object and copy all values from
-// input javascript object
-func SentRtpStreamStatsFromJS(value js.Wrapper) *SentRtpStreamStats {
-	input := value.JSValue()
+// SentRtpStreamStats object and copy all values in the value javascript object.
+func SentRtpStreamStatsFromJS(value js.Value) *SentRtpStreamStats {
 	var out SentRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2791,43 +2749,43 @@ func SentRtpStreamStatsFromJS(value js.Wrapper) *SentRtpStreamStats {
 		value17 int              // javascript: unsigned long long {bytesSent BytesSent bytesSent}
 		value18 int              // javascript: unsigned long long {bytesDiscardedOnSend BytesDiscardedOnSend bytesDiscardedOnSend}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
 	return &out
 }
@@ -2853,7 +2811,7 @@ type TransportStats struct {
 	TlsGroup                string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TransportStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2895,10 +2853,8 @@ func (_this *TransportStats) JSValue() js.Value {
 }
 
 // TransportStatsFromJS is allocating a new
-// TransportStats object and copy all values from
-// input javascript object
-func TransportStatsFromJS(value js.Wrapper) *TransportStats {
-	input := value.JSValue()
+// TransportStats object and copy all values in the value javascript object.
+func TransportStatsFromJS(value js.Value) *TransportStats {
 	var out TransportStats
 	var (
 		value0  float64                   // javascript: double {timestamp Timestamp timestamp}
@@ -2919,39 +2875,39 @@ func TransportStatsFromJS(value js.Wrapper) *TransportStats {
 		value15 string                    // javascript: DOMString {srtpCipher SrtpCipher srtpCipher}
 		value16 string                    // javascript: DOMString {tlsGroup TlsGroup tlsGroup}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("packetsSent")).Int())
+	value3 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value3
-	value4 = (uint)((input.Get("packetsReceived")).Int())
+	value4 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value4
-	value5 = (input.Get("bytesSent")).Int()
+	value5 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value5
-	value6 = (input.Get("bytesReceived")).Int()
+	value6 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value6
-	value7 = (input.Get("rtcpTransportStatsId")).String()
+	value7 = (value.Get("rtcpTransportStatsId")).String()
 	out.RtcpTransportStatsId = value7
-	value8 = webrtc.IceRoleFromJS(input.Get("iceRole"))
+	value8 = webrtc.IceRoleFromJS(value.Get("iceRole"))
 	out.IceRole = value8
-	value9 = webrtc.DtlsTransportStateFromJS(input.Get("dtlsState"))
+	value9 = webrtc.DtlsTransportStateFromJS(value.Get("dtlsState"))
 	out.DtlsState = value9
-	value10 = (input.Get("selectedCandidatePairId")).String()
+	value10 = (value.Get("selectedCandidatePairId")).String()
 	out.SelectedCandidatePairId = value10
-	value11 = (input.Get("localCertificateId")).String()
+	value11 = (value.Get("localCertificateId")).String()
 	out.LocalCertificateId = value11
-	value12 = (input.Get("remoteCertificateId")).String()
+	value12 = (value.Get("remoteCertificateId")).String()
 	out.RemoteCertificateId = value12
-	value13 = (input.Get("tlsVersion")).String()
+	value13 = (value.Get("tlsVersion")).String()
 	out.TlsVersion = value13
-	value14 = (input.Get("dtlsCipher")).String()
+	value14 = (value.Get("dtlsCipher")).String()
 	out.DtlsCipher = value14
-	value15 = (input.Get("srtpCipher")).String()
+	value15 = (value.Get("srtpCipher")).String()
 	out.SrtpCipher = value15
-	value16 = (input.Get("tlsGroup")).String()
+	value16 = (value.Get("tlsGroup")).String()
 	out.TlsGroup = value16
 	return &out
 }
@@ -2971,7 +2927,7 @@ type VideoHandlerStats struct {
 	FramesPerSecond float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3001,10 +2957,8 @@ func (_this *VideoHandlerStats) JSValue() js.Value {
 }
 
 // VideoHandlerStatsFromJS is allocating a new
-// VideoHandlerStats object and copy all values from
-// input javascript object
-func VideoHandlerStatsFromJS(value js.Wrapper) *VideoHandlerStats {
-	input := value.JSValue()
+// VideoHandlerStats object and copy all values in the value javascript object.
+func VideoHandlerStatsFromJS(value js.Value) *VideoHandlerStats {
 	var out VideoHandlerStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3019,27 +2973,27 @@ func VideoHandlerStatsFromJS(value js.Wrapper) *VideoHandlerStats {
 		value9  uint                // javascript: unsigned long {frameHeight FrameHeight frameHeight}
 		value10 float64             // javascript: double {framesPerSecond FramesPerSecond framesPerSecond}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
 	return &out
 }
@@ -3068,7 +3022,7 @@ type VideoReceiverStats struct {
 	FullFramesLost            uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoReceiverStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3116,10 +3070,8 @@ func (_this *VideoReceiverStats) JSValue() js.Value {
 }
 
 // VideoReceiverStatsFromJS is allocating a new
-// VideoReceiverStats object and copy all values from
-// input javascript object
-func VideoReceiverStatsFromJS(value js.Wrapper) *VideoReceiverStats {
-	input := value.JSValue()
+// VideoReceiverStats object and copy all values in the value javascript object.
+func VideoReceiverStatsFromJS(value js.Value) *VideoReceiverStats {
 	var out VideoReceiverStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3143,45 +3095,45 @@ func VideoReceiverStatsFromJS(value js.Wrapper) *VideoReceiverStats {
 		value18 uint                // javascript: unsigned long {partialFramesLost PartialFramesLost partialFramesLost}
 		value19 uint                // javascript: unsigned long {fullFramesLost FullFramesLost fullFramesLost}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (input.Get("estimatedPlayoutTimestamp")).Float()
+	value11 = (value.Get("estimatedPlayoutTimestamp")).Float()
 	out.EstimatedPlayoutTimestamp = value11
-	value12 = (input.Get("jitterBufferDelay")).Float()
+	value12 = (value.Get("jitterBufferDelay")).Float()
 	out.JitterBufferDelay = value12
-	value13 = (input.Get("jitterBufferEmittedCount")).Int()
+	value13 = (value.Get("jitterBufferEmittedCount")).Int()
 	out.JitterBufferEmittedCount = value13
-	value14 = (uint)((input.Get("framesReceived")).Int())
+	value14 = (uint)((value.Get("framesReceived")).Int())
 	out.FramesReceived = value14
-	value15 = (uint)((input.Get("keyFramesReceived")).Int())
+	value15 = (uint)((value.Get("keyFramesReceived")).Int())
 	out.KeyFramesReceived = value15
-	value16 = (uint)((input.Get("framesDecoded")).Int())
+	value16 = (uint)((value.Get("framesDecoded")).Int())
 	out.FramesDecoded = value16
-	value17 = (uint)((input.Get("framesDropped")).Int())
+	value17 = (uint)((value.Get("framesDropped")).Int())
 	out.FramesDropped = value17
-	value18 = (uint)((input.Get("partialFramesLost")).Int())
+	value18 = (uint)((value.Get("partialFramesLost")).Int())
 	out.PartialFramesLost = value18
-	value19 = (uint)((input.Get("fullFramesLost")).Int())
+	value19 = (uint)((value.Get("fullFramesLost")).Int())
 	out.FullFramesLost = value19
 	return &out
 }
@@ -3205,7 +3157,7 @@ type VideoSenderStats struct {
 	KeyFramesSent   uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoSenderStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3243,10 +3195,8 @@ func (_this *VideoSenderStats) JSValue() js.Value {
 }
 
 // VideoSenderStatsFromJS is allocating a new
-// VideoSenderStats object and copy all values from
-// input javascript object
-func VideoSenderStatsFromJS(value js.Wrapper) *VideoSenderStats {
-	input := value.JSValue()
+// VideoSenderStats object and copy all values in the value javascript object.
+func VideoSenderStatsFromJS(value js.Value) *VideoSenderStats {
 	var out VideoSenderStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3265,35 +3215,35 @@ func VideoSenderStatsFromJS(value js.Wrapper) *VideoSenderStats {
 		value13 uint                // javascript: unsigned long {hugeFramesSent HugeFramesSent hugeFramesSent}
 		value14 uint                // javascript: unsigned long {keyFramesSent KeyFramesSent keyFramesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (uint)((input.Get("framesCaptured")).Int())
+	value11 = (uint)((value.Get("framesCaptured")).Int())
 	out.FramesCaptured = value11
-	value12 = (uint)((input.Get("framesSent")).Int())
+	value12 = (uint)((value.Get("framesSent")).Int())
 	out.FramesSent = value12
-	value13 = (uint)((input.Get("hugeFramesSent")).Int())
+	value13 = (uint)((value.Get("hugeFramesSent")).Int())
 	out.HugeFramesSent = value13
-	value14 = (uint)((input.Get("keyFramesSent")).Int())
+	value14 = (uint)((value.Get("keyFramesSent")).Int())
 	out.KeyFramesSent = value14
 	return &out
 }

--- a/media/webrtc/stats/stats_js.go
+++ b/media/webrtc/stats/stats_js.go
@@ -233,7 +233,7 @@ type AudioHandlerStats struct {
 	TotalSamplesDuration float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -265,10 +265,8 @@ func (_this *AudioHandlerStats) JSValue() js.Value {
 }
 
 // AudioHandlerStatsFromJS is allocating a new
-// AudioHandlerStats object and copy all values from
-// input javascript object
-func AudioHandlerStatsFromJS(value js.Wrapper) *AudioHandlerStats {
-	input := value.JSValue()
+// AudioHandlerStats object and copy all values in the value javascript object.
+func AudioHandlerStatsFromJS(value js.Value) *AudioHandlerStats {
 	var out AudioHandlerStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -284,29 +282,29 @@ func AudioHandlerStatsFromJS(value js.Wrapper) *AudioHandlerStats {
 		value10 bool                // javascript: boolean {voiceActivityFlag VoiceActivityFlag voiceActivityFlag}
 		value11 float64             // javascript: double {totalSamplesDuration TotalSamplesDuration totalSamplesDuration}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
 	return &out
 }
@@ -333,7 +331,7 @@ type AudioReceiverStats struct {
 	ConcealmentEvents         int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioReceiverStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -377,10 +375,8 @@ func (_this *AudioReceiverStats) JSValue() js.Value {
 }
 
 // AudioReceiverStatsFromJS is allocating a new
-// AudioReceiverStats object and copy all values from
-// input javascript object
-func AudioReceiverStatsFromJS(value js.Wrapper) *AudioReceiverStats {
-	input := value.JSValue()
+// AudioReceiverStats object and copy all values in the value javascript object.
+func AudioReceiverStatsFromJS(value js.Value) *AudioReceiverStats {
 	var out AudioReceiverStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -402,41 +398,41 @@ func AudioReceiverStatsFromJS(value js.Wrapper) *AudioReceiverStats {
 		value16 int                 // javascript: unsigned long long {concealedSamples ConcealedSamples concealedSamples}
 		value17 int                 // javascript: unsigned long long {concealmentEvents ConcealmentEvents concealmentEvents}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("estimatedPlayoutTimestamp")).Float()
+	value12 = (value.Get("estimatedPlayoutTimestamp")).Float()
 	out.EstimatedPlayoutTimestamp = value12
-	value13 = (input.Get("jitterBufferDelay")).Float()
+	value13 = (value.Get("jitterBufferDelay")).Float()
 	out.JitterBufferDelay = value13
-	value14 = (input.Get("jitterBufferEmittedCount")).Int()
+	value14 = (value.Get("jitterBufferEmittedCount")).Int()
 	out.JitterBufferEmittedCount = value14
-	value15 = (input.Get("totalSamplesReceived")).Int()
+	value15 = (value.Get("totalSamplesReceived")).Int()
 	out.TotalSamplesReceived = value15
-	value16 = (input.Get("concealedSamples")).Int()
+	value16 = (value.Get("concealedSamples")).Int()
 	out.ConcealedSamples = value16
-	value17 = (input.Get("concealmentEvents")).Int()
+	value17 = (value.Get("concealmentEvents")).Int()
 	out.ConcealmentEvents = value17
 	return &out
 }
@@ -460,7 +456,7 @@ type AudioSenderStats struct {
 	TotalSamplesSent          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AudioSenderStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -498,10 +494,8 @@ func (_this *AudioSenderStats) JSValue() js.Value {
 }
 
 // AudioSenderStatsFromJS is allocating a new
-// AudioSenderStats object and copy all values from
-// input javascript object
-func AudioSenderStatsFromJS(value js.Wrapper) *AudioSenderStats {
-	input := value.JSValue()
+// AudioSenderStats object and copy all values in the value javascript object.
+func AudioSenderStatsFromJS(value js.Value) *AudioSenderStats {
 	var out AudioSenderStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -520,35 +514,35 @@ func AudioSenderStatsFromJS(value js.Wrapper) *AudioSenderStats {
 		value13 float64             // javascript: double {echoReturnLossEnhancement EchoReturnLossEnhancement echoReturnLossEnhancement}
 		value14 int                 // javascript: unsigned long long {totalSamplesSent TotalSamplesSent totalSamplesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("echoReturnLoss")).Float()
+	value12 = (value.Get("echoReturnLoss")).Float()
 	out.EchoReturnLoss = value12
-	value13 = (input.Get("echoReturnLossEnhancement")).Float()
+	value13 = (value.Get("echoReturnLossEnhancement")).Float()
 	out.EchoReturnLossEnhancement = value13
-	value14 = (input.Get("totalSamplesSent")).Int()
+	value14 = (value.Get("totalSamplesSent")).Int()
 	out.TotalSamplesSent = value14
 	return &out
 }
@@ -564,7 +558,7 @@ type CertificateStats struct {
 	IssuerCertificateId  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CertificateStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -586,10 +580,8 @@ func (_this *CertificateStats) JSValue() js.Value {
 }
 
 // CertificateStatsFromJS is allocating a new
-// CertificateStats object and copy all values from
-// input javascript object
-func CertificateStatsFromJS(value js.Wrapper) *CertificateStats {
-	input := value.JSValue()
+// CertificateStats object and copy all values in the value javascript object.
+func CertificateStatsFromJS(value js.Value) *CertificateStats {
 	var out CertificateStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -600,19 +592,19 @@ func CertificateStatsFromJS(value js.Wrapper) *CertificateStats {
 		value5 string           // javascript: DOMString {base64Certificate Base64Certificate base64Certificate}
 		value6 string           // javascript: DOMString {issuerCertificateId IssuerCertificateId issuerCertificateId}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("fingerprint")).String()
+	value3 = (value.Get("fingerprint")).String()
 	out.Fingerprint = value3
-	value4 = (input.Get("fingerprintAlgorithm")).String()
+	value4 = (value.Get("fingerprintAlgorithm")).String()
 	out.FingerprintAlgorithm = value4
-	value5 = (input.Get("base64Certificate")).String()
+	value5 = (value.Get("base64Certificate")).String()
 	out.Base64Certificate = value5
-	value6 = (input.Get("issuerCertificateId")).String()
+	value6 = (value.Get("issuerCertificateId")).String()
 	out.IssuerCertificateId = value6
 	return &out
 }
@@ -632,7 +624,7 @@ type CodecStats struct {
 	Implementation string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CodecStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -662,10 +654,8 @@ func (_this *CodecStats) JSValue() js.Value {
 }
 
 // CodecStatsFromJS is allocating a new
-// CodecStats object and copy all values from
-// input javascript object
-func CodecStatsFromJS(value js.Wrapper) *CodecStats {
-	input := value.JSValue()
+// CodecStats object and copy all values in the value javascript object.
+func CodecStatsFromJS(value js.Value) *CodecStats {
 	var out CodecStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -680,27 +670,27 @@ func CodecStatsFromJS(value js.Wrapper) *CodecStats {
 		value9  string           // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 		value10 string           // javascript: DOMString {implementation Implementation implementation}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("payloadType")).Int())
+	value3 = (uint)((value.Get("payloadType")).Int())
 	out.PayloadType = value3
-	value4 = CodecTypeFromJS(input.Get("codecType"))
+	value4 = CodecTypeFromJS(value.Get("codecType"))
 	out.CodecType = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("mimeType")).String()
+	value6 = (value.Get("mimeType")).String()
 	out.MimeType = value6
-	value7 = (uint)((input.Get("clockRate")).Int())
+	value7 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value7
-	value8 = (uint)((input.Get("channels")).Int())
+	value8 = (uint)((value.Get("channels")).Int())
 	out.Channels = value8
-	value9 = (input.Get("sdpFmtpLine")).String()
+	value9 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value9
-	value10 = (input.Get("implementation")).String()
+	value10 = (value.Get("implementation")).String()
 	out.Implementation = value10
 	return &out
 }
@@ -721,7 +711,7 @@ type DataChannelStats struct {
 	BytesReceived         int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -753,10 +743,8 @@ func (_this *DataChannelStats) JSValue() js.Value {
 }
 
 // DataChannelStatsFromJS is allocating a new
-// DataChannelStats object and copy all values from
-// input javascript object
-func DataChannelStatsFromJS(value js.Wrapper) *DataChannelStats {
-	input := value.JSValue()
+// DataChannelStats object and copy all values in the value javascript object.
+func DataChannelStatsFromJS(value js.Value) *DataChannelStats {
 	var out DataChannelStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -772,29 +760,29 @@ func DataChannelStatsFromJS(value js.Wrapper) *DataChannelStats {
 		value10 uint                    // javascript: unsigned long {messagesReceived MessagesReceived messagesReceived}
 		value11 int                     // javascript: unsigned long long {bytesReceived BytesReceived bytesReceived}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("label")).String()
+	value3 = (value.Get("label")).String()
 	out.Label = value3
-	value4 = (input.Get("protocol")).String()
+	value4 = (value.Get("protocol")).String()
 	out.Protocol = value4
-	value5 = (input.Get("dataChannelIdentifier")).Int()
+	value5 = (value.Get("dataChannelIdentifier")).Int()
 	out.DataChannelIdentifier = value5
-	value6 = (input.Get("transportId")).String()
+	value6 = (value.Get("transportId")).String()
 	out.TransportId = value6
-	value7 = webrtc.DataChannelStateFromJS(input.Get("state"))
+	value7 = webrtc.DataChannelStateFromJS(value.Get("state"))
 	out.State = value7
-	value8 = (uint)((input.Get("messagesSent")).Int())
+	value8 = (uint)((value.Get("messagesSent")).Int())
 	out.MessagesSent = value8
-	value9 = (input.Get("bytesSent")).Int()
+	value9 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value9
-	value10 = (uint)((input.Get("messagesReceived")).Int())
+	value10 = (uint)((value.Get("messagesReceived")).Int())
 	out.MessagesReceived = value10
-	value11 = (input.Get("bytesReceived")).Int()
+	value11 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value11
 	return &out
 }
@@ -836,7 +824,7 @@ type IceCandidatePairStats struct {
 	Priority                    int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidatePairStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -910,10 +898,8 @@ func (_this *IceCandidatePairStats) JSValue() js.Value {
 }
 
 // IceCandidatePairStatsFromJS is allocating a new
-// IceCandidatePairStats object and copy all values from
-// input javascript object
-func IceCandidatePairStatsFromJS(value js.Wrapper) *IceCandidatePairStats {
-	input := value.JSValue()
+// IceCandidatePairStats object and copy all values in the value javascript object.
+func IceCandidatePairStatsFromJS(value js.Value) *IceCandidatePairStats {
 	var out IceCandidatePairStats
 	var (
 		value0  float64                    // javascript: double {timestamp Timestamp timestamp}
@@ -950,71 +936,71 @@ func IceCandidatePairStatsFromJS(value js.Wrapper) *IceCandidatePairStats {
 		value31 float64                    // javascript: double {currentRtt CurrentRtt currentRtt}
 		value32 int                        // javascript: unsigned long long {priority Priority priority}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("transportId")).String()
+	value3 = (value.Get("transportId")).String()
 	out.TransportId = value3
-	value4 = (input.Get("localCandidateId")).String()
+	value4 = (value.Get("localCandidateId")).String()
 	out.LocalCandidateId = value4
-	value5 = (input.Get("remoteCandidateId")).String()
+	value5 = (value.Get("remoteCandidateId")).String()
 	out.RemoteCandidateId = value5
-	value6 = StatsIceCandidatePairStateFromJS(input.Get("state"))
+	value6 = StatsIceCandidatePairStateFromJS(value.Get("state"))
 	out.State = value6
-	value7 = (input.Get("nominated")).Bool()
+	value7 = (value.Get("nominated")).Bool()
 	out.Nominated = value7
-	value8 = (uint)((input.Get("packetsSent")).Int())
+	value8 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value8
-	value9 = (uint)((input.Get("packetsReceived")).Int())
+	value9 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value9
-	value10 = (input.Get("bytesSent")).Int()
+	value10 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value10
-	value11 = (input.Get("bytesReceived")).Int()
+	value11 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value11
-	value12 = (input.Get("lastPacketSentTimestamp")).Float()
+	value12 = (value.Get("lastPacketSentTimestamp")).Float()
 	out.LastPacketSentTimestamp = value12
-	value13 = (input.Get("lastPacketReceivedTimestamp")).Float()
+	value13 = (value.Get("lastPacketReceivedTimestamp")).Float()
 	out.LastPacketReceivedTimestamp = value13
-	value14 = (input.Get("firstRequestTimestamp")).Float()
+	value14 = (value.Get("firstRequestTimestamp")).Float()
 	out.FirstRequestTimestamp = value14
-	value15 = (input.Get("lastRequestTimestamp")).Float()
+	value15 = (value.Get("lastRequestTimestamp")).Float()
 	out.LastRequestTimestamp = value15
-	value16 = (input.Get("lastResponseTimestamp")).Float()
+	value16 = (value.Get("lastResponseTimestamp")).Float()
 	out.LastResponseTimestamp = value16
-	value17 = (input.Get("totalRoundTripTime")).Float()
+	value17 = (value.Get("totalRoundTripTime")).Float()
 	out.TotalRoundTripTime = value17
-	value18 = (input.Get("currentRoundTripTime")).Float()
+	value18 = (value.Get("currentRoundTripTime")).Float()
 	out.CurrentRoundTripTime = value18
-	value19 = (input.Get("availableOutgoingBitrate")).Float()
+	value19 = (value.Get("availableOutgoingBitrate")).Float()
 	out.AvailableOutgoingBitrate = value19
-	value20 = (input.Get("availableIncomingBitrate")).Float()
+	value20 = (value.Get("availableIncomingBitrate")).Float()
 	out.AvailableIncomingBitrate = value20
-	value21 = (uint)((input.Get("circuitBreakerTriggerCount")).Int())
+	value21 = (uint)((value.Get("circuitBreakerTriggerCount")).Int())
 	out.CircuitBreakerTriggerCount = value21
-	value22 = (input.Get("requestsReceived")).Int()
+	value22 = (value.Get("requestsReceived")).Int()
 	out.RequestsReceived = value22
-	value23 = (input.Get("requestsSent")).Int()
+	value23 = (value.Get("requestsSent")).Int()
 	out.RequestsSent = value23
-	value24 = (input.Get("responsesReceived")).Int()
+	value24 = (value.Get("responsesReceived")).Int()
 	out.ResponsesReceived = value24
-	value25 = (input.Get("responsesSent")).Int()
+	value25 = (value.Get("responsesSent")).Int()
 	out.ResponsesSent = value25
-	value26 = (input.Get("retransmissionsReceived")).Int()
+	value26 = (value.Get("retransmissionsReceived")).Int()
 	out.RetransmissionsReceived = value26
-	value27 = (input.Get("retransmissionsSent")).Int()
+	value27 = (value.Get("retransmissionsSent")).Int()
 	out.RetransmissionsSent = value27
-	value28 = (input.Get("consentRequestsSent")).Int()
+	value28 = (value.Get("consentRequestsSent")).Int()
 	out.ConsentRequestsSent = value28
-	value29 = (input.Get("consentExpiredTimestamp")).Float()
+	value29 = (value.Get("consentExpiredTimestamp")).Float()
 	out.ConsentExpiredTimestamp = value29
-	value30 = (input.Get("totalRtt")).Float()
+	value30 = (value.Get("totalRtt")).Float()
 	out.TotalRtt = value30
-	value31 = (input.Get("currentRtt")).Float()
+	value31 = (value.Get("currentRtt")).Float()
 	out.CurrentRtt = value31
-	value32 = (input.Get("priority")).Int()
+	value32 = (value.Get("priority")).Int()
 	out.Priority = value32
 	return &out
 }
@@ -1037,7 +1023,7 @@ type IceCandidateStats struct {
 	IsRemote      bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidateStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1079,10 +1065,8 @@ func (_this *IceCandidateStats) JSValue() js.Value {
 }
 
 // IceCandidateStatsFromJS is allocating a new
-// IceCandidateStats object and copy all values from
-// input javascript object
-func IceCandidateStatsFromJS(value js.Wrapper) *IceCandidateStats {
-	input := value.JSValue()
+// IceCandidateStats object and copy all values in the value javascript object.
+func IceCandidateStatsFromJS(value js.Value) *IceCandidateStats {
 	var out IceCandidateStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -1100,36 +1084,36 @@ func IceCandidateStatsFromJS(value js.Wrapper) *IceCandidateStats {
 		value12 bool                    // javascript: boolean {deleted Deleted deleted}
 		value13 bool                    // javascript: boolean {isRemote IsRemote isRemote}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("transportId")).String()
+	value3 = (value.Get("transportId")).String()
 	out.TransportId = value3
-	value4 = NetworkTypeFromJS(input.Get("networkType"))
+	value4 = NetworkTypeFromJS(value.Get("networkType"))
 	out.NetworkType = value4
-	if input.Get("address").Type() != js.TypeNull && input.Get("address").Type() != js.TypeUndefined {
-		__tmp := (input.Get("address")).String()
+	if value.Get("address").Type() != js.TypeNull && value.Get("address").Type() != js.TypeUndefined {
+		__tmp := (value.Get("address")).String()
 		value5 = &__tmp
 	}
 	out.Address = value5
-	value6 = (input.Get("port")).Int()
+	value6 = (value.Get("port")).Int()
 	out.Port = value6
-	value7 = (input.Get("protocol")).String()
+	value7 = (value.Get("protocol")).String()
 	out.Protocol = value7
-	value8 = webrtc.IceCandidateTypeFromJS(input.Get("candidateType"))
+	value8 = webrtc.IceCandidateTypeFromJS(value.Get("candidateType"))
 	out.CandidateType = value8
-	value9 = (input.Get("priority")).Int()
+	value9 = (value.Get("priority")).Int()
 	out.Priority = value9
-	value10 = (input.Get("url")).String()
+	value10 = (value.Get("url")).String()
 	out.Url = value10
-	value11 = (input.Get("relayProtocol")).String()
+	value11 = (value.Get("relayProtocol")).String()
 	out.RelayProtocol = value11
-	value12 = (input.Get("deleted")).Bool()
+	value12 = (value.Get("deleted")).Bool()
 	out.Deleted = value12
-	value13 = (input.Get("isRemote")).Bool()
+	value13 = (value.Get("isRemote")).Bool()
 	out.IsRemote = value13
 	return &out
 }
@@ -1175,7 +1159,7 @@ type InboundRtpStreamStats struct {
 	PacketsDuplicated           uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *InboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1257,10 +1241,8 @@ func (_this *InboundRtpStreamStats) JSValue() js.Value {
 }
 
 // InboundRtpStreamStatsFromJS is allocating a new
-// InboundRtpStreamStats object and copy all values from
-// input javascript object
-func InboundRtpStreamStatsFromJS(value js.Wrapper) *InboundRtpStreamStats {
-	input := value.JSValue()
+// InboundRtpStreamStats object and copy all values in the value javascript object.
+func InboundRtpStreamStatsFromJS(value js.Value) *InboundRtpStreamStats {
 	var out InboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1301,79 +1283,79 @@ func InboundRtpStreamStatsFromJS(value js.Wrapper) *InboundRtpStreamStats {
 		value35 uint             // javascript: unsigned long {packetsFailedDecryption PacketsFailedDecryption packetsFailedDecryption}
 		value36 uint             // javascript: unsigned long {packetsDuplicated PacketsDuplicated packetsDuplicated}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
-	value27 = (input.Get("trackId")).String()
+	value27 = (value.Get("trackId")).String()
 	out.TrackId = value27
-	value28 = (input.Get("receiverId")).String()
+	value28 = (value.Get("receiverId")).String()
 	out.ReceiverId = value28
-	value29 = (input.Get("remoteId")).String()
+	value29 = (value.Get("remoteId")).String()
 	out.RemoteId = value29
-	value30 = (uint)((input.Get("framesDecoded")).Int())
+	value30 = (uint)((value.Get("framesDecoded")).Int())
 	out.FramesDecoded = value30
-	value31 = (input.Get("lastPacketReceivedTimestamp")).Float()
+	value31 = (value.Get("lastPacketReceivedTimestamp")).Float()
 	out.LastPacketReceivedTimestamp = value31
-	value32 = (input.Get("averageRtcpInterval")).Float()
+	value32 = (value.Get("averageRtcpInterval")).Float()
 	out.AverageRtcpInterval = value32
-	value33 = (uint)((input.Get("fecPacketsReceived")).Int())
+	value33 = (uint)((value.Get("fecPacketsReceived")).Int())
 	out.FecPacketsReceived = value33
-	value34 = (input.Get("bytesReceived")).Int()
+	value34 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value34
-	value35 = (uint)((input.Get("packetsFailedDecryption")).Int())
+	value35 = (uint)((value.Get("packetsFailedDecryption")).Int())
 	out.PacketsFailedDecryption = value35
-	value36 = (uint)((input.Get("packetsDuplicated")).Int())
+	value36 = (uint)((value.Get("packetsDuplicated")).Int())
 	out.PacketsDuplicated = value36
 	return &out
 }
@@ -1390,7 +1372,7 @@ type MediaHandlerStats struct {
 	Priority        webrtc.PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1414,10 +1396,8 @@ func (_this *MediaHandlerStats) JSValue() js.Value {
 }
 
 // MediaHandlerStatsFromJS is allocating a new
-// MediaHandlerStats object and copy all values from
-// input javascript object
-func MediaHandlerStatsFromJS(value js.Wrapper) *MediaHandlerStats {
-	input := value.JSValue()
+// MediaHandlerStats object and copy all values in the value javascript object.
+func MediaHandlerStatsFromJS(value js.Value) *MediaHandlerStats {
 	var out MediaHandlerStats
 	var (
 		value0 float64             // javascript: double {timestamp Timestamp timestamp}
@@ -1429,21 +1409,21 @@ func MediaHandlerStatsFromJS(value js.Wrapper) *MediaHandlerStats {
 		value6 string              // javascript: DOMString {kind Kind kind}
 		value7 webrtc.PriorityType // javascript: RTCPriorityType {priority Priority priority}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
 	return &out
 }
@@ -1457,7 +1437,7 @@ type MediaStreamStats struct {
 	TrackIds         []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MediaStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1479,10 +1459,8 @@ func (_this *MediaStreamStats) JSValue() js.Value {
 }
 
 // MediaStreamStatsFromJS is allocating a new
-// MediaStreamStats object and copy all values from
-// input javascript object
-func MediaStreamStatsFromJS(value js.Wrapper) *MediaStreamStats {
-	input := value.JSValue()
+// MediaStreamStats object and copy all values in the value javascript object.
+func MediaStreamStatsFromJS(value js.Value) *MediaStreamStats {
 	var out MediaStreamStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1491,19 +1469,19 @@ func MediaStreamStatsFromJS(value js.Wrapper) *MediaStreamStats {
 		value3 string           // javascript: DOMString {streamIdentifier StreamIdentifier streamIdentifier}
 		value4 []string         // javascript: sequence<DOMString> {trackIds TrackIds trackIds}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("streamIdentifier")).String()
+	value3 = (value.Get("streamIdentifier")).String()
 	out.StreamIdentifier = value3
-	__length4 := input.Get("trackIds").Length()
+	__length4 := value.Get("trackIds").Length()
 	__array4 := make([]string, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 string
-		__seq_in4 := input.Get("trackIds").Index(__idx4)
+		__seq_in4 := value.Get("trackIds").Index(__idx4)
 		__seq_out4 = (__seq_in4).String()
 		__array4[__idx4] = __seq_out4
 	}
@@ -1544,7 +1522,7 @@ type OutboundRtpStreamStats struct {
 	QualityLimitationReason QualityLimitationReason
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OutboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1608,10 +1586,8 @@ func (_this *OutboundRtpStreamStats) JSValue() js.Value {
 }
 
 // OutboundRtpStreamStatsFromJS is allocating a new
-// OutboundRtpStreamStats object and copy all values from
-// input javascript object
-func OutboundRtpStreamStatsFromJS(value js.Wrapper) *OutboundRtpStreamStats {
-	input := value.JSValue()
+// OutboundRtpStreamStats object and copy all values in the value javascript object.
+func OutboundRtpStreamStatsFromJS(value js.Value) *OutboundRtpStreamStats {
 	var out OutboundRtpStreamStats
 	var (
 		value0  float64                 // javascript: double {timestamp Timestamp timestamp}
@@ -1643,61 +1619,61 @@ func OutboundRtpStreamStatsFromJS(value js.Wrapper) *OutboundRtpStreamStats {
 		value26 float64                 // javascript: double {averageRtcpInterval AverageRtcpInterval averageRtcpInterval}
 		value27 QualityLimitationReason // javascript: RTCQualityLimitationReason {qualityLimitationReason QualityLimitationReason qualityLimitationReason}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
-	value19 = (input.Get("trackId")).String()
+	value19 = (value.Get("trackId")).String()
 	out.TrackId = value19
-	value20 = (input.Get("senderId")).String()
+	value20 = (value.Get("senderId")).String()
 	out.SenderId = value20
-	value21 = (input.Get("remoteId")).String()
+	value21 = (value.Get("remoteId")).String()
 	out.RemoteId = value21
-	value22 = (input.Get("lastPacketSentTimestamp")).Float()
+	value22 = (value.Get("lastPacketSentTimestamp")).Float()
 	out.LastPacketSentTimestamp = value22
-	value23 = (input.Get("targetBitrate")).Float()
+	value23 = (value.Get("targetBitrate")).Float()
 	out.TargetBitrate = value23
-	value24 = (uint)((input.Get("framesEncoded")).Int())
+	value24 = (uint)((value.Get("framesEncoded")).Int())
 	out.FramesEncoded = value24
-	value25 = (input.Get("totalEncodeTime")).Float()
+	value25 = (value.Get("totalEncodeTime")).Float()
 	out.TotalEncodeTime = value25
-	value26 = (input.Get("averageRtcpInterval")).Float()
+	value26 = (value.Get("averageRtcpInterval")).Float()
 	out.AverageRtcpInterval = value26
-	value27 = QualityLimitationReasonFromJS(input.Get("qualityLimitationReason"))
+	value27 = QualityLimitationReasonFromJS(value.Get("qualityLimitationReason"))
 	out.QualityLimitationReason = value27
 	return &out
 }
@@ -1713,7 +1689,7 @@ type PeerConnectionStats struct {
 	DataChannelsAccepted  uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1735,10 +1711,8 @@ func (_this *PeerConnectionStats) JSValue() js.Value {
 }
 
 // PeerConnectionStatsFromJS is allocating a new
-// PeerConnectionStats object and copy all values from
-// input javascript object
-func PeerConnectionStatsFromJS(value js.Wrapper) *PeerConnectionStats {
-	input := value.JSValue()
+// PeerConnectionStats object and copy all values in the value javascript object.
+func PeerConnectionStatsFromJS(value js.Value) *PeerConnectionStats {
 	var out PeerConnectionStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1749,19 +1723,19 @@ func PeerConnectionStatsFromJS(value js.Wrapper) *PeerConnectionStats {
 		value5 uint             // javascript: unsigned long {dataChannelsRequested DataChannelsRequested dataChannelsRequested}
 		value6 uint             // javascript: unsigned long {dataChannelsAccepted DataChannelsAccepted dataChannelsAccepted}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("dataChannelsOpened")).Int())
+	value3 = (uint)((value.Get("dataChannelsOpened")).Int())
 	out.DataChannelsOpened = value3
-	value4 = (uint)((input.Get("dataChannelsClosed")).Int())
+	value4 = (uint)((value.Get("dataChannelsClosed")).Int())
 	out.DataChannelsClosed = value4
-	value5 = (uint)((input.Get("dataChannelsRequested")).Int())
+	value5 = (uint)((value.Get("dataChannelsRequested")).Int())
 	out.DataChannelsRequested = value5
-	value6 = (uint)((input.Get("dataChannelsAccepted")).Int())
+	value6 = (uint)((value.Get("dataChannelsAccepted")).Int())
 	out.DataChannelsAccepted = value6
 	return &out
 }
@@ -1797,7 +1771,7 @@ type ReceivedRtpStreamStats struct {
 	GapDiscardRate        float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReceivedRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1859,10 +1833,8 @@ func (_this *ReceivedRtpStreamStats) JSValue() js.Value {
 }
 
 // ReceivedRtpStreamStatsFromJS is allocating a new
-// ReceivedRtpStreamStats object and copy all values from
-// input javascript object
-func ReceivedRtpStreamStatsFromJS(value js.Wrapper) *ReceivedRtpStreamStats {
-	input := value.JSValue()
+// ReceivedRtpStreamStats object and copy all values in the value javascript object.
+func ReceivedRtpStreamStatsFromJS(value js.Value) *ReceivedRtpStreamStats {
 	var out ReceivedRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -1893,59 +1865,59 @@ func ReceivedRtpStreamStatsFromJS(value js.Wrapper) *ReceivedRtpStreamStats {
 		value25 float64          // javascript: double {gapLossRate GapLossRate gapLossRate}
 		value26 float64          // javascript: double {gapDiscardRate GapDiscardRate gapDiscardRate}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
 	return &out
 }
@@ -1984,7 +1956,7 @@ type RemoteInboundRtpStreamStats struct {
 	FractionLost          float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RemoteInboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2052,10 +2024,8 @@ func (_this *RemoteInboundRtpStreamStats) JSValue() js.Value {
 }
 
 // RemoteInboundRtpStreamStatsFromJS is allocating a new
-// RemoteInboundRtpStreamStats object and copy all values from
-// input javascript object
-func RemoteInboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteInboundRtpStreamStats {
-	input := value.JSValue()
+// RemoteInboundRtpStreamStats object and copy all values in the value javascript object.
+func RemoteInboundRtpStreamStatsFromJS(value js.Value) *RemoteInboundRtpStreamStats {
 	var out RemoteInboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2089,65 +2059,65 @@ func RemoteInboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteInboundRtpStream
 		value28 float64          // javascript: double {roundTripTime RoundTripTime roundTripTime}
 		value29 float64          // javascript: double {fractionLost FractionLost fractionLost}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsReceived")).Int())
+	value14 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value14
-	value15 = (input.Get("packetsLost")).Int()
+	value15 = (value.Get("packetsLost")).Int()
 	out.PacketsLost = value15
-	value16 = (input.Get("jitter")).Float()
+	value16 = (value.Get("jitter")).Float()
 	out.Jitter = value16
-	value17 = (uint)((input.Get("packetsDiscarded")).Int())
+	value17 = (uint)((value.Get("packetsDiscarded")).Int())
 	out.PacketsDiscarded = value17
-	value18 = (uint)((input.Get("packetsRepaired")).Int())
+	value18 = (uint)((value.Get("packetsRepaired")).Int())
 	out.PacketsRepaired = value18
-	value19 = (uint)((input.Get("burstPacketsLost")).Int())
+	value19 = (uint)((value.Get("burstPacketsLost")).Int())
 	out.BurstPacketsLost = value19
-	value20 = (uint)((input.Get("burstPacketsDiscarded")).Int())
+	value20 = (uint)((value.Get("burstPacketsDiscarded")).Int())
 	out.BurstPacketsDiscarded = value20
-	value21 = (uint)((input.Get("burstLossCount")).Int())
+	value21 = (uint)((value.Get("burstLossCount")).Int())
 	out.BurstLossCount = value21
-	value22 = (uint)((input.Get("burstDiscardCount")).Int())
+	value22 = (uint)((value.Get("burstDiscardCount")).Int())
 	out.BurstDiscardCount = value22
-	value23 = (input.Get("burstLossRate")).Float()
+	value23 = (value.Get("burstLossRate")).Float()
 	out.BurstLossRate = value23
-	value24 = (input.Get("burstDiscardRate")).Float()
+	value24 = (value.Get("burstDiscardRate")).Float()
 	out.BurstDiscardRate = value24
-	value25 = (input.Get("gapLossRate")).Float()
+	value25 = (value.Get("gapLossRate")).Float()
 	out.GapLossRate = value25
-	value26 = (input.Get("gapDiscardRate")).Float()
+	value26 = (value.Get("gapDiscardRate")).Float()
 	out.GapDiscardRate = value26
-	value27 = (input.Get("localId")).String()
+	value27 = (value.Get("localId")).String()
 	out.LocalId = value27
-	value28 = (input.Get("roundTripTime")).Float()
+	value28 = (value.Get("roundTripTime")).Float()
 	out.RoundTripTime = value28
-	value29 = (input.Get("fractionLost")).Float()
+	value29 = (value.Get("fractionLost")).Float()
 	out.FractionLost = value29
 	return &out
 }
@@ -2177,7 +2147,7 @@ type RemoteOutboundRtpStreamStats struct {
 	RemoteTimestamp        float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RemoteOutboundRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2227,10 +2197,8 @@ func (_this *RemoteOutboundRtpStreamStats) JSValue() js.Value {
 }
 
 // RemoteOutboundRtpStreamStatsFromJS is allocating a new
-// RemoteOutboundRtpStreamStats object and copy all values from
-// input javascript object
-func RemoteOutboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteOutboundRtpStreamStats {
-	input := value.JSValue()
+// RemoteOutboundRtpStreamStats object and copy all values in the value javascript object.
+func RemoteOutboundRtpStreamStatsFromJS(value js.Value) *RemoteOutboundRtpStreamStats {
 	var out RemoteOutboundRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2255,47 +2223,47 @@ func RemoteOutboundRtpStreamStatsFromJS(value js.Wrapper) *RemoteOutboundRtpStre
 		value19 string           // javascript: DOMString {localId LocalId localId}
 		value20 float64          // javascript: double {remoteTimestamp RemoteTimestamp remoteTimestamp}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
-	value19 = (input.Get("localId")).String()
+	value19 = (value.Get("localId")).String()
 	out.LocalId = value19
-	value20 = (input.Get("remoteTimestamp")).Float()
+	value20 = (value.Get("remoteTimestamp")).Float()
 	out.RemoteTimestamp = value20
 	return &out
 }
@@ -2311,7 +2279,7 @@ type RtpContributingSourceStats struct {
 	AudioLevel           float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpContributingSourceStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2333,10 +2301,8 @@ func (_this *RtpContributingSourceStats) JSValue() js.Value {
 }
 
 // RtpContributingSourceStatsFromJS is allocating a new
-// RtpContributingSourceStats object and copy all values from
-// input javascript object
-func RtpContributingSourceStatsFromJS(value js.Wrapper) *RtpContributingSourceStats {
-	input := value.JSValue()
+// RtpContributingSourceStats object and copy all values in the value javascript object.
+func RtpContributingSourceStatsFromJS(value js.Value) *RtpContributingSourceStats {
 	var out RtpContributingSourceStats
 	var (
 		value0 float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2347,19 +2313,19 @@ func RtpContributingSourceStatsFromJS(value js.Wrapper) *RtpContributingSourceSt
 		value5 uint             // javascript: unsigned long {packetsContributedTo PacketsContributedTo packetsContributedTo}
 		value6 float64          // javascript: double {audioLevel AudioLevel audioLevel}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("contributorSsrc")).Int())
+	value3 = (uint)((value.Get("contributorSsrc")).Int())
 	out.ContributorSsrc = value3
-	value4 = (input.Get("inboundRtpStreamId")).String()
+	value4 = (value.Get("inboundRtpStreamId")).String()
 	out.InboundRtpStreamId = value4
-	value5 = (uint)((input.Get("packetsContributedTo")).Int())
+	value5 = (uint)((value.Get("packetsContributedTo")).Int())
 	out.PacketsContributedTo = value5
-	value6 = (input.Get("audioLevel")).Float()
+	value6 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value6
 	return &out
 }
@@ -2382,7 +2348,7 @@ type RtpStreamStats struct {
 	AverageRTCPInterval float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2418,10 +2384,8 @@ func (_this *RtpStreamStats) JSValue() js.Value {
 }
 
 // RtpStreamStatsFromJS is allocating a new
-// RtpStreamStats object and copy all values from
-// input javascript object
-func RtpStreamStatsFromJS(value js.Wrapper) *RtpStreamStats {
-	input := value.JSValue()
+// RtpStreamStats object and copy all values in the value javascript object.
+func RtpStreamStatsFromJS(value js.Value) *RtpStreamStats {
 	var out RtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2439,33 +2403,33 @@ func RtpStreamStatsFromJS(value js.Wrapper) *RtpStreamStats {
 		value12 string           // javascript: DOMString {mediaType MediaType mediaType}
 		value13 float64          // javascript: double {averageRTCPInterval AverageRTCPInterval averageRTCPInterval}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
 	return &out
 }
@@ -2489,7 +2453,7 @@ type SenderAudioTrackAttachmentStats struct {
 	TotalSamplesSent          int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SenderAudioTrackAttachmentStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2527,10 +2491,8 @@ func (_this *SenderAudioTrackAttachmentStats) JSValue() js.Value {
 }
 
 // SenderAudioTrackAttachmentStatsFromJS is allocating a new
-// SenderAudioTrackAttachmentStats object and copy all values from
-// input javascript object
-func SenderAudioTrackAttachmentStatsFromJS(value js.Wrapper) *SenderAudioTrackAttachmentStats {
-	input := value.JSValue()
+// SenderAudioTrackAttachmentStats object and copy all values in the value javascript object.
+func SenderAudioTrackAttachmentStatsFromJS(value js.Value) *SenderAudioTrackAttachmentStats {
 	var out SenderAudioTrackAttachmentStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -2549,35 +2511,35 @@ func SenderAudioTrackAttachmentStatsFromJS(value js.Wrapper) *SenderAudioTrackAt
 		value13 float64             // javascript: double {echoReturnLossEnhancement EchoReturnLossEnhancement echoReturnLossEnhancement}
 		value14 int                 // javascript: unsigned long long {totalSamplesSent TotalSamplesSent totalSamplesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (input.Get("audioLevel")).Float()
+	value8 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value8
-	value9 = (input.Get("totalAudioEnergy")).Float()
+	value9 = (value.Get("totalAudioEnergy")).Float()
 	out.TotalAudioEnergy = value9
-	value10 = (input.Get("voiceActivityFlag")).Bool()
+	value10 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value10
-	value11 = (input.Get("totalSamplesDuration")).Float()
+	value11 = (value.Get("totalSamplesDuration")).Float()
 	out.TotalSamplesDuration = value11
-	value12 = (input.Get("echoReturnLoss")).Float()
+	value12 = (value.Get("echoReturnLoss")).Float()
 	out.EchoReturnLoss = value12
-	value13 = (input.Get("echoReturnLossEnhancement")).Float()
+	value13 = (value.Get("echoReturnLossEnhancement")).Float()
 	out.EchoReturnLossEnhancement = value13
-	value14 = (input.Get("totalSamplesSent")).Int()
+	value14 = (value.Get("totalSamplesSent")).Int()
 	out.TotalSamplesSent = value14
 	return &out
 }
@@ -2601,7 +2563,7 @@ type SenderVideoTrackAttachmentStats struct {
 	KeyFramesSent   uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SenderVideoTrackAttachmentStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2639,10 +2601,8 @@ func (_this *SenderVideoTrackAttachmentStats) JSValue() js.Value {
 }
 
 // SenderVideoTrackAttachmentStatsFromJS is allocating a new
-// SenderVideoTrackAttachmentStats object and copy all values from
-// input javascript object
-func SenderVideoTrackAttachmentStatsFromJS(value js.Wrapper) *SenderVideoTrackAttachmentStats {
-	input := value.JSValue()
+// SenderVideoTrackAttachmentStats object and copy all values in the value javascript object.
+func SenderVideoTrackAttachmentStatsFromJS(value js.Value) *SenderVideoTrackAttachmentStats {
 	var out SenderVideoTrackAttachmentStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -2661,35 +2621,35 @@ func SenderVideoTrackAttachmentStatsFromJS(value js.Wrapper) *SenderVideoTrackAt
 		value13 uint                // javascript: unsigned long {hugeFramesSent HugeFramesSent hugeFramesSent}
 		value14 uint                // javascript: unsigned long {keyFramesSent KeyFramesSent keyFramesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (uint)((input.Get("framesCaptured")).Int())
+	value11 = (uint)((value.Get("framesCaptured")).Int())
 	out.FramesCaptured = value11
-	value12 = (uint)((input.Get("framesSent")).Int())
+	value12 = (uint)((value.Get("framesSent")).Int())
 	out.FramesSent = value12
-	value13 = (uint)((input.Get("hugeFramesSent")).Int())
+	value13 = (uint)((value.Get("hugeFramesSent")).Int())
 	out.HugeFramesSent = value13
-	value14 = (uint)((input.Get("keyFramesSent")).Int())
+	value14 = (uint)((value.Get("keyFramesSent")).Int())
 	out.KeyFramesSent = value14
 	return &out
 }
@@ -2717,7 +2677,7 @@ type SentRtpStreamStats struct {
 	BytesDiscardedOnSend   int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SentRtpStreamStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2763,10 +2723,8 @@ func (_this *SentRtpStreamStats) JSValue() js.Value {
 }
 
 // SentRtpStreamStatsFromJS is allocating a new
-// SentRtpStreamStats object and copy all values from
-// input javascript object
-func SentRtpStreamStatsFromJS(value js.Wrapper) *SentRtpStreamStats {
-	input := value.JSValue()
+// SentRtpStreamStats object and copy all values in the value javascript object.
+func SentRtpStreamStatsFromJS(value js.Value) *SentRtpStreamStats {
 	var out SentRtpStreamStats
 	var (
 		value0  float64          // javascript: double {timestamp Timestamp timestamp}
@@ -2789,43 +2747,43 @@ func SentRtpStreamStatsFromJS(value js.Wrapper) *SentRtpStreamStats {
 		value17 int              // javascript: unsigned long long {bytesSent BytesSent bytesSent}
 		value18 int              // javascript: unsigned long long {bytesDiscardedOnSend BytesDiscardedOnSend bytesDiscardedOnSend}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("ssrc")).Int())
+	value3 = (uint)((value.Get("ssrc")).Int())
 	out.Ssrc = value3
-	value4 = (input.Get("kind")).String()
+	value4 = (value.Get("kind")).String()
 	out.Kind = value4
-	value5 = (input.Get("transportId")).String()
+	value5 = (value.Get("transportId")).String()
 	out.TransportId = value5
-	value6 = (input.Get("codecId")).String()
+	value6 = (value.Get("codecId")).String()
 	out.CodecId = value6
-	value7 = (uint)((input.Get("firCount")).Int())
+	value7 = (uint)((value.Get("firCount")).Int())
 	out.FirCount = value7
-	value8 = (uint)((input.Get("pliCount")).Int())
+	value8 = (uint)((value.Get("pliCount")).Int())
 	out.PliCount = value8
-	value9 = (uint)((input.Get("nackCount")).Int())
+	value9 = (uint)((value.Get("nackCount")).Int())
 	out.NackCount = value9
-	value10 = (uint)((input.Get("sliCount")).Int())
+	value10 = (uint)((value.Get("sliCount")).Int())
 	out.SliCount = value10
-	value11 = (input.Get("qpSum")).Int()
+	value11 = (value.Get("qpSum")).Int()
 	out.QpSum = value11
-	value12 = (input.Get("mediaType")).String()
+	value12 = (value.Get("mediaType")).String()
 	out.MediaType = value12
-	value13 = (input.Get("averageRTCPInterval")).Float()
+	value13 = (value.Get("averageRTCPInterval")).Float()
 	out.AverageRTCPInterval = value13
-	value14 = (uint)((input.Get("packetsSent")).Int())
+	value14 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value14
-	value15 = (uint)((input.Get("packetsDiscardedOnSend")).Int())
+	value15 = (uint)((value.Get("packetsDiscardedOnSend")).Int())
 	out.PacketsDiscardedOnSend = value15
-	value16 = (uint)((input.Get("fecPacketsSent")).Int())
+	value16 = (uint)((value.Get("fecPacketsSent")).Int())
 	out.FecPacketsSent = value16
-	value17 = (input.Get("bytesSent")).Int()
+	value17 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value17
-	value18 = (input.Get("bytesDiscardedOnSend")).Int()
+	value18 = (value.Get("bytesDiscardedOnSend")).Int()
 	out.BytesDiscardedOnSend = value18
 	return &out
 }
@@ -2851,7 +2809,7 @@ type TransportStats struct {
 	TlsGroup                string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TransportStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2893,10 +2851,8 @@ func (_this *TransportStats) JSValue() js.Value {
 }
 
 // TransportStatsFromJS is allocating a new
-// TransportStats object and copy all values from
-// input javascript object
-func TransportStatsFromJS(value js.Wrapper) *TransportStats {
-	input := value.JSValue()
+// TransportStats object and copy all values in the value javascript object.
+func TransportStatsFromJS(value js.Value) *TransportStats {
 	var out TransportStats
 	var (
 		value0  float64                   // javascript: double {timestamp Timestamp timestamp}
@@ -2917,39 +2873,39 @@ func TransportStatsFromJS(value js.Wrapper) *TransportStats {
 		value15 string                    // javascript: DOMString {srtpCipher SrtpCipher srtpCipher}
 		value16 string                    // javascript: DOMString {tlsGroup TlsGroup tlsGroup}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (uint)((input.Get("packetsSent")).Int())
+	value3 = (uint)((value.Get("packetsSent")).Int())
 	out.PacketsSent = value3
-	value4 = (uint)((input.Get("packetsReceived")).Int())
+	value4 = (uint)((value.Get("packetsReceived")).Int())
 	out.PacketsReceived = value4
-	value5 = (input.Get("bytesSent")).Int()
+	value5 = (value.Get("bytesSent")).Int()
 	out.BytesSent = value5
-	value6 = (input.Get("bytesReceived")).Int()
+	value6 = (value.Get("bytesReceived")).Int()
 	out.BytesReceived = value6
-	value7 = (input.Get("rtcpTransportStatsId")).String()
+	value7 = (value.Get("rtcpTransportStatsId")).String()
 	out.RtcpTransportStatsId = value7
-	value8 = webrtc.IceRoleFromJS(input.Get("iceRole"))
+	value8 = webrtc.IceRoleFromJS(value.Get("iceRole"))
 	out.IceRole = value8
-	value9 = webrtc.DtlsTransportStateFromJS(input.Get("dtlsState"))
+	value9 = webrtc.DtlsTransportStateFromJS(value.Get("dtlsState"))
 	out.DtlsState = value9
-	value10 = (input.Get("selectedCandidatePairId")).String()
+	value10 = (value.Get("selectedCandidatePairId")).String()
 	out.SelectedCandidatePairId = value10
-	value11 = (input.Get("localCertificateId")).String()
+	value11 = (value.Get("localCertificateId")).String()
 	out.LocalCertificateId = value11
-	value12 = (input.Get("remoteCertificateId")).String()
+	value12 = (value.Get("remoteCertificateId")).String()
 	out.RemoteCertificateId = value12
-	value13 = (input.Get("tlsVersion")).String()
+	value13 = (value.Get("tlsVersion")).String()
 	out.TlsVersion = value13
-	value14 = (input.Get("dtlsCipher")).String()
+	value14 = (value.Get("dtlsCipher")).String()
 	out.DtlsCipher = value14
-	value15 = (input.Get("srtpCipher")).String()
+	value15 = (value.Get("srtpCipher")).String()
 	out.SrtpCipher = value15
-	value16 = (input.Get("tlsGroup")).String()
+	value16 = (value.Get("tlsGroup")).String()
 	out.TlsGroup = value16
 	return &out
 }
@@ -2969,7 +2925,7 @@ type VideoHandlerStats struct {
 	FramesPerSecond float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoHandlerStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2999,10 +2955,8 @@ func (_this *VideoHandlerStats) JSValue() js.Value {
 }
 
 // VideoHandlerStatsFromJS is allocating a new
-// VideoHandlerStats object and copy all values from
-// input javascript object
-func VideoHandlerStatsFromJS(value js.Wrapper) *VideoHandlerStats {
-	input := value.JSValue()
+// VideoHandlerStats object and copy all values in the value javascript object.
+func VideoHandlerStatsFromJS(value js.Value) *VideoHandlerStats {
 	var out VideoHandlerStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3017,27 +2971,27 @@ func VideoHandlerStatsFromJS(value js.Wrapper) *VideoHandlerStats {
 		value9  uint                // javascript: unsigned long {frameHeight FrameHeight frameHeight}
 		value10 float64             // javascript: double {framesPerSecond FramesPerSecond framesPerSecond}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
 	return &out
 }
@@ -3066,7 +3020,7 @@ type VideoReceiverStats struct {
 	FullFramesLost            uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoReceiverStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3114,10 +3068,8 @@ func (_this *VideoReceiverStats) JSValue() js.Value {
 }
 
 // VideoReceiverStatsFromJS is allocating a new
-// VideoReceiverStats object and copy all values from
-// input javascript object
-func VideoReceiverStatsFromJS(value js.Wrapper) *VideoReceiverStats {
-	input := value.JSValue()
+// VideoReceiverStats object and copy all values in the value javascript object.
+func VideoReceiverStatsFromJS(value js.Value) *VideoReceiverStats {
 	var out VideoReceiverStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3141,45 +3093,45 @@ func VideoReceiverStatsFromJS(value js.Wrapper) *VideoReceiverStats {
 		value18 uint                // javascript: unsigned long {partialFramesLost PartialFramesLost partialFramesLost}
 		value19 uint                // javascript: unsigned long {fullFramesLost FullFramesLost fullFramesLost}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (input.Get("estimatedPlayoutTimestamp")).Float()
+	value11 = (value.Get("estimatedPlayoutTimestamp")).Float()
 	out.EstimatedPlayoutTimestamp = value11
-	value12 = (input.Get("jitterBufferDelay")).Float()
+	value12 = (value.Get("jitterBufferDelay")).Float()
 	out.JitterBufferDelay = value12
-	value13 = (input.Get("jitterBufferEmittedCount")).Int()
+	value13 = (value.Get("jitterBufferEmittedCount")).Int()
 	out.JitterBufferEmittedCount = value13
-	value14 = (uint)((input.Get("framesReceived")).Int())
+	value14 = (uint)((value.Get("framesReceived")).Int())
 	out.FramesReceived = value14
-	value15 = (uint)((input.Get("keyFramesReceived")).Int())
+	value15 = (uint)((value.Get("keyFramesReceived")).Int())
 	out.KeyFramesReceived = value15
-	value16 = (uint)((input.Get("framesDecoded")).Int())
+	value16 = (uint)((value.Get("framesDecoded")).Int())
 	out.FramesDecoded = value16
-	value17 = (uint)((input.Get("framesDropped")).Int())
+	value17 = (uint)((value.Get("framesDropped")).Int())
 	out.FramesDropped = value17
-	value18 = (uint)((input.Get("partialFramesLost")).Int())
+	value18 = (uint)((value.Get("partialFramesLost")).Int())
 	out.PartialFramesLost = value18
-	value19 = (uint)((input.Get("fullFramesLost")).Int())
+	value19 = (uint)((value.Get("fullFramesLost")).Int())
 	out.FullFramesLost = value19
 	return &out
 }
@@ -3203,7 +3155,7 @@ type VideoSenderStats struct {
 	KeyFramesSent   uint
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *VideoSenderStats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3241,10 +3193,8 @@ func (_this *VideoSenderStats) JSValue() js.Value {
 }
 
 // VideoSenderStatsFromJS is allocating a new
-// VideoSenderStats object and copy all values from
-// input javascript object
-func VideoSenderStatsFromJS(value js.Wrapper) *VideoSenderStats {
-	input := value.JSValue()
+// VideoSenderStats object and copy all values in the value javascript object.
+func VideoSenderStatsFromJS(value js.Value) *VideoSenderStats {
 	var out VideoSenderStats
 	var (
 		value0  float64             // javascript: double {timestamp Timestamp timestamp}
@@ -3263,35 +3213,35 @@ func VideoSenderStatsFromJS(value js.Wrapper) *VideoSenderStats {
 		value13 uint                // javascript: unsigned long {hugeFramesSent HugeFramesSent hugeFramesSent}
 		value14 uint                // javascript: unsigned long {keyFramesSent KeyFramesSent keyFramesSent}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = webrtc.StatsTypeFromJS(input.Get("type"))
+	value1 = webrtc.StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
-	value3 = (input.Get("trackIdentifier")).String()
+	value3 = (value.Get("trackIdentifier")).String()
 	out.TrackIdentifier = value3
-	value4 = (input.Get("remoteSource")).Bool()
+	value4 = (value.Get("remoteSource")).Bool()
 	out.RemoteSource = value4
-	value5 = (input.Get("ended")).Bool()
+	value5 = (value.Get("ended")).Bool()
 	out.Ended = value5
-	value6 = (input.Get("kind")).String()
+	value6 = (value.Get("kind")).String()
 	out.Kind = value6
-	value7 = webrtc.PriorityTypeFromJS(input.Get("priority"))
+	value7 = webrtc.PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value7
-	value8 = (uint)((input.Get("frameWidth")).Int())
+	value8 = (uint)((value.Get("frameWidth")).Int())
 	out.FrameWidth = value8
-	value9 = (uint)((input.Get("frameHeight")).Int())
+	value9 = (uint)((value.Get("frameHeight")).Int())
 	out.FrameHeight = value9
-	value10 = (input.Get("framesPerSecond")).Float()
+	value10 = (value.Get("framesPerSecond")).Float()
 	out.FramesPerSecond = value10
-	value11 = (uint)((input.Get("framesCaptured")).Int())
+	value11 = (uint)((value.Get("framesCaptured")).Int())
 	out.FramesCaptured = value11
-	value12 = (uint)((input.Get("framesSent")).Int())
+	value12 = (uint)((value.Get("framesSent")).Int())
 	out.FramesSent = value12
-	value13 = (uint)((input.Get("hugeFramesSent")).Int())
+	value13 = (uint)((value.Get("hugeFramesSent")).Int())
 	out.HugeFramesSent = value13
-	value14 = (uint)((input.Get("keyFramesSent")).Int())
+	value14 = (uint)((value.Get("keyFramesSent")).Int())
 	out.KeyFramesSent = value14
 	return &out
 }

--- a/media/webrtc/webrtc.go
+++ b/media/webrtc/webrtc.go
@@ -7,6 +7,7 @@ package webrtc
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/channel"
@@ -1495,7 +1496,7 @@ type AnswerOptions struct {
 	VoiceActivityDetection bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnswerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1505,15 +1506,13 @@ func (_this *AnswerOptions) JSValue() js.Value {
 }
 
 // AnswerOptionsFromJS is allocating a new
-// AnswerOptions object and copy all values from
-// input javascript object
-func AnswerOptionsFromJS(value js.Wrapper) *AnswerOptions {
-	input := value.JSValue()
+// AnswerOptions object and copy all values in the value javascript object.
+func AnswerOptionsFromJS(value js.Value) *AnswerOptions {
 	var out AnswerOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
 	return &out
 }
@@ -1523,7 +1522,7 @@ type CertificateExpiration struct {
 	Expires int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CertificateExpiration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1533,15 +1532,13 @@ func (_this *CertificateExpiration) JSValue() js.Value {
 }
 
 // CertificateExpirationFromJS is allocating a new
-// CertificateExpiration object and copy all values from
-// input javascript object
-func CertificateExpirationFromJS(value js.Wrapper) *CertificateExpiration {
-	input := value.JSValue()
+// CertificateExpiration object and copy all values in the value javascript object.
+func CertificateExpirationFromJS(value js.Value) *CertificateExpiration {
 	var out CertificateExpiration
 	var (
 		value0 int // javascript: unsigned long long {expires Expires expires}
 	)
-	value0 = (input.Get("expires")).Int()
+	value0 = (value.Get("expires")).Int()
 	out.Expires = value0
 	return &out
 }
@@ -1557,7 +1554,7 @@ type Configuration struct {
 	IceCandidatePoolSize int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Configuration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1587,10 +1584,8 @@ func (_this *Configuration) JSValue() js.Value {
 }
 
 // ConfigurationFromJS is allocating a new
-// Configuration object and copy all values from
-// input javascript object
-func ConfigurationFromJS(value js.Wrapper) *Configuration {
-	input := value.JSValue()
+// Configuration object and copy all values in the value javascript object.
+func ConfigurationFromJS(value js.Value) *Configuration {
 	var out Configuration
 	var (
 		value0 []*IceServer       // javascript: sequence<RTCIceServer> {iceServers IceServers iceServers}
@@ -1601,35 +1596,35 @@ func ConfigurationFromJS(value js.Wrapper) *Configuration {
 		value5 []*Certificate     // javascript: sequence<RTCCertificate> {certificates Certificates certificates}
 		value6 int                // javascript: octet {iceCandidatePoolSize IceCandidatePoolSize iceCandidatePoolSize}
 	)
-	__length0 := input.Get("iceServers").Length()
+	__length0 := value.Get("iceServers").Length()
 	__array0 := make([]*IceServer, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *IceServer
-		__seq_in0 := input.Get("iceServers").Index(__idx0)
+		__seq_in0 := value.Get("iceServers").Index(__idx0)
 		__seq_out0 = IceServerFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.IceServers = value0
-	value1 = IceTransportPolicyFromJS(input.Get("iceTransportPolicy"))
+	value1 = IceTransportPolicyFromJS(value.Get("iceTransportPolicy"))
 	out.IceTransportPolicy = value1
-	value2 = BundlePolicyFromJS(input.Get("bundlePolicy"))
+	value2 = BundlePolicyFromJS(value.Get("bundlePolicy"))
 	out.BundlePolicy = value2
-	value3 = RtcpMuxPolicyFromJS(input.Get("rtcpMuxPolicy"))
+	value3 = RtcpMuxPolicyFromJS(value.Get("rtcpMuxPolicy"))
 	out.RtcpMuxPolicy = value3
-	value4 = (input.Get("peerIdentity")).String()
+	value4 = (value.Get("peerIdentity")).String()
 	out.PeerIdentity = value4
-	__length5 := input.Get("certificates").Length()
+	__length5 := value.Get("certificates").Length()
 	__array5 := make([]*Certificate, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *Certificate
-		__seq_in5 := input.Get("certificates").Index(__idx5)
+		__seq_in5 := value.Get("certificates").Index(__idx5)
 		__seq_out5 = CertificateFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Certificates = value5
-	value6 = (input.Get("iceCandidatePoolSize")).Int()
+	value6 = (value.Get("iceCandidatePoolSize")).Int()
 	out.IceCandidatePoolSize = value6
 	return &out
 }
@@ -1642,7 +1637,7 @@ type DTMFToneChangeEventInit struct {
 	Tone       string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DTMFToneChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1658,10 +1653,8 @@ func (_this *DTMFToneChangeEventInit) JSValue() js.Value {
 }
 
 // DTMFToneChangeEventInitFromJS is allocating a new
-// DTMFToneChangeEventInit object and copy all values from
-// input javascript object
-func DTMFToneChangeEventInitFromJS(value js.Wrapper) *DTMFToneChangeEventInit {
-	input := value.JSValue()
+// DTMFToneChangeEventInit object and copy all values in the value javascript object.
+func DTMFToneChangeEventInitFromJS(value js.Value) *DTMFToneChangeEventInit {
 	var out DTMFToneChangeEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1669,13 +1662,13 @@ func DTMFToneChangeEventInitFromJS(value js.Wrapper) *DTMFToneChangeEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 string // javascript: DOMString {tone Tone tone}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("tone")).String()
+	value3 = (value.Get("tone")).String()
 	out.Tone = value3
 	return &out
 }
@@ -1688,7 +1681,7 @@ type DataChannelEventInit struct {
 	Channel    *DataChannel
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1704,10 +1697,8 @@ func (_this *DataChannelEventInit) JSValue() js.Value {
 }
 
 // DataChannelEventInitFromJS is allocating a new
-// DataChannelEventInit object and copy all values from
-// input javascript object
-func DataChannelEventInitFromJS(value js.Wrapper) *DataChannelEventInit {
-	input := value.JSValue()
+// DataChannelEventInit object and copy all values in the value javascript object.
+func DataChannelEventInitFromJS(value js.Value) *DataChannelEventInit {
 	var out DataChannelEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1715,13 +1706,13 @@ func DataChannelEventInitFromJS(value js.Wrapper) *DataChannelEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *DataChannel // javascript: RTCDataChannel {channel Channel channel}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DataChannelFromJS(input.Get("channel"))
+	value3 = DataChannelFromJS(value.Get("channel"))
 	out.Channel = value3
 	return &out
 }
@@ -1737,7 +1728,7 @@ type DataChannelInit struct {
 	Priority          PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1759,10 +1750,8 @@ func (_this *DataChannelInit) JSValue() js.Value {
 }
 
 // DataChannelInitFromJS is allocating a new
-// DataChannelInit object and copy all values from
-// input javascript object
-func DataChannelInitFromJS(value js.Wrapper) *DataChannelInit {
-	input := value.JSValue()
+// DataChannelInit object and copy all values in the value javascript object.
+func DataChannelInitFromJS(value js.Value) *DataChannelInit {
 	var out DataChannelInit
 	var (
 		value0 bool         // javascript: boolean {ordered Ordered ordered}
@@ -1773,19 +1762,19 @@ func DataChannelInitFromJS(value js.Wrapper) *DataChannelInit {
 		value5 int          // javascript: unsigned short {id Id id}
 		value6 PriorityType // javascript: RTCPriorityType {priority Priority priority}
 	)
-	value0 = (input.Get("ordered")).Bool()
+	value0 = (value.Get("ordered")).Bool()
 	out.Ordered = value0
-	value1 = (input.Get("maxPacketLifeTime")).Int()
+	value1 = (value.Get("maxPacketLifeTime")).Int()
 	out.MaxPacketLifeTime = value1
-	value2 = (input.Get("maxRetransmits")).Int()
+	value2 = (value.Get("maxRetransmits")).Int()
 	out.MaxRetransmits = value2
-	value3 = (input.Get("protocol")).String()
+	value3 = (value.Get("protocol")).String()
 	out.Protocol = value3
-	value4 = (input.Get("negotiated")).Bool()
+	value4 = (value.Get("negotiated")).Bool()
 	out.Negotiated = value4
-	value5 = (input.Get("id")).Int()
+	value5 = (value.Get("id")).Int()
 	out.Id = value5
-	value6 = PriorityTypeFromJS(input.Get("priority"))
+	value6 = PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value6
 	return &out
 }
@@ -1796,7 +1785,7 @@ type DtlsFingerprint struct {
 	Value     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DtlsFingerprint) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1808,18 +1797,16 @@ func (_this *DtlsFingerprint) JSValue() js.Value {
 }
 
 // DtlsFingerprintFromJS is allocating a new
-// DtlsFingerprint object and copy all values from
-// input javascript object
-func DtlsFingerprintFromJS(value js.Wrapper) *DtlsFingerprint {
-	input := value.JSValue()
+// DtlsFingerprint object and copy all values in the value javascript object.
+func DtlsFingerprintFromJS(value js.Value) *DtlsFingerprint {
 	var out DtlsFingerprint
 	var (
 		value0 string // javascript: DOMString {algorithm Algorithm algorithm}
 		value1 string // javascript: DOMString {value Value value}
 	)
-	value0 = (input.Get("algorithm")).String()
+	value0 = (value.Get("algorithm")).String()
 	out.Algorithm = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -1832,7 +1819,7 @@ type ErrorEventInit struct {
 	Error      *Error
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1848,10 +1835,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1859,14 +1844,14 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Error // javascript: RTCError {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("error").Type() != js.TypeNull && input.Get("error").Type() != js.TypeUndefined {
-		value3 = ErrorFromJS(input.Get("error"))
+	if value.Get("error").Type() != js.TypeNull && value.Get("error").Type() != js.TypeUndefined {
+		value3 = ErrorFromJS(value.Get("error"))
 	}
 	out.Error = value3
 	return &out
@@ -1880,7 +1865,7 @@ type IceCandidateInit struct {
 	UsernameFragment string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1908,10 +1893,8 @@ func (_this *IceCandidateInit) JSValue() js.Value {
 }
 
 // IceCandidateInitFromJS is allocating a new
-// IceCandidateInit object and copy all values from
-// input javascript object
-func IceCandidateInitFromJS(value js.Wrapper) *IceCandidateInit {
-	input := value.JSValue()
+// IceCandidateInit object and copy all values in the value javascript object.
+func IceCandidateInitFromJS(value js.Value) *IceCandidateInit {
 	var out IceCandidateInit
 	var (
 		value0 string  // javascript: DOMString {candidate Candidate candidate}
@@ -1919,19 +1902,19 @@ func IceCandidateInitFromJS(value js.Wrapper) *IceCandidateInit {
 		value2 *int    // javascript: unsigned short {sdpMLineIndex SdpMLineIndex sdpMLineIndex}
 		value3 string  // javascript: DOMString {usernameFragment UsernameFragment usernameFragment}
 	)
-	value0 = (input.Get("candidate")).String()
+	value0 = (value.Get("candidate")).String()
 	out.Candidate = value0
-	if input.Get("sdpMid").Type() != js.TypeNull && input.Get("sdpMid").Type() != js.TypeUndefined {
-		__tmp := (input.Get("sdpMid")).String()
+	if value.Get("sdpMid").Type() != js.TypeNull && value.Get("sdpMid").Type() != js.TypeUndefined {
+		__tmp := (value.Get("sdpMid")).String()
 		value1 = &__tmp
 	}
 	out.SdpMid = value1
-	if input.Get("sdpMLineIndex").Type() != js.TypeNull && input.Get("sdpMLineIndex").Type() != js.TypeUndefined {
-		__tmp := (input.Get("sdpMLineIndex")).Int()
+	if value.Get("sdpMLineIndex").Type() != js.TypeNull && value.Get("sdpMLineIndex").Type() != js.TypeUndefined {
+		__tmp := (value.Get("sdpMLineIndex")).Int()
 		value2 = &__tmp
 	}
 	out.SdpMLineIndex = value2
-	value3 = (input.Get("usernameFragment")).String()
+	value3 = (value.Get("usernameFragment")).String()
 	out.UsernameFragment = value3
 	return &out
 }
@@ -1942,7 +1925,7 @@ type IceCandidatePair struct {
 	Remote *IceCandidate
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidatePair) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1954,18 +1937,16 @@ func (_this *IceCandidatePair) JSValue() js.Value {
 }
 
 // IceCandidatePairFromJS is allocating a new
-// IceCandidatePair object and copy all values from
-// input javascript object
-func IceCandidatePairFromJS(value js.Wrapper) *IceCandidatePair {
-	input := value.JSValue()
+// IceCandidatePair object and copy all values in the value javascript object.
+func IceCandidatePairFromJS(value js.Value) *IceCandidatePair {
 	var out IceCandidatePair
 	var (
 		value0 *IceCandidate // javascript: RTCIceCandidate {local Local local}
 		value1 *IceCandidate // javascript: RTCIceCandidate {remote Remote remote}
 	)
-	value0 = IceCandidateFromJS(input.Get("local"))
+	value0 = IceCandidateFromJS(value.Get("local"))
 	out.Local = value0
-	value1 = IceCandidateFromJS(input.Get("remote"))
+	value1 = IceCandidateFromJS(value.Get("remote"))
 	out.Remote = value1
 	return &out
 }
@@ -1976,7 +1957,7 @@ type IceParameters struct {
 	Password         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1988,18 +1969,16 @@ func (_this *IceParameters) JSValue() js.Value {
 }
 
 // IceParametersFromJS is allocating a new
-// IceParameters object and copy all values from
-// input javascript object
-func IceParametersFromJS(value js.Wrapper) *IceParameters {
-	input := value.JSValue()
+// IceParameters object and copy all values in the value javascript object.
+func IceParametersFromJS(value js.Value) *IceParameters {
 	var out IceParameters
 	var (
 		value0 string // javascript: DOMString {usernameFragment UsernameFragment usernameFragment}
 		value1 string // javascript: DOMString {password Password password}
 	)
-	value0 = (input.Get("usernameFragment")).String()
+	value0 = (value.Get("usernameFragment")).String()
 	out.UsernameFragment = value0
-	value1 = (input.Get("password")).String()
+	value1 = (value.Get("password")).String()
 	out.Password = value1
 	return &out
 }
@@ -2012,7 +1991,7 @@ type IceServer struct {
 	CredentialType IceCredentialType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceServer) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2028,10 +2007,8 @@ func (_this *IceServer) JSValue() js.Value {
 }
 
 // IceServerFromJS is allocating a new
-// IceServer object and copy all values from
-// input javascript object
-func IceServerFromJS(value js.Wrapper) *IceServer {
-	input := value.JSValue()
+// IceServer object and copy all values in the value javascript object.
+func IceServerFromJS(value js.Value) *IceServer {
 	var out IceServer
 	var (
 		value0 *Union            // javascript: Union {urls Urls urls}
@@ -2039,13 +2016,13 @@ func IceServerFromJS(value js.Wrapper) *IceServer {
 		value2 *Union            // javascript: Union {credential Credential credential}
 		value3 IceCredentialType // javascript: RTCIceCredentialType {credentialType CredentialType credentialType}
 	)
-	value0 = UnionFromJS(input.Get("urls"))
+	value0 = UnionFromJS(value.Get("urls"))
 	out.Urls = value0
-	value1 = (input.Get("username")).String()
+	value1 = (value.Get("username")).String()
 	out.Username = value1
-	value2 = UnionFromJS(input.Get("credential"))
+	value2 = UnionFromJS(value.Get("credential"))
 	out.Credential = value2
-	value3 = IceCredentialTypeFromJS(input.Get("credentialType"))
+	value3 = IceCredentialTypeFromJS(value.Get("credentialType"))
 	out.CredentialType = value3
 	return &out
 }
@@ -2056,7 +2033,7 @@ type OAuthCredential struct {
 	AccessToken string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OAuthCredential) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2068,18 +2045,16 @@ func (_this *OAuthCredential) JSValue() js.Value {
 }
 
 // OAuthCredentialFromJS is allocating a new
-// OAuthCredential object and copy all values from
-// input javascript object
-func OAuthCredentialFromJS(value js.Wrapper) *OAuthCredential {
-	input := value.JSValue()
+// OAuthCredential object and copy all values in the value javascript object.
+func OAuthCredentialFromJS(value js.Value) *OAuthCredential {
 	var out OAuthCredential
 	var (
 		value0 string // javascript: DOMString {macKey MacKey macKey}
 		value1 string // javascript: DOMString {accessToken AccessToken accessToken}
 	)
-	value0 = (input.Get("macKey")).String()
+	value0 = (value.Get("macKey")).String()
 	out.MacKey = value0
-	value1 = (input.Get("accessToken")).String()
+	value1 = (value.Get("accessToken")).String()
 	out.AccessToken = value1
 	return &out
 }
@@ -2089,7 +2064,7 @@ type OfferAnswerOptions struct {
 	VoiceActivityDetection bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfferAnswerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2099,15 +2074,13 @@ func (_this *OfferAnswerOptions) JSValue() js.Value {
 }
 
 // OfferAnswerOptionsFromJS is allocating a new
-// OfferAnswerOptions object and copy all values from
-// input javascript object
-func OfferAnswerOptionsFromJS(value js.Wrapper) *OfferAnswerOptions {
-	input := value.JSValue()
+// OfferAnswerOptions object and copy all values in the value javascript object.
+func OfferAnswerOptionsFromJS(value js.Value) *OfferAnswerOptions {
 	var out OfferAnswerOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
 	return &out
 }
@@ -2120,7 +2093,7 @@ type OfferOptions struct {
 	OfferToReceiveVideo    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfferOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2136,10 +2109,8 @@ func (_this *OfferOptions) JSValue() js.Value {
 }
 
 // OfferOptionsFromJS is allocating a new
-// OfferOptions object and copy all values from
-// input javascript object
-func OfferOptionsFromJS(value js.Wrapper) *OfferOptions {
-	input := value.JSValue()
+// OfferOptions object and copy all values in the value javascript object.
+func OfferOptionsFromJS(value js.Value) *OfferOptions {
 	var out OfferOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
@@ -2147,13 +2118,13 @@ func OfferOptionsFromJS(value js.Wrapper) *OfferOptions {
 		value2 bool // javascript: boolean {offerToReceiveAudio OfferToReceiveAudio offerToReceiveAudio}
 		value3 bool // javascript: boolean {offerToReceiveVideo OfferToReceiveVideo offerToReceiveVideo}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
-	value1 = (input.Get("iceRestart")).Bool()
+	value1 = (value.Get("iceRestart")).Bool()
 	out.IceRestart = value1
-	value2 = (input.Get("offerToReceiveAudio")).Bool()
+	value2 = (value.Get("offerToReceiveAudio")).Bool()
 	out.OfferToReceiveAudio = value2
-	value3 = (input.Get("offerToReceiveVideo")).Bool()
+	value3 = (value.Get("offerToReceiveVideo")).Bool()
 	out.OfferToReceiveVideo = value3
 	return &out
 }
@@ -2169,7 +2140,7 @@ type PeerConnectionIceErrorEventInit struct {
 	StatusText    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionIceErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2191,10 +2162,8 @@ func (_this *PeerConnectionIceErrorEventInit) JSValue() js.Value {
 }
 
 // PeerConnectionIceErrorEventInitFromJS is allocating a new
-// PeerConnectionIceErrorEventInit object and copy all values from
-// input javascript object
-func PeerConnectionIceErrorEventInitFromJS(value js.Wrapper) *PeerConnectionIceErrorEventInit {
-	input := value.JSValue()
+// PeerConnectionIceErrorEventInit object and copy all values in the value javascript object.
+func PeerConnectionIceErrorEventInitFromJS(value js.Value) *PeerConnectionIceErrorEventInit {
 	var out PeerConnectionIceErrorEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -2205,19 +2174,19 @@ func PeerConnectionIceErrorEventInitFromJS(value js.Wrapper) *PeerConnectionIceE
 		value5 int    // javascript: unsigned short {errorCode ErrorCode errorCode}
 		value6 string // javascript: USVString {statusText StatusText statusText}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("hostCandidate")).String()
+	value3 = (value.Get("hostCandidate")).String()
 	out.HostCandidate = value3
-	value4 = (input.Get("url")).String()
+	value4 = (value.Get("url")).String()
 	out.Url = value4
-	value5 = (input.Get("errorCode")).Int()
+	value5 = (value.Get("errorCode")).Int()
 	out.ErrorCode = value5
-	value6 = (input.Get("statusText")).String()
+	value6 = (value.Get("statusText")).String()
 	out.StatusText = value6
 	return &out
 }
@@ -2231,7 +2200,7 @@ type PeerConnectionIceEventInit struct {
 	Url        *string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionIceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2255,10 +2224,8 @@ func (_this *PeerConnectionIceEventInit) JSValue() js.Value {
 }
 
 // PeerConnectionIceEventInitFromJS is allocating a new
-// PeerConnectionIceEventInit object and copy all values from
-// input javascript object
-func PeerConnectionIceEventInitFromJS(value js.Wrapper) *PeerConnectionIceEventInit {
-	input := value.JSValue()
+// PeerConnectionIceEventInit object and copy all values in the value javascript object.
+func PeerConnectionIceEventInitFromJS(value js.Value) *PeerConnectionIceEventInit {
 	var out PeerConnectionIceEventInit
 	var (
 		value0 bool          // javascript: boolean {bubbles Bubbles bubbles}
@@ -2267,18 +2234,18 @@ func PeerConnectionIceEventInitFromJS(value js.Wrapper) *PeerConnectionIceEventI
 		value3 *IceCandidate // javascript: RTCIceCandidate {candidate Candidate candidate}
 		value4 *string       // javascript: DOMString {url Url url}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("candidate").Type() != js.TypeNull && input.Get("candidate").Type() != js.TypeUndefined {
-		value3 = IceCandidateFromJS(input.Get("candidate"))
+	if value.Get("candidate").Type() != js.TypeNull && value.Get("candidate").Type() != js.TypeUndefined {
+		value3 = IceCandidateFromJS(value.Get("candidate"))
 	}
 	out.Candidate = value3
-	if input.Get("url").Type() != js.TypeNull && input.Get("url").Type() != js.TypeUndefined {
-		__tmp := (input.Get("url")).String()
+	if value.Get("url").Type() != js.TypeNull && value.Get("url").Type() != js.TypeUndefined {
+		__tmp := (value.Get("url")).String()
 		value4 = &__tmp
 	}
 	out.Url = value4
@@ -2291,7 +2258,7 @@ type RtcpParameters struct {
 	ReducedSize bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtcpParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2303,18 +2270,16 @@ func (_this *RtcpParameters) JSValue() js.Value {
 }
 
 // RtcpParametersFromJS is allocating a new
-// RtcpParameters object and copy all values from
-// input javascript object
-func RtcpParametersFromJS(value js.Wrapper) *RtcpParameters {
-	input := value.JSValue()
+// RtcpParameters object and copy all values in the value javascript object.
+func RtcpParametersFromJS(value js.Value) *RtcpParameters {
 	var out RtcpParameters
 	var (
 		value0 string // javascript: DOMString {cname Cname cname}
 		value1 bool   // javascript: boolean {reducedSize ReducedSize reducedSize}
 	)
-	value0 = (input.Get("cname")).String()
+	value0 = (value.Get("cname")).String()
 	out.Cname = value0
-	value1 = (input.Get("reducedSize")).Bool()
+	value1 = (value.Get("reducedSize")).Bool()
 	out.ReducedSize = value1
 	return &out
 }
@@ -2325,7 +2290,7 @@ type RtpCapabilities struct {
 	HeaderExtensions []*RtpHeaderExtensionCapability
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCapabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2345,30 +2310,28 @@ func (_this *RtpCapabilities) JSValue() js.Value {
 }
 
 // RtpCapabilitiesFromJS is allocating a new
-// RtpCapabilities object and copy all values from
-// input javascript object
-func RtpCapabilitiesFromJS(value js.Wrapper) *RtpCapabilities {
-	input := value.JSValue()
+// RtpCapabilities object and copy all values in the value javascript object.
+func RtpCapabilitiesFromJS(value js.Value) *RtpCapabilities {
 	var out RtpCapabilities
 	var (
 		value0 []*RtpCodecCapability           // javascript: sequence<RTCRtpCodecCapability> {codecs Codecs codecs}
 		value1 []*RtpHeaderExtensionCapability // javascript: sequence<RTCRtpHeaderExtensionCapability> {headerExtensions HeaderExtensions headerExtensions}
 	)
-	__length0 := input.Get("codecs").Length()
+	__length0 := value.Get("codecs").Length()
 	__array0 := make([]*RtpCodecCapability, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpCodecCapability
-		__seq_in0 := input.Get("codecs").Index(__idx0)
+		__seq_in0 := value.Get("codecs").Index(__idx0)
 		__seq_out0 = RtpCodecCapabilityFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Codecs = value0
-	__length1 := input.Get("headerExtensions").Length()
+	__length1 := value.Get("headerExtensions").Length()
 	__array1 := make([]*RtpHeaderExtensionCapability, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *RtpHeaderExtensionCapability
-		__seq_in1 := input.Get("headerExtensions").Index(__idx1)
+		__seq_in1 := value.Get("headerExtensions").Index(__idx1)
 		__seq_out1 = RtpHeaderExtensionCapabilityFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -2385,7 +2348,7 @@ type RtpCodecCapability struct {
 	SdpFmtpLine string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodecCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2401,10 +2364,8 @@ func (_this *RtpCodecCapability) JSValue() js.Value {
 }
 
 // RtpCodecCapabilityFromJS is allocating a new
-// RtpCodecCapability object and copy all values from
-// input javascript object
-func RtpCodecCapabilityFromJS(value js.Wrapper) *RtpCodecCapability {
-	input := value.JSValue()
+// RtpCodecCapability object and copy all values in the value javascript object.
+func RtpCodecCapabilityFromJS(value js.Value) *RtpCodecCapability {
 	var out RtpCodecCapability
 	var (
 		value0 string // javascript: DOMString {mimeType MimeType mimeType}
@@ -2412,13 +2373,13 @@ func RtpCodecCapabilityFromJS(value js.Wrapper) *RtpCodecCapability {
 		value2 int    // javascript: unsigned short {channels Channels channels}
 		value3 string // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 	)
-	value0 = (input.Get("mimeType")).String()
+	value0 = (value.Get("mimeType")).String()
 	out.MimeType = value0
-	value1 = (uint)((input.Get("clockRate")).Int())
+	value1 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value1
-	value2 = (input.Get("channels")).Int()
+	value2 = (value.Get("channels")).Int()
 	out.Channels = value2
-	value3 = (input.Get("sdpFmtpLine")).String()
+	value3 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value3
 	return &out
 }
@@ -2432,7 +2393,7 @@ type RtpCodecParameters struct {
 	SdpFmtpLine string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodecParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2450,10 +2411,8 @@ func (_this *RtpCodecParameters) JSValue() js.Value {
 }
 
 // RtpCodecParametersFromJS is allocating a new
-// RtpCodecParameters object and copy all values from
-// input javascript object
-func RtpCodecParametersFromJS(value js.Wrapper) *RtpCodecParameters {
-	input := value.JSValue()
+// RtpCodecParameters object and copy all values in the value javascript object.
+func RtpCodecParametersFromJS(value js.Value) *RtpCodecParameters {
 	var out RtpCodecParameters
 	var (
 		value0 int    // javascript: octet {payloadType PayloadType payloadType}
@@ -2462,15 +2421,15 @@ func RtpCodecParametersFromJS(value js.Wrapper) *RtpCodecParameters {
 		value3 int    // javascript: unsigned short {channels Channels channels}
 		value4 string // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 	)
-	value0 = (input.Get("payloadType")).Int()
+	value0 = (value.Get("payloadType")).Int()
 	out.PayloadType = value0
-	value1 = (input.Get("mimeType")).String()
+	value1 = (value.Get("mimeType")).String()
 	out.MimeType = value1
-	value2 = (uint)((input.Get("clockRate")).Int())
+	value2 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value2
-	value3 = (input.Get("channels")).Int()
+	value3 = (value.Get("channels")).Int()
 	out.Channels = value3
-	value4 = (input.Get("sdpFmtpLine")).String()
+	value4 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value4
 	return &out
 }
@@ -2480,7 +2439,7 @@ type RtpCodingParameters struct {
 	Rid string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2490,15 +2449,13 @@ func (_this *RtpCodingParameters) JSValue() js.Value {
 }
 
 // RtpCodingParametersFromJS is allocating a new
-// RtpCodingParameters object and copy all values from
-// input javascript object
-func RtpCodingParametersFromJS(value js.Wrapper) *RtpCodingParameters {
-	input := value.JSValue()
+// RtpCodingParameters object and copy all values in the value javascript object.
+func RtpCodingParametersFromJS(value js.Value) *RtpCodingParameters {
 	var out RtpCodingParameters
 	var (
 		value0 string // javascript: DOMString {rid Rid rid}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
 	return &out
 }
@@ -2510,7 +2467,7 @@ type RtpContributingSource struct {
 	AudioLevel float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpContributingSource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2524,21 +2481,19 @@ func (_this *RtpContributingSource) JSValue() js.Value {
 }
 
 // RtpContributingSourceFromJS is allocating a new
-// RtpContributingSource object and copy all values from
-// input javascript object
-func RtpContributingSourceFromJS(value js.Wrapper) *RtpContributingSource {
-	input := value.JSValue()
+// RtpContributingSource object and copy all values in the value javascript object.
+func RtpContributingSourceFromJS(value js.Value) *RtpContributingSource {
 	var out RtpContributingSource
 	var (
 		value0 float64 // javascript: double {timestamp Timestamp timestamp}
 		value1 uint    // javascript: unsigned long {source Source source}
 		value2 float64 // javascript: double {audioLevel AudioLevel audioLevel}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = (uint)((input.Get("source")).Int())
+	value1 = (uint)((value.Get("source")).Int())
 	out.Source = value1
-	value2 = (input.Get("audioLevel")).Float()
+	value2 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value2
 	return &out
 }
@@ -2548,7 +2503,7 @@ type RtpDecodingParameters struct {
 	Rid string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpDecodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2558,15 +2513,13 @@ func (_this *RtpDecodingParameters) JSValue() js.Value {
 }
 
 // RtpDecodingParametersFromJS is allocating a new
-// RtpDecodingParameters object and copy all values from
-// input javascript object
-func RtpDecodingParametersFromJS(value js.Wrapper) *RtpDecodingParameters {
-	input := value.JSValue()
+// RtpDecodingParameters object and copy all values in the value javascript object.
+func RtpDecodingParametersFromJS(value js.Value) *RtpDecodingParameters {
 	var out RtpDecodingParameters
 	var (
 		value0 string // javascript: DOMString {rid Rid rid}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
 	return &out
 }
@@ -2584,7 +2537,7 @@ type RtpEncodingParameters struct {
 	NetworkPriority       PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpEncodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2610,10 +2563,8 @@ func (_this *RtpEncodingParameters) JSValue() js.Value {
 }
 
 // RtpEncodingParametersFromJS is allocating a new
-// RtpEncodingParameters object and copy all values from
-// input javascript object
-func RtpEncodingParametersFromJS(value js.Wrapper) *RtpEncodingParameters {
-	input := value.JSValue()
+// RtpEncodingParameters object and copy all values in the value javascript object.
+func RtpEncodingParametersFromJS(value js.Value) *RtpEncodingParameters {
 	var out RtpEncodingParameters
 	var (
 		value0 string       // javascript: DOMString {rid Rid rid}
@@ -2626,23 +2577,23 @@ func RtpEncodingParametersFromJS(value js.Wrapper) *RtpEncodingParameters {
 		value7 float64      // javascript: double {scaleResolutionDownBy ScaleResolutionDownBy scaleResolutionDownBy}
 		value8 PriorityType // javascript: RTCPriorityType {networkPriority NetworkPriority networkPriority}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
-	value1 = (input.Get("codecPayloadType")).Int()
+	value1 = (value.Get("codecPayloadType")).Int()
 	out.CodecPayloadType = value1
-	value2 = DtxStatusFromJS(input.Get("dtx"))
+	value2 = DtxStatusFromJS(value.Get("dtx"))
 	out.Dtx = value2
-	value3 = (input.Get("active")).Bool()
+	value3 = (value.Get("active")).Bool()
 	out.Active = value3
-	value4 = (uint)((input.Get("ptime")).Int())
+	value4 = (uint)((value.Get("ptime")).Int())
 	out.Ptime = value4
-	value5 = (uint)((input.Get("maxBitrate")).Int())
+	value5 = (uint)((value.Get("maxBitrate")).Int())
 	out.MaxBitrate = value5
-	value6 = (input.Get("maxFramerate")).Float()
+	value6 = (value.Get("maxFramerate")).Float()
 	out.MaxFramerate = value6
-	value7 = (input.Get("scaleResolutionDownBy")).Float()
+	value7 = (value.Get("scaleResolutionDownBy")).Float()
 	out.ScaleResolutionDownBy = value7
-	value8 = PriorityTypeFromJS(input.Get("networkPriority"))
+	value8 = PriorityTypeFromJS(value.Get("networkPriority"))
 	out.NetworkPriority = value8
 	return &out
 }
@@ -2652,7 +2603,7 @@ type RtpHeaderExtensionCapability struct {
 	Uri string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpHeaderExtensionCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2662,15 +2613,13 @@ func (_this *RtpHeaderExtensionCapability) JSValue() js.Value {
 }
 
 // RtpHeaderExtensionCapabilityFromJS is allocating a new
-// RtpHeaderExtensionCapability object and copy all values from
-// input javascript object
-func RtpHeaderExtensionCapabilityFromJS(value js.Wrapper) *RtpHeaderExtensionCapability {
-	input := value.JSValue()
+// RtpHeaderExtensionCapability object and copy all values in the value javascript object.
+func RtpHeaderExtensionCapabilityFromJS(value js.Value) *RtpHeaderExtensionCapability {
 	var out RtpHeaderExtensionCapability
 	var (
 		value0 string // javascript: DOMString {uri Uri uri}
 	)
-	value0 = (input.Get("uri")).String()
+	value0 = (value.Get("uri")).String()
 	out.Uri = value0
 	return &out
 }
@@ -2682,7 +2631,7 @@ type RtpHeaderExtensionParameters struct {
 	Encrypted bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpHeaderExtensionParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2696,21 +2645,19 @@ func (_this *RtpHeaderExtensionParameters) JSValue() js.Value {
 }
 
 // RtpHeaderExtensionParametersFromJS is allocating a new
-// RtpHeaderExtensionParameters object and copy all values from
-// input javascript object
-func RtpHeaderExtensionParametersFromJS(value js.Wrapper) *RtpHeaderExtensionParameters {
-	input := value.JSValue()
+// RtpHeaderExtensionParameters object and copy all values in the value javascript object.
+func RtpHeaderExtensionParametersFromJS(value js.Value) *RtpHeaderExtensionParameters {
 	var out RtpHeaderExtensionParameters
 	var (
 		value0 string // javascript: DOMString {uri Uri uri}
 		value1 int    // javascript: unsigned short {id Id id}
 		value2 bool   // javascript: boolean {encrypted Encrypted encrypted}
 	)
-	value0 = (input.Get("uri")).String()
+	value0 = (value.Get("uri")).String()
 	out.Uri = value0
-	value1 = (input.Get("id")).Int()
+	value1 = (value.Get("id")).Int()
 	out.Id = value1
-	value2 = (input.Get("encrypted")).Bool()
+	value2 = (value.Get("encrypted")).Bool()
 	out.Encrypted = value2
 	return &out
 }
@@ -2722,7 +2669,7 @@ type RtpParameters struct {
 	Codecs           []*RtpCodecParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2744,33 +2691,31 @@ func (_this *RtpParameters) JSValue() js.Value {
 }
 
 // RtpParametersFromJS is allocating a new
-// RtpParameters object and copy all values from
-// input javascript object
-func RtpParametersFromJS(value js.Wrapper) *RtpParameters {
-	input := value.JSValue()
+// RtpParameters object and copy all values in the value javascript object.
+func RtpParametersFromJS(value js.Value) *RtpParameters {
 	var out RtpParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
 		value1 *RtcpParameters                 // javascript: RTCRtcpParameters {rtcp Rtcp rtcp}
 		value2 []*RtpCodecParameters           // javascript: sequence<RTCRtpCodecParameters> {codecs Codecs codecs}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -2787,7 +2732,7 @@ type RtpReceiveParameters struct {
 	Encodings        []*RtpDecodingParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpReceiveParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2815,10 +2760,8 @@ func (_this *RtpReceiveParameters) JSValue() js.Value {
 }
 
 // RtpReceiveParametersFromJS is allocating a new
-// RtpReceiveParameters object and copy all values from
-// input javascript object
-func RtpReceiveParametersFromJS(value js.Wrapper) *RtpReceiveParameters {
-	input := value.JSValue()
+// RtpReceiveParameters object and copy all values in the value javascript object.
+func RtpReceiveParametersFromJS(value js.Value) *RtpReceiveParameters {
 	var out RtpReceiveParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
@@ -2826,33 +2769,33 @@ func RtpReceiveParametersFromJS(value js.Wrapper) *RtpReceiveParameters {
 		value2 []*RtpCodecParameters           // javascript: sequence<RTCRtpCodecParameters> {codecs Codecs codecs}
 		value3 []*RtpDecodingParameters        // javascript: sequence<RTCRtpDecodingParameters> {encodings Encodings encodings}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Codecs = value2
-	__length3 := input.Get("encodings").Length()
+	__length3 := value.Get("encodings").Length()
 	__array3 := make([]*RtpDecodingParameters, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *RtpDecodingParameters
-		__seq_in3 := input.Get("encodings").Index(__idx3)
+		__seq_in3 := value.Get("encodings").Index(__idx3)
 		__seq_out3 = RtpDecodingParametersFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -2872,7 +2815,7 @@ type RtpSendParameters struct {
 	Priority              PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpSendParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2906,10 +2849,8 @@ func (_this *RtpSendParameters) JSValue() js.Value {
 }
 
 // RtpSendParametersFromJS is allocating a new
-// RtpSendParameters object and copy all values from
-// input javascript object
-func RtpSendParametersFromJS(value js.Wrapper) *RtpSendParameters {
-	input := value.JSValue()
+// RtpSendParameters object and copy all values in the value javascript object.
+func RtpSendParametersFromJS(value js.Value) *RtpSendParameters {
 	var out RtpSendParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
@@ -2920,43 +2861,43 @@ func RtpSendParametersFromJS(value js.Wrapper) *RtpSendParameters {
 		value5 DegradationPreference           // javascript: RTCDegradationPreference {degradationPreference DegradationPreference degradationPreference}
 		value6 PriorityType                    // javascript: RTCPriorityType {priority Priority priority}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Codecs = value2
-	value3 = (input.Get("transactionId")).String()
+	value3 = (value.Get("transactionId")).String()
 	out.TransactionId = value3
-	__length4 := input.Get("encodings").Length()
+	__length4 := value.Get("encodings").Length()
 	__array4 := make([]*RtpEncodingParameters, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *RtpEncodingParameters
-		__seq_in4 := input.Get("encodings").Index(__idx4)
+		__seq_in4 := value.Get("encodings").Index(__idx4)
 		__seq_out4 = RtpEncodingParametersFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Encodings = value4
-	value5 = DegradationPreferenceFromJS(input.Get("degradationPreference"))
+	value5 = DegradationPreferenceFromJS(value.Get("degradationPreference"))
 	out.DegradationPreference = value5
-	value6 = PriorityTypeFromJS(input.Get("priority"))
+	value6 = PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value6
 	return &out
 }
@@ -2969,7 +2910,7 @@ type RtpSynchronizationSource struct {
 	VoiceActivityFlag bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpSynchronizationSource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2985,10 +2926,8 @@ func (_this *RtpSynchronizationSource) JSValue() js.Value {
 }
 
 // RtpSynchronizationSourceFromJS is allocating a new
-// RtpSynchronizationSource object and copy all values from
-// input javascript object
-func RtpSynchronizationSourceFromJS(value js.Wrapper) *RtpSynchronizationSource {
-	input := value.JSValue()
+// RtpSynchronizationSource object and copy all values in the value javascript object.
+func RtpSynchronizationSourceFromJS(value js.Value) *RtpSynchronizationSource {
 	var out RtpSynchronizationSource
 	var (
 		value0 float64 // javascript: double {timestamp Timestamp timestamp}
@@ -2996,13 +2935,13 @@ func RtpSynchronizationSourceFromJS(value js.Wrapper) *RtpSynchronizationSource 
 		value2 float64 // javascript: double {audioLevel AudioLevel audioLevel}
 		value3 bool    // javascript: boolean {voiceActivityFlag VoiceActivityFlag voiceActivityFlag}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = (uint)((input.Get("source")).Int())
+	value1 = (uint)((value.Get("source")).Int())
 	out.Source = value1
-	value2 = (input.Get("audioLevel")).Float()
+	value2 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value2
-	value3 = (input.Get("voiceActivityFlag")).Bool()
+	value3 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value3
 	return &out
 }
@@ -3014,7 +2953,7 @@ type RtpTransceiverInit struct {
 	SendEncodings []*RtpEncodingParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpTransceiverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3036,33 +2975,31 @@ func (_this *RtpTransceiverInit) JSValue() js.Value {
 }
 
 // RtpTransceiverInitFromJS is allocating a new
-// RtpTransceiverInit object and copy all values from
-// input javascript object
-func RtpTransceiverInitFromJS(value js.Wrapper) *RtpTransceiverInit {
-	input := value.JSValue()
+// RtpTransceiverInit object and copy all values in the value javascript object.
+func RtpTransceiverInitFromJS(value js.Value) *RtpTransceiverInit {
 	var out RtpTransceiverInit
 	var (
 		value0 RtpTransceiverDirection  // javascript: RTCRtpTransceiverDirection {direction Direction direction}
 		value1 []*local.MediaStream     // javascript: sequence<MediaStream> {streams Streams streams}
 		value2 []*RtpEncodingParameters // javascript: sequence<RTCRtpEncodingParameters> {sendEncodings SendEncodings sendEncodings}
 	)
-	value0 = RtpTransceiverDirectionFromJS(input.Get("direction"))
+	value0 = RtpTransceiverDirectionFromJS(value.Get("direction"))
 	out.Direction = value0
-	__length1 := input.Get("streams").Length()
+	__length1 := value.Get("streams").Length()
 	__array1 := make([]*local.MediaStream, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *local.MediaStream
-		__seq_in1 := input.Get("streams").Index(__idx1)
+		__seq_in1 := value.Get("streams").Index(__idx1)
 		__seq_out1 = local.MediaStreamFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.Streams = value1
-	__length2 := input.Get("sendEncodings").Length()
+	__length2 := value.Get("sendEncodings").Length()
 	__array2 := make([]*RtpEncodingParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpEncodingParameters
-		__seq_in2 := input.Get("sendEncodings").Index(__idx2)
+		__seq_in2 := value.Get("sendEncodings").Index(__idx2)
 		__seq_out2 = RtpEncodingParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -3077,7 +3014,7 @@ type SessionDescriptionInit struct {
 	Sdp  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SessionDescriptionInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3089,18 +3026,16 @@ func (_this *SessionDescriptionInit) JSValue() js.Value {
 }
 
 // SessionDescriptionInitFromJS is allocating a new
-// SessionDescriptionInit object and copy all values from
-// input javascript object
-func SessionDescriptionInitFromJS(value js.Wrapper) *SessionDescriptionInit {
-	input := value.JSValue()
+// SessionDescriptionInit object and copy all values in the value javascript object.
+func SessionDescriptionInitFromJS(value js.Value) *SessionDescriptionInit {
 	var out SessionDescriptionInit
 	var (
 		value0 SdpType // javascript: RTCSdpType {type Type _type}
 		value1 string  // javascript: DOMString {sdp Sdp sdp}
 	)
-	value0 = SdpTypeFromJS(input.Get("type"))
+	value0 = SdpTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = (input.Get("sdp")).String()
+	value1 = (value.Get("sdp")).String()
 	out.Sdp = value1
 	return &out
 }
@@ -3112,7 +3047,7 @@ type Stats struct {
 	Id        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Stats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3126,21 +3061,19 @@ func (_this *Stats) JSValue() js.Value {
 }
 
 // StatsFromJS is allocating a new
-// Stats object and copy all values from
-// input javascript object
-func StatsFromJS(value js.Wrapper) *Stats {
-	input := value.JSValue()
+// Stats object and copy all values in the value javascript object.
+func StatsFromJS(value js.Value) *Stats {
 	var out Stats
 	var (
 		value0 float64   // javascript: double {timestamp Timestamp timestamp}
 		value1 StatsType // javascript: RTCStatsType {type Type _type}
 		value2 string    // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = StatsTypeFromJS(input.Get("type"))
+	value1 = StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
 	return &out
 }
@@ -3153,7 +3086,7 @@ type StatsEventInit struct {
 	Report     *StatsReport
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3169,10 +3102,8 @@ func (_this *StatsEventInit) JSValue() js.Value {
 }
 
 // StatsEventInitFromJS is allocating a new
-// StatsEventInit object and copy all values from
-// input javascript object
-func StatsEventInitFromJS(value js.Wrapper) *StatsEventInit {
-	input := value.JSValue()
+// StatsEventInit object and copy all values in the value javascript object.
+func StatsEventInitFromJS(value js.Value) *StatsEventInit {
 	var out StatsEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -3180,13 +3111,13 @@ func StatsEventInitFromJS(value js.Wrapper) *StatsEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *StatsReport // javascript: RTCStatsReport {report Report report}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = StatsReportFromJS(input.Get("report"))
+	value3 = StatsReportFromJS(value.Get("report"))
 	out.Report = value3
 	return &out
 }
@@ -3197,7 +3128,7 @@ type StatsReportEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3213,26 +3144,24 @@ func (_this *StatsReportEntryIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportEntryIteratorValueFromJS is allocating a new
-// StatsReportEntryIteratorValue object and copy all values from
-// input javascript object
-func StatsReportEntryIteratorValueFromJS(value js.Wrapper) *StatsReportEntryIteratorValue {
-	input := value.JSValue()
+// StatsReportEntryIteratorValue object and copy all values in the value javascript object.
+func StatsReportEntryIteratorValueFromJS(value js.Value) *StatsReportEntryIteratorValue {
 	var out StatsReportEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3243,7 +3172,7 @@ type StatsReportKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3255,18 +3184,16 @@ func (_this *StatsReportKeyIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportKeyIteratorValueFromJS is allocating a new
-// StatsReportKeyIteratorValue object and copy all values from
-// input javascript object
-func StatsReportKeyIteratorValueFromJS(value js.Wrapper) *StatsReportKeyIteratorValue {
-	input := value.JSValue()
+// StatsReportKeyIteratorValue object and copy all values in the value javascript object.
+func StatsReportKeyIteratorValueFromJS(value js.Value) *StatsReportKeyIteratorValue {
 	var out StatsReportKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3277,7 +3204,7 @@ type StatsReportValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3289,18 +3216,16 @@ func (_this *StatsReportValueIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportValueIteratorValueFromJS is allocating a new
-// StatsReportValueIteratorValue object and copy all values from
-// input javascript object
-func StatsReportValueIteratorValueFromJS(value js.Wrapper) *StatsReportValueIteratorValue {
-	input := value.JSValue()
+// StatsReportValueIteratorValue object and copy all values in the value javascript object.
+func StatsReportValueIteratorValueFromJS(value js.Value) *StatsReportValueIteratorValue {
 	var out StatsReportValueIteratorValue
 	var (
 		value0 *javascript.Object // javascript: object {value Value value}
 		value1 bool               // javascript: boolean {done Done done}
 	)
-	value0 = javascript.ObjectFromJS(input.Get("value"))
+	value0 = javascript.ObjectFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3316,7 +3241,7 @@ type TrackEventInit struct {
 	Transceiver *RtpTransceiver
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3342,10 +3267,8 @@ func (_this *TrackEventInit) JSValue() js.Value {
 }
 
 // TrackEventInitFromJS is allocating a new
-// TrackEventInit object and copy all values from
-// input javascript object
-func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
-	input := value.JSValue()
+// TrackEventInit object and copy all values in the value javascript object.
+func TrackEventInitFromJS(value js.Value) *TrackEventInit {
 	var out TrackEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -3356,27 +3279,27 @@ func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
 		value5 []*local.MediaStream    // javascript: sequence<MediaStream> {streams Streams streams}
 		value6 *RtpTransceiver         // javascript: RTCRtpTransceiver {transceiver Transceiver transceiver}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = RtpReceiverFromJS(input.Get("receiver"))
+	value3 = RtpReceiverFromJS(value.Get("receiver"))
 	out.Receiver = value3
-	value4 = local.MediaStreamTrackFromJS(input.Get("track"))
+	value4 = local.MediaStreamTrackFromJS(value.Get("track"))
 	out.Track = value4
-	__length5 := input.Get("streams").Length()
+	__length5 := value.Get("streams").Length()
 	__array5 := make([]*local.MediaStream, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *local.MediaStream
-		__seq_in5 := input.Get("streams").Index(__idx5)
+		__seq_in5 := value.Get("streams").Index(__idx5)
 		__seq_out5 = local.MediaStreamFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Streams = value5
-	value6 = RtpTransceiverFromJS(input.Get("transceiver"))
+	value6 = RtpTransceiverFromJS(value.Get("transceiver"))
 	out.Transceiver = value6
 	return &out
 }
@@ -3391,15 +3314,19 @@ func (_this *Certificate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CertificateFromJS is casting a js.Wrapper into Certificate.
-func CertificateFromJS(value js.Wrapper) *Certificate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CertificateFromJS is casting a js.Value into Certificate.
+func CertificateFromJS(value js.Value) *Certificate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Certificate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CertificateFromJS is casting from something that holds a js.Value into Certificate.
+func CertificateFromWrapper(input core.Wrapper) *Certificate {
+	return CertificateFromJS(input.JSValue())
 }
 
 func GetSupportedAlgorithms() (_result []*Union) {
@@ -3462,15 +3389,19 @@ type DTMFSender struct {
 	domcore.EventTarget
 }
 
-// DTMFSenderFromJS is casting a js.Wrapper into DTMFSender.
-func DTMFSenderFromJS(value js.Wrapper) *DTMFSender {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DTMFSenderFromJS is casting a js.Value into DTMFSender.
+func DTMFSenderFromJS(value js.Value) *DTMFSender {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DTMFSender{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DTMFSenderFromJS is casting from something that holds a js.Value into DTMFSender.
+func DTMFSenderFromWrapper(input core.Wrapper) *DTMFSender {
+	return DTMFSenderFromJS(input.JSValue())
 }
 
 // OnToneChange returning attribute 'ontonechange' with
@@ -3571,15 +3502,19 @@ type DTMFToneChangeEvent struct {
 	domcore.Event
 }
 
-// DTMFToneChangeEventFromJS is casting a js.Wrapper into DTMFToneChangeEvent.
-func DTMFToneChangeEventFromJS(value js.Wrapper) *DTMFToneChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DTMFToneChangeEventFromJS is casting a js.Value into DTMFToneChangeEvent.
+func DTMFToneChangeEventFromJS(value js.Value) *DTMFToneChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DTMFToneChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DTMFToneChangeEventFromJS is casting from something that holds a js.Value into DTMFToneChangeEvent.
+func DTMFToneChangeEventFromWrapper(input core.Wrapper) *DTMFToneChangeEvent {
+	return DTMFToneChangeEventFromJS(input.JSValue())
 }
 
 func NewRTCDTMFToneChangeEvent(_type string, eventInitDict *DTMFToneChangeEventInit) (_result *DTMFToneChangeEvent) {
@@ -3617,15 +3552,19 @@ type DataChannel struct {
 	domcore.EventTarget
 }
 
-// DataChannelFromJS is casting a js.Wrapper into DataChannel.
-func DataChannelFromJS(value js.Wrapper) *DataChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataChannelFromJS is casting a js.Value into DataChannel.
+func DataChannelFromJS(value js.Value) *DataChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataChannelFromJS is casting from something that holds a js.Value into DataChannel.
+func DataChannelFromWrapper(input core.Wrapper) *DataChannel {
+	return DataChannelFromJS(input.JSValue())
 }
 
 // Label returning attribute 'label' with
@@ -3998,15 +3937,19 @@ type DataChannelEvent struct {
 	domcore.Event
 }
 
-// DataChannelEventFromJS is casting a js.Wrapper into DataChannelEvent.
-func DataChannelEventFromJS(value js.Wrapper) *DataChannelEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataChannelEventFromJS is casting a js.Value into DataChannelEvent.
+func DataChannelEventFromJS(value js.Value) *DataChannelEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataChannelEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataChannelEventFromJS is casting from something that holds a js.Value into DataChannelEvent.
+func DataChannelEventFromWrapper(input core.Wrapper) *DataChannelEvent {
+	return DataChannelEventFromJS(input.JSValue())
 }
 
 func NewRTCDataChannelEvent(_type string, eventInitDict *DataChannelEventInit) (_result *DataChannelEvent) {
@@ -4044,15 +3987,19 @@ type DtlsTransport struct {
 	domcore.EventTarget
 }
 
-// DtlsTransportFromJS is casting a js.Wrapper into DtlsTransport.
-func DtlsTransportFromJS(value js.Wrapper) *DtlsTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DtlsTransportFromJS is casting a js.Value into DtlsTransport.
+func DtlsTransportFromJS(value js.Value) *DtlsTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DtlsTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DtlsTransportFromJS is casting from something that holds a js.Value into DtlsTransport.
+func DtlsTransportFromWrapper(input core.Wrapper) *DtlsTransport {
+	return DtlsTransportFromJS(input.JSValue())
 }
 
 // IceTransport returning attribute 'iceTransport' with
@@ -4187,15 +4134,19 @@ func (_this *Error) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ErrorFromJS is casting a js.Wrapper into Error.
-func ErrorFromJS(value js.Wrapper) *Error {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorFromJS is casting a js.Value into Error.
+func ErrorFromJS(value js.Value) *Error {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Error{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorFromJS is casting from something that holds a js.Value into Error.
+func ErrorFromWrapper(input core.Wrapper) *Error {
+	return ErrorFromJS(input.JSValue())
 }
 
 // class: RTCErrorEvent
@@ -4203,15 +4154,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewRTCErrorEvent(_type string, eventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -4256,15 +4211,19 @@ func (_this *IceCandidate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IceCandidateFromJS is casting a js.Wrapper into IceCandidate.
-func IceCandidateFromJS(value js.Wrapper) *IceCandidate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IceCandidateFromJS is casting a js.Value into IceCandidate.
+func IceCandidateFromJS(value js.Value) *IceCandidate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IceCandidate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IceCandidateFromJS is casting from something that holds a js.Value into IceCandidate.
+func IceCandidateFromWrapper(input core.Wrapper) *IceCandidate {
+	return IceCandidateFromJS(input.JSValue())
 }
 
 func NewRTCIceCandidate(candidateInitDict *IceCandidateInit) (_result *IceCandidate) {
@@ -4471,15 +4430,19 @@ type IceTransport struct {
 	domcore.EventTarget
 }
 
-// IceTransportFromJS is casting a js.Wrapper into IceTransport.
-func IceTransportFromJS(value js.Wrapper) *IceTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IceTransportFromJS is casting a js.Value into IceTransport.
+func IceTransportFromJS(value js.Value) *IceTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IceTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IceTransportFromJS is casting from something that holds a js.Value into IceTransport.
+func IceTransportFromWrapper(input core.Wrapper) *IceTransport {
+	return IceTransportFromJS(input.JSValue())
 }
 
 // Role returning attribute 'role' with
@@ -4710,15 +4673,19 @@ type PeerConnection struct {
 	domcore.EventTarget
 }
 
-// PeerConnectionFromJS is casting a js.Wrapper into PeerConnection.
-func PeerConnectionFromJS(value js.Wrapper) *PeerConnection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionFromJS is casting a js.Value into PeerConnection.
+func PeerConnectionFromJS(value js.Value) *PeerConnection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionFromJS is casting from something that holds a js.Value into PeerConnection.
+func PeerConnectionFromWrapper(input core.Wrapper) *PeerConnection {
+	return PeerConnectionFromJS(input.JSValue())
 }
 
 func GetDefaultIceServers() (_result []*IceServer) {
@@ -5739,15 +5706,19 @@ type PeerConnectionIceErrorEvent struct {
 	domcore.Event
 }
 
-// PeerConnectionIceErrorEventFromJS is casting a js.Wrapper into PeerConnectionIceErrorEvent.
-func PeerConnectionIceErrorEventFromJS(value js.Wrapper) *PeerConnectionIceErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionIceErrorEventFromJS is casting a js.Value into PeerConnectionIceErrorEvent.
+func PeerConnectionIceErrorEventFromJS(value js.Value) *PeerConnectionIceErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnectionIceErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionIceErrorEventFromJS is casting from something that holds a js.Value into PeerConnectionIceErrorEvent.
+func PeerConnectionIceErrorEventFromWrapper(input core.Wrapper) *PeerConnectionIceErrorEvent {
+	return PeerConnectionIceErrorEventFromJS(input.JSValue())
 }
 
 func NewRTCPeerConnectionIceErrorEvent(_type string, eventInitDict *PeerConnectionIceErrorEventInit) (_result *PeerConnectionIceErrorEvent) {
@@ -5812,15 +5783,19 @@ type PeerConnectionIceEvent struct {
 	domcore.Event
 }
 
-// PeerConnectionIceEventFromJS is casting a js.Wrapper into PeerConnectionIceEvent.
-func PeerConnectionIceEventFromJS(value js.Wrapper) *PeerConnectionIceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionIceEventFromJS is casting a js.Value into PeerConnectionIceEvent.
+func PeerConnectionIceEventFromJS(value js.Value) *PeerConnectionIceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnectionIceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionIceEventFromJS is casting from something that holds a js.Value into PeerConnectionIceEvent.
+func PeerConnectionIceEventFromWrapper(input core.Wrapper) *PeerConnectionIceEvent {
+	return PeerConnectionIceEventFromJS(input.JSValue())
 }
 
 func NewRTCPeerConnectionIceEvent(_type string, eventInitDict *PeerConnectionIceEventInit) (_result *PeerConnectionIceEvent) {
@@ -5879,15 +5854,19 @@ func (_this *PromiseCertificate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCertificateFromJS is casting a js.Wrapper into PromiseCertificate.
-func PromiseCertificateFromJS(value js.Wrapper) *PromiseCertificate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCertificateFromJS is casting a js.Value into PromiseCertificate.
+func PromiseCertificateFromJS(value js.Value) *PromiseCertificate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCertificate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCertificateFromJS is casting from something that holds a js.Value into PromiseCertificate.
+func PromiseCertificateFromWrapper(input core.Wrapper) *PromiseCertificate {
+	return PromiseCertificateFromJS(input.JSValue())
 }
 
 func (_this *PromiseCertificate) Then(onFulfilled *PromiseCertificateOnFulfilled, onRejected *PromiseCertificateOnRejected) (_result *PromiseCertificate) {
@@ -5984,15 +5963,19 @@ func (_this *PromiseSessionDescriptionInit) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSessionDescriptionInitFromJS is casting a js.Wrapper into PromiseSessionDescriptionInit.
-func PromiseSessionDescriptionInitFromJS(value js.Wrapper) *PromiseSessionDescriptionInit {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSessionDescriptionInitFromJS is casting a js.Value into PromiseSessionDescriptionInit.
+func PromiseSessionDescriptionInitFromJS(value js.Value) *PromiseSessionDescriptionInit {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSessionDescriptionInit{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSessionDescriptionInitFromJS is casting from something that holds a js.Value into PromiseSessionDescriptionInit.
+func PromiseSessionDescriptionInitFromWrapper(input core.Wrapper) *PromiseSessionDescriptionInit {
+	return PromiseSessionDescriptionInitFromJS(input.JSValue())
 }
 
 func (_this *PromiseSessionDescriptionInit) Then(onFulfilled *PromiseSessionDescriptionInitOnFulfilled, onRejected *PromiseSessionDescriptionInitOnRejected) (_result *PromiseSessionDescriptionInit) {
@@ -6089,15 +6072,19 @@ func (_this *PromiseStatsReport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStatsReportFromJS is casting a js.Wrapper into PromiseStatsReport.
-func PromiseStatsReportFromJS(value js.Wrapper) *PromiseStatsReport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStatsReportFromJS is casting a js.Value into PromiseStatsReport.
+func PromiseStatsReportFromJS(value js.Value) *PromiseStatsReport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseStatsReport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStatsReportFromJS is casting from something that holds a js.Value into PromiseStatsReport.
+func PromiseStatsReportFromWrapper(input core.Wrapper) *PromiseStatsReport {
+	return PromiseStatsReportFromJS(input.JSValue())
 }
 
 func (_this *PromiseStatsReport) Then(onFulfilled *PromiseStatsReportOnFulfilled, onRejected *PromiseStatsReportOnRejected) (_result *PromiseStatsReport) {
@@ -6194,15 +6181,19 @@ func (_this *RtpReceiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpReceiverFromJS is casting a js.Wrapper into RtpReceiver.
-func RtpReceiverFromJS(value js.Wrapper) *RtpReceiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpReceiverFromJS is casting a js.Value into RtpReceiver.
+func RtpReceiverFromJS(value js.Value) *RtpReceiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpReceiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpReceiverFromJS is casting from something that holds a js.Value into RtpReceiver.
+func RtpReceiverFromWrapper(input core.Wrapper) *RtpReceiver {
+	return RtpReceiverFromJS(input.JSValue())
 }
 
 func GetCapabilities(kind string) (_result *RtpCapabilities) {
@@ -6339,15 +6330,19 @@ func (_this *RtpSender) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpSenderFromJS is casting a js.Wrapper into RtpSender.
-func RtpSenderFromJS(value js.Wrapper) *RtpSender {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpSenderFromJS is casting a js.Value into RtpSender.
+func RtpSenderFromJS(value js.Value) *RtpSender {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpSender{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpSenderFromJS is casting from something that holds a js.Value into RtpSender.
+func RtpSenderFromWrapper(input core.Wrapper) *RtpSender {
+	return RtpSenderFromJS(input.JSValue())
 }
 
 func GetCapabilities2(kind string) (_result *RtpCapabilities) {
@@ -6501,15 +6496,19 @@ func (_this *RtpTransceiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpTransceiverFromJS is casting a js.Wrapper into RtpTransceiver.
-func RtpTransceiverFromJS(value js.Wrapper) *RtpTransceiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpTransceiverFromJS is casting a js.Value into RtpTransceiver.
+func RtpTransceiverFromJS(value js.Value) *RtpTransceiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpTransceiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpTransceiverFromJS is casting from something that holds a js.Value into RtpTransceiver.
+func RtpTransceiverFromWrapper(input core.Wrapper) *RtpTransceiver {
+	return RtpTransceiverFromJS(input.JSValue())
 }
 
 // Mid returning attribute 'mid' with
@@ -6614,15 +6613,19 @@ func (_this *SctpTransport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SctpTransportFromJS is casting a js.Wrapper into SctpTransport.
-func SctpTransportFromJS(value js.Wrapper) *SctpTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SctpTransportFromJS is casting a js.Value into SctpTransport.
+func SctpTransportFromJS(value js.Value) *SctpTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SctpTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SctpTransportFromJS is casting from something that holds a js.Value into SctpTransport.
+func SctpTransportFromWrapper(input core.Wrapper) *SctpTransport {
+	return SctpTransportFromJS(input.JSValue())
 }
 
 // Transport returning attribute 'transport' with
@@ -6715,15 +6718,19 @@ func (_this *SessionDescription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SessionDescriptionFromJS is casting a js.Wrapper into SessionDescription.
-func SessionDescriptionFromJS(value js.Wrapper) *SessionDescription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SessionDescriptionFromJS is casting a js.Value into SessionDescription.
+func SessionDescriptionFromJS(value js.Value) *SessionDescription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SessionDescription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SessionDescriptionFromJS is casting from something that holds a js.Value into SessionDescription.
+func SessionDescriptionFromWrapper(input core.Wrapper) *SessionDescription {
+	return SessionDescriptionFromJS(input.JSValue())
 }
 
 func NewRTCSessionDescription(descriptionInitDict *SessionDescriptionInit) (_result *SessionDescription) {
@@ -6781,15 +6788,19 @@ type StatsEvent struct {
 	domcore.Event
 }
 
-// StatsEventFromJS is casting a js.Wrapper into StatsEvent.
-func StatsEventFromJS(value js.Wrapper) *StatsEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsEventFromJS is casting a js.Value into StatsEvent.
+func StatsEventFromJS(value js.Value) *StatsEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsEventFromJS is casting from something that holds a js.Value into StatsEvent.
+func StatsEventFromWrapper(input core.Wrapper) *StatsEvent {
+	return StatsEventFromJS(input.JSValue())
 }
 
 func NewRTCStatsEvent(_type string, eventInitDict *StatsEventInit) (_result *StatsEvent) {
@@ -6832,15 +6843,19 @@ func (_this *StatsReport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportFromJS is casting a js.Wrapper into StatsReport.
-func StatsReportFromJS(value js.Wrapper) *StatsReport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportFromJS is casting a js.Value into StatsReport.
+func StatsReportFromJS(value js.Value) *StatsReport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportFromJS is casting from something that holds a js.Value into StatsReport.
+func StatsReportFromWrapper(input core.Wrapper) *StatsReport {
+	return StatsReportFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -6964,15 +6979,19 @@ func (_this *StatsReportEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportEntryIteratorFromJS is casting a js.Wrapper into StatsReportEntryIterator.
-func StatsReportEntryIteratorFromJS(value js.Wrapper) *StatsReportEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportEntryIteratorFromJS is casting a js.Value into StatsReportEntryIterator.
+func StatsReportEntryIteratorFromJS(value js.Value) *StatsReportEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportEntryIteratorFromJS is casting from something that holds a js.Value into StatsReportEntryIterator.
+func StatsReportEntryIteratorFromWrapper(input core.Wrapper) *StatsReportEntryIterator {
+	return StatsReportEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportEntryIterator) Next() (_result *StatsReportEntryIteratorValue) {
@@ -6999,15 +7018,19 @@ func (_this *StatsReportKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportKeyIteratorFromJS is casting a js.Wrapper into StatsReportKeyIterator.
-func StatsReportKeyIteratorFromJS(value js.Wrapper) *StatsReportKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportKeyIteratorFromJS is casting a js.Value into StatsReportKeyIterator.
+func StatsReportKeyIteratorFromJS(value js.Value) *StatsReportKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportKeyIteratorFromJS is casting from something that holds a js.Value into StatsReportKeyIterator.
+func StatsReportKeyIteratorFromWrapper(input core.Wrapper) *StatsReportKeyIterator {
+	return StatsReportKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportKeyIterator) Next() (_result *StatsReportKeyIteratorValue) {
@@ -7034,15 +7057,19 @@ func (_this *StatsReportValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportValueIteratorFromJS is casting a js.Wrapper into StatsReportValueIterator.
-func StatsReportValueIteratorFromJS(value js.Wrapper) *StatsReportValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportValueIteratorFromJS is casting a js.Value into StatsReportValueIterator.
+func StatsReportValueIteratorFromJS(value js.Value) *StatsReportValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportValueIteratorFromJS is casting from something that holds a js.Value into StatsReportValueIterator.
+func StatsReportValueIteratorFromWrapper(input core.Wrapper) *StatsReportValueIterator {
+	return StatsReportValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportValueIterator) Next() (_result *StatsReportValueIteratorValue) {
@@ -7064,15 +7091,19 @@ type TrackEvent struct {
 	domcore.Event
 }
 
-// TrackEventFromJS is casting a js.Wrapper into TrackEvent.
-func TrackEventFromJS(value js.Wrapper) *TrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TrackEventFromJS is casting a js.Value into TrackEvent.
+func TrackEventFromJS(value js.Value) *TrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TrackEventFromJS is casting from something that holds a js.Value into TrackEvent.
+func TrackEventFromWrapper(input core.Wrapper) *TrackEvent {
+	return TrackEventFromJS(input.JSValue())
 }
 
 func NewRTCTrackEvent(_type string, eventInitDict *TrackEventInit) (_result *TrackEvent) {

--- a/media/webrtc/webrtc_js.go
+++ b/media/webrtc/webrtc_js.go
@@ -5,6 +5,7 @@ package webrtc
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/channel"
@@ -1493,7 +1494,7 @@ type AnswerOptions struct {
 	VoiceActivityDetection bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AnswerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1503,15 +1504,13 @@ func (_this *AnswerOptions) JSValue() js.Value {
 }
 
 // AnswerOptionsFromJS is allocating a new
-// AnswerOptions object and copy all values from
-// input javascript object
-func AnswerOptionsFromJS(value js.Wrapper) *AnswerOptions {
-	input := value.JSValue()
+// AnswerOptions object and copy all values in the value javascript object.
+func AnswerOptionsFromJS(value js.Value) *AnswerOptions {
 	var out AnswerOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
 	return &out
 }
@@ -1521,7 +1520,7 @@ type CertificateExpiration struct {
 	Expires int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CertificateExpiration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1531,15 +1530,13 @@ func (_this *CertificateExpiration) JSValue() js.Value {
 }
 
 // CertificateExpirationFromJS is allocating a new
-// CertificateExpiration object and copy all values from
-// input javascript object
-func CertificateExpirationFromJS(value js.Wrapper) *CertificateExpiration {
-	input := value.JSValue()
+// CertificateExpiration object and copy all values in the value javascript object.
+func CertificateExpirationFromJS(value js.Value) *CertificateExpiration {
 	var out CertificateExpiration
 	var (
 		value0 int // javascript: unsigned long long {expires Expires expires}
 	)
-	value0 = (input.Get("expires")).Int()
+	value0 = (value.Get("expires")).Int()
 	out.Expires = value0
 	return &out
 }
@@ -1555,7 +1552,7 @@ type Configuration struct {
 	IceCandidatePoolSize int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Configuration) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1585,10 +1582,8 @@ func (_this *Configuration) JSValue() js.Value {
 }
 
 // ConfigurationFromJS is allocating a new
-// Configuration object and copy all values from
-// input javascript object
-func ConfigurationFromJS(value js.Wrapper) *Configuration {
-	input := value.JSValue()
+// Configuration object and copy all values in the value javascript object.
+func ConfigurationFromJS(value js.Value) *Configuration {
 	var out Configuration
 	var (
 		value0 []*IceServer       // javascript: sequence<RTCIceServer> {iceServers IceServers iceServers}
@@ -1599,35 +1594,35 @@ func ConfigurationFromJS(value js.Wrapper) *Configuration {
 		value5 []*Certificate     // javascript: sequence<RTCCertificate> {certificates Certificates certificates}
 		value6 int                // javascript: octet {iceCandidatePoolSize IceCandidatePoolSize iceCandidatePoolSize}
 	)
-	__length0 := input.Get("iceServers").Length()
+	__length0 := value.Get("iceServers").Length()
 	__array0 := make([]*IceServer, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *IceServer
-		__seq_in0 := input.Get("iceServers").Index(__idx0)
+		__seq_in0 := value.Get("iceServers").Index(__idx0)
 		__seq_out0 = IceServerFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.IceServers = value0
-	value1 = IceTransportPolicyFromJS(input.Get("iceTransportPolicy"))
+	value1 = IceTransportPolicyFromJS(value.Get("iceTransportPolicy"))
 	out.IceTransportPolicy = value1
-	value2 = BundlePolicyFromJS(input.Get("bundlePolicy"))
+	value2 = BundlePolicyFromJS(value.Get("bundlePolicy"))
 	out.BundlePolicy = value2
-	value3 = RtcpMuxPolicyFromJS(input.Get("rtcpMuxPolicy"))
+	value3 = RtcpMuxPolicyFromJS(value.Get("rtcpMuxPolicy"))
 	out.RtcpMuxPolicy = value3
-	value4 = (input.Get("peerIdentity")).String()
+	value4 = (value.Get("peerIdentity")).String()
 	out.PeerIdentity = value4
-	__length5 := input.Get("certificates").Length()
+	__length5 := value.Get("certificates").Length()
 	__array5 := make([]*Certificate, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *Certificate
-		__seq_in5 := input.Get("certificates").Index(__idx5)
+		__seq_in5 := value.Get("certificates").Index(__idx5)
 		__seq_out5 = CertificateFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Certificates = value5
-	value6 = (input.Get("iceCandidatePoolSize")).Int()
+	value6 = (value.Get("iceCandidatePoolSize")).Int()
 	out.IceCandidatePoolSize = value6
 	return &out
 }
@@ -1640,7 +1635,7 @@ type DTMFToneChangeEventInit struct {
 	Tone       string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DTMFToneChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1656,10 +1651,8 @@ func (_this *DTMFToneChangeEventInit) JSValue() js.Value {
 }
 
 // DTMFToneChangeEventInitFromJS is allocating a new
-// DTMFToneChangeEventInit object and copy all values from
-// input javascript object
-func DTMFToneChangeEventInitFromJS(value js.Wrapper) *DTMFToneChangeEventInit {
-	input := value.JSValue()
+// DTMFToneChangeEventInit object and copy all values in the value javascript object.
+func DTMFToneChangeEventInitFromJS(value js.Value) *DTMFToneChangeEventInit {
 	var out DTMFToneChangeEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1667,13 +1660,13 @@ func DTMFToneChangeEventInitFromJS(value js.Wrapper) *DTMFToneChangeEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 string // javascript: DOMString {tone Tone tone}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("tone")).String()
+	value3 = (value.Get("tone")).String()
 	out.Tone = value3
 	return &out
 }
@@ -1686,7 +1679,7 @@ type DataChannelEventInit struct {
 	Channel    *DataChannel
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1702,10 +1695,8 @@ func (_this *DataChannelEventInit) JSValue() js.Value {
 }
 
 // DataChannelEventInitFromJS is allocating a new
-// DataChannelEventInit object and copy all values from
-// input javascript object
-func DataChannelEventInitFromJS(value js.Wrapper) *DataChannelEventInit {
-	input := value.JSValue()
+// DataChannelEventInit object and copy all values in the value javascript object.
+func DataChannelEventInitFromJS(value js.Value) *DataChannelEventInit {
 	var out DataChannelEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -1713,13 +1704,13 @@ func DataChannelEventInitFromJS(value js.Wrapper) *DataChannelEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *DataChannel // javascript: RTCDataChannel {channel Channel channel}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = DataChannelFromJS(input.Get("channel"))
+	value3 = DataChannelFromJS(value.Get("channel"))
 	out.Channel = value3
 	return &out
 }
@@ -1735,7 +1726,7 @@ type DataChannelInit struct {
 	Priority          PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DataChannelInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1757,10 +1748,8 @@ func (_this *DataChannelInit) JSValue() js.Value {
 }
 
 // DataChannelInitFromJS is allocating a new
-// DataChannelInit object and copy all values from
-// input javascript object
-func DataChannelInitFromJS(value js.Wrapper) *DataChannelInit {
-	input := value.JSValue()
+// DataChannelInit object and copy all values in the value javascript object.
+func DataChannelInitFromJS(value js.Value) *DataChannelInit {
 	var out DataChannelInit
 	var (
 		value0 bool         // javascript: boolean {ordered Ordered ordered}
@@ -1771,19 +1760,19 @@ func DataChannelInitFromJS(value js.Wrapper) *DataChannelInit {
 		value5 int          // javascript: unsigned short {id Id id}
 		value6 PriorityType // javascript: RTCPriorityType {priority Priority priority}
 	)
-	value0 = (input.Get("ordered")).Bool()
+	value0 = (value.Get("ordered")).Bool()
 	out.Ordered = value0
-	value1 = (input.Get("maxPacketLifeTime")).Int()
+	value1 = (value.Get("maxPacketLifeTime")).Int()
 	out.MaxPacketLifeTime = value1
-	value2 = (input.Get("maxRetransmits")).Int()
+	value2 = (value.Get("maxRetransmits")).Int()
 	out.MaxRetransmits = value2
-	value3 = (input.Get("protocol")).String()
+	value3 = (value.Get("protocol")).String()
 	out.Protocol = value3
-	value4 = (input.Get("negotiated")).Bool()
+	value4 = (value.Get("negotiated")).Bool()
 	out.Negotiated = value4
-	value5 = (input.Get("id")).Int()
+	value5 = (value.Get("id")).Int()
 	out.Id = value5
-	value6 = PriorityTypeFromJS(input.Get("priority"))
+	value6 = PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value6
 	return &out
 }
@@ -1794,7 +1783,7 @@ type DtlsFingerprint struct {
 	Value     string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *DtlsFingerprint) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1806,18 +1795,16 @@ func (_this *DtlsFingerprint) JSValue() js.Value {
 }
 
 // DtlsFingerprintFromJS is allocating a new
-// DtlsFingerprint object and copy all values from
-// input javascript object
-func DtlsFingerprintFromJS(value js.Wrapper) *DtlsFingerprint {
-	input := value.JSValue()
+// DtlsFingerprint object and copy all values in the value javascript object.
+func DtlsFingerprintFromJS(value js.Value) *DtlsFingerprint {
 	var out DtlsFingerprint
 	var (
 		value0 string // javascript: DOMString {algorithm Algorithm algorithm}
 		value1 string // javascript: DOMString {value Value value}
 	)
-	value0 = (input.Get("algorithm")).String()
+	value0 = (value.Get("algorithm")).String()
 	out.Algorithm = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -1830,7 +1817,7 @@ type ErrorEventInit struct {
 	Error      *Error
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1846,10 +1833,8 @@ func (_this *ErrorEventInit) JSValue() js.Value {
 }
 
 // ErrorEventInitFromJS is allocating a new
-// ErrorEventInit object and copy all values from
-// input javascript object
-func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
-	input := value.JSValue()
+// ErrorEventInit object and copy all values in the value javascript object.
+func ErrorEventInitFromJS(value js.Value) *ErrorEventInit {
 	var out ErrorEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1857,14 +1842,14 @@ func ErrorEventInitFromJS(value js.Wrapper) *ErrorEventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Error // javascript: RTCError {error Error _error}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("error").Type() != js.TypeNull && input.Get("error").Type() != js.TypeUndefined {
-		value3 = ErrorFromJS(input.Get("error"))
+	if value.Get("error").Type() != js.TypeNull && value.Get("error").Type() != js.TypeUndefined {
+		value3 = ErrorFromJS(value.Get("error"))
 	}
 	out.Error = value3
 	return &out
@@ -1878,7 +1863,7 @@ type IceCandidateInit struct {
 	UsernameFragment string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidateInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1906,10 +1891,8 @@ func (_this *IceCandidateInit) JSValue() js.Value {
 }
 
 // IceCandidateInitFromJS is allocating a new
-// IceCandidateInit object and copy all values from
-// input javascript object
-func IceCandidateInitFromJS(value js.Wrapper) *IceCandidateInit {
-	input := value.JSValue()
+// IceCandidateInit object and copy all values in the value javascript object.
+func IceCandidateInitFromJS(value js.Value) *IceCandidateInit {
 	var out IceCandidateInit
 	var (
 		value0 string  // javascript: DOMString {candidate Candidate candidate}
@@ -1917,19 +1900,19 @@ func IceCandidateInitFromJS(value js.Wrapper) *IceCandidateInit {
 		value2 *int    // javascript: unsigned short {sdpMLineIndex SdpMLineIndex sdpMLineIndex}
 		value3 string  // javascript: DOMString {usernameFragment UsernameFragment usernameFragment}
 	)
-	value0 = (input.Get("candidate")).String()
+	value0 = (value.Get("candidate")).String()
 	out.Candidate = value0
-	if input.Get("sdpMid").Type() != js.TypeNull && input.Get("sdpMid").Type() != js.TypeUndefined {
-		__tmp := (input.Get("sdpMid")).String()
+	if value.Get("sdpMid").Type() != js.TypeNull && value.Get("sdpMid").Type() != js.TypeUndefined {
+		__tmp := (value.Get("sdpMid")).String()
 		value1 = &__tmp
 	}
 	out.SdpMid = value1
-	if input.Get("sdpMLineIndex").Type() != js.TypeNull && input.Get("sdpMLineIndex").Type() != js.TypeUndefined {
-		__tmp := (input.Get("sdpMLineIndex")).Int()
+	if value.Get("sdpMLineIndex").Type() != js.TypeNull && value.Get("sdpMLineIndex").Type() != js.TypeUndefined {
+		__tmp := (value.Get("sdpMLineIndex")).Int()
 		value2 = &__tmp
 	}
 	out.SdpMLineIndex = value2
-	value3 = (input.Get("usernameFragment")).String()
+	value3 = (value.Get("usernameFragment")).String()
 	out.UsernameFragment = value3
 	return &out
 }
@@ -1940,7 +1923,7 @@ type IceCandidatePair struct {
 	Remote *IceCandidate
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceCandidatePair) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1952,18 +1935,16 @@ func (_this *IceCandidatePair) JSValue() js.Value {
 }
 
 // IceCandidatePairFromJS is allocating a new
-// IceCandidatePair object and copy all values from
-// input javascript object
-func IceCandidatePairFromJS(value js.Wrapper) *IceCandidatePair {
-	input := value.JSValue()
+// IceCandidatePair object and copy all values in the value javascript object.
+func IceCandidatePairFromJS(value js.Value) *IceCandidatePair {
 	var out IceCandidatePair
 	var (
 		value0 *IceCandidate // javascript: RTCIceCandidate {local Local local}
 		value1 *IceCandidate // javascript: RTCIceCandidate {remote Remote remote}
 	)
-	value0 = IceCandidateFromJS(input.Get("local"))
+	value0 = IceCandidateFromJS(value.Get("local"))
 	out.Local = value0
-	value1 = IceCandidateFromJS(input.Get("remote"))
+	value1 = IceCandidateFromJS(value.Get("remote"))
 	out.Remote = value1
 	return &out
 }
@@ -1974,7 +1955,7 @@ type IceParameters struct {
 	Password         string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1986,18 +1967,16 @@ func (_this *IceParameters) JSValue() js.Value {
 }
 
 // IceParametersFromJS is allocating a new
-// IceParameters object and copy all values from
-// input javascript object
-func IceParametersFromJS(value js.Wrapper) *IceParameters {
-	input := value.JSValue()
+// IceParameters object and copy all values in the value javascript object.
+func IceParametersFromJS(value js.Value) *IceParameters {
 	var out IceParameters
 	var (
 		value0 string // javascript: DOMString {usernameFragment UsernameFragment usernameFragment}
 		value1 string // javascript: DOMString {password Password password}
 	)
-	value0 = (input.Get("usernameFragment")).String()
+	value0 = (value.Get("usernameFragment")).String()
 	out.UsernameFragment = value0
-	value1 = (input.Get("password")).String()
+	value1 = (value.Get("password")).String()
 	out.Password = value1
 	return &out
 }
@@ -2010,7 +1989,7 @@ type IceServer struct {
 	CredentialType IceCredentialType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *IceServer) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2026,10 +2005,8 @@ func (_this *IceServer) JSValue() js.Value {
 }
 
 // IceServerFromJS is allocating a new
-// IceServer object and copy all values from
-// input javascript object
-func IceServerFromJS(value js.Wrapper) *IceServer {
-	input := value.JSValue()
+// IceServer object and copy all values in the value javascript object.
+func IceServerFromJS(value js.Value) *IceServer {
 	var out IceServer
 	var (
 		value0 *Union            // javascript: Union {urls Urls urls}
@@ -2037,13 +2014,13 @@ func IceServerFromJS(value js.Wrapper) *IceServer {
 		value2 *Union            // javascript: Union {credential Credential credential}
 		value3 IceCredentialType // javascript: RTCIceCredentialType {credentialType CredentialType credentialType}
 	)
-	value0 = UnionFromJS(input.Get("urls"))
+	value0 = UnionFromJS(value.Get("urls"))
 	out.Urls = value0
-	value1 = (input.Get("username")).String()
+	value1 = (value.Get("username")).String()
 	out.Username = value1
-	value2 = UnionFromJS(input.Get("credential"))
+	value2 = UnionFromJS(value.Get("credential"))
 	out.Credential = value2
-	value3 = IceCredentialTypeFromJS(input.Get("credentialType"))
+	value3 = IceCredentialTypeFromJS(value.Get("credentialType"))
 	out.CredentialType = value3
 	return &out
 }
@@ -2054,7 +2031,7 @@ type OAuthCredential struct {
 	AccessToken string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OAuthCredential) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2066,18 +2043,16 @@ func (_this *OAuthCredential) JSValue() js.Value {
 }
 
 // OAuthCredentialFromJS is allocating a new
-// OAuthCredential object and copy all values from
-// input javascript object
-func OAuthCredentialFromJS(value js.Wrapper) *OAuthCredential {
-	input := value.JSValue()
+// OAuthCredential object and copy all values in the value javascript object.
+func OAuthCredentialFromJS(value js.Value) *OAuthCredential {
 	var out OAuthCredential
 	var (
 		value0 string // javascript: DOMString {macKey MacKey macKey}
 		value1 string // javascript: DOMString {accessToken AccessToken accessToken}
 	)
-	value0 = (input.Get("macKey")).String()
+	value0 = (value.Get("macKey")).String()
 	out.MacKey = value0
-	value1 = (input.Get("accessToken")).String()
+	value1 = (value.Get("accessToken")).String()
 	out.AccessToken = value1
 	return &out
 }
@@ -2087,7 +2062,7 @@ type OfferAnswerOptions struct {
 	VoiceActivityDetection bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfferAnswerOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2097,15 +2072,13 @@ func (_this *OfferAnswerOptions) JSValue() js.Value {
 }
 
 // OfferAnswerOptionsFromJS is allocating a new
-// OfferAnswerOptions object and copy all values from
-// input javascript object
-func OfferAnswerOptionsFromJS(value js.Wrapper) *OfferAnswerOptions {
-	input := value.JSValue()
+// OfferAnswerOptions object and copy all values in the value javascript object.
+func OfferAnswerOptionsFromJS(value js.Value) *OfferAnswerOptions {
 	var out OfferAnswerOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
 	return &out
 }
@@ -2118,7 +2091,7 @@ type OfferOptions struct {
 	OfferToReceiveVideo    bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *OfferOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2134,10 +2107,8 @@ func (_this *OfferOptions) JSValue() js.Value {
 }
 
 // OfferOptionsFromJS is allocating a new
-// OfferOptions object and copy all values from
-// input javascript object
-func OfferOptionsFromJS(value js.Wrapper) *OfferOptions {
-	input := value.JSValue()
+// OfferOptions object and copy all values in the value javascript object.
+func OfferOptionsFromJS(value js.Value) *OfferOptions {
 	var out OfferOptions
 	var (
 		value0 bool // javascript: boolean {voiceActivityDetection VoiceActivityDetection voiceActivityDetection}
@@ -2145,13 +2116,13 @@ func OfferOptionsFromJS(value js.Wrapper) *OfferOptions {
 		value2 bool // javascript: boolean {offerToReceiveAudio OfferToReceiveAudio offerToReceiveAudio}
 		value3 bool // javascript: boolean {offerToReceiveVideo OfferToReceiveVideo offerToReceiveVideo}
 	)
-	value0 = (input.Get("voiceActivityDetection")).Bool()
+	value0 = (value.Get("voiceActivityDetection")).Bool()
 	out.VoiceActivityDetection = value0
-	value1 = (input.Get("iceRestart")).Bool()
+	value1 = (value.Get("iceRestart")).Bool()
 	out.IceRestart = value1
-	value2 = (input.Get("offerToReceiveAudio")).Bool()
+	value2 = (value.Get("offerToReceiveAudio")).Bool()
 	out.OfferToReceiveAudio = value2
-	value3 = (input.Get("offerToReceiveVideo")).Bool()
+	value3 = (value.Get("offerToReceiveVideo")).Bool()
 	out.OfferToReceiveVideo = value3
 	return &out
 }
@@ -2167,7 +2138,7 @@ type PeerConnectionIceErrorEventInit struct {
 	StatusText    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionIceErrorEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2189,10 +2160,8 @@ func (_this *PeerConnectionIceErrorEventInit) JSValue() js.Value {
 }
 
 // PeerConnectionIceErrorEventInitFromJS is allocating a new
-// PeerConnectionIceErrorEventInit object and copy all values from
-// input javascript object
-func PeerConnectionIceErrorEventInitFromJS(value js.Wrapper) *PeerConnectionIceErrorEventInit {
-	input := value.JSValue()
+// PeerConnectionIceErrorEventInit object and copy all values in the value javascript object.
+func PeerConnectionIceErrorEventInitFromJS(value js.Value) *PeerConnectionIceErrorEventInit {
 	var out PeerConnectionIceErrorEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -2203,19 +2172,19 @@ func PeerConnectionIceErrorEventInitFromJS(value js.Wrapper) *PeerConnectionIceE
 		value5 int    // javascript: unsigned short {errorCode ErrorCode errorCode}
 		value6 string // javascript: USVString {statusText StatusText statusText}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("hostCandidate")).String()
+	value3 = (value.Get("hostCandidate")).String()
 	out.HostCandidate = value3
-	value4 = (input.Get("url")).String()
+	value4 = (value.Get("url")).String()
 	out.Url = value4
-	value5 = (input.Get("errorCode")).Int()
+	value5 = (value.Get("errorCode")).Int()
 	out.ErrorCode = value5
-	value6 = (input.Get("statusText")).String()
+	value6 = (value.Get("statusText")).String()
 	out.StatusText = value6
 	return &out
 }
@@ -2229,7 +2198,7 @@ type PeerConnectionIceEventInit struct {
 	Url        *string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PeerConnectionIceEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2253,10 +2222,8 @@ func (_this *PeerConnectionIceEventInit) JSValue() js.Value {
 }
 
 // PeerConnectionIceEventInitFromJS is allocating a new
-// PeerConnectionIceEventInit object and copy all values from
-// input javascript object
-func PeerConnectionIceEventInitFromJS(value js.Wrapper) *PeerConnectionIceEventInit {
-	input := value.JSValue()
+// PeerConnectionIceEventInit object and copy all values in the value javascript object.
+func PeerConnectionIceEventInitFromJS(value js.Value) *PeerConnectionIceEventInit {
 	var out PeerConnectionIceEventInit
 	var (
 		value0 bool          // javascript: boolean {bubbles Bubbles bubbles}
@@ -2265,18 +2232,18 @@ func PeerConnectionIceEventInitFromJS(value js.Wrapper) *PeerConnectionIceEventI
 		value3 *IceCandidate // javascript: RTCIceCandidate {candidate Candidate candidate}
 		value4 *string       // javascript: DOMString {url Url url}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	if input.Get("candidate").Type() != js.TypeNull && input.Get("candidate").Type() != js.TypeUndefined {
-		value3 = IceCandidateFromJS(input.Get("candidate"))
+	if value.Get("candidate").Type() != js.TypeNull && value.Get("candidate").Type() != js.TypeUndefined {
+		value3 = IceCandidateFromJS(value.Get("candidate"))
 	}
 	out.Candidate = value3
-	if input.Get("url").Type() != js.TypeNull && input.Get("url").Type() != js.TypeUndefined {
-		__tmp := (input.Get("url")).String()
+	if value.Get("url").Type() != js.TypeNull && value.Get("url").Type() != js.TypeUndefined {
+		__tmp := (value.Get("url")).String()
 		value4 = &__tmp
 	}
 	out.Url = value4
@@ -2289,7 +2256,7 @@ type RtcpParameters struct {
 	ReducedSize bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtcpParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2301,18 +2268,16 @@ func (_this *RtcpParameters) JSValue() js.Value {
 }
 
 // RtcpParametersFromJS is allocating a new
-// RtcpParameters object and copy all values from
-// input javascript object
-func RtcpParametersFromJS(value js.Wrapper) *RtcpParameters {
-	input := value.JSValue()
+// RtcpParameters object and copy all values in the value javascript object.
+func RtcpParametersFromJS(value js.Value) *RtcpParameters {
 	var out RtcpParameters
 	var (
 		value0 string // javascript: DOMString {cname Cname cname}
 		value1 bool   // javascript: boolean {reducedSize ReducedSize reducedSize}
 	)
-	value0 = (input.Get("cname")).String()
+	value0 = (value.Get("cname")).String()
 	out.Cname = value0
-	value1 = (input.Get("reducedSize")).Bool()
+	value1 = (value.Get("reducedSize")).Bool()
 	out.ReducedSize = value1
 	return &out
 }
@@ -2323,7 +2288,7 @@ type RtpCapabilities struct {
 	HeaderExtensions []*RtpHeaderExtensionCapability
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCapabilities) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2343,30 +2308,28 @@ func (_this *RtpCapabilities) JSValue() js.Value {
 }
 
 // RtpCapabilitiesFromJS is allocating a new
-// RtpCapabilities object and copy all values from
-// input javascript object
-func RtpCapabilitiesFromJS(value js.Wrapper) *RtpCapabilities {
-	input := value.JSValue()
+// RtpCapabilities object and copy all values in the value javascript object.
+func RtpCapabilitiesFromJS(value js.Value) *RtpCapabilities {
 	var out RtpCapabilities
 	var (
 		value0 []*RtpCodecCapability           // javascript: sequence<RTCRtpCodecCapability> {codecs Codecs codecs}
 		value1 []*RtpHeaderExtensionCapability // javascript: sequence<RTCRtpHeaderExtensionCapability> {headerExtensions HeaderExtensions headerExtensions}
 	)
-	__length0 := input.Get("codecs").Length()
+	__length0 := value.Get("codecs").Length()
 	__array0 := make([]*RtpCodecCapability, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpCodecCapability
-		__seq_in0 := input.Get("codecs").Index(__idx0)
+		__seq_in0 := value.Get("codecs").Index(__idx0)
 		__seq_out0 = RtpCodecCapabilityFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Codecs = value0
-	__length1 := input.Get("headerExtensions").Length()
+	__length1 := value.Get("headerExtensions").Length()
 	__array1 := make([]*RtpHeaderExtensionCapability, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *RtpHeaderExtensionCapability
-		__seq_in1 := input.Get("headerExtensions").Index(__idx1)
+		__seq_in1 := value.Get("headerExtensions").Index(__idx1)
 		__seq_out1 = RtpHeaderExtensionCapabilityFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
@@ -2383,7 +2346,7 @@ type RtpCodecCapability struct {
 	SdpFmtpLine string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodecCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2399,10 +2362,8 @@ func (_this *RtpCodecCapability) JSValue() js.Value {
 }
 
 // RtpCodecCapabilityFromJS is allocating a new
-// RtpCodecCapability object and copy all values from
-// input javascript object
-func RtpCodecCapabilityFromJS(value js.Wrapper) *RtpCodecCapability {
-	input := value.JSValue()
+// RtpCodecCapability object and copy all values in the value javascript object.
+func RtpCodecCapabilityFromJS(value js.Value) *RtpCodecCapability {
 	var out RtpCodecCapability
 	var (
 		value0 string // javascript: DOMString {mimeType MimeType mimeType}
@@ -2410,13 +2371,13 @@ func RtpCodecCapabilityFromJS(value js.Wrapper) *RtpCodecCapability {
 		value2 int    // javascript: unsigned short {channels Channels channels}
 		value3 string // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 	)
-	value0 = (input.Get("mimeType")).String()
+	value0 = (value.Get("mimeType")).String()
 	out.MimeType = value0
-	value1 = (uint)((input.Get("clockRate")).Int())
+	value1 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value1
-	value2 = (input.Get("channels")).Int()
+	value2 = (value.Get("channels")).Int()
 	out.Channels = value2
-	value3 = (input.Get("sdpFmtpLine")).String()
+	value3 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value3
 	return &out
 }
@@ -2430,7 +2391,7 @@ type RtpCodecParameters struct {
 	SdpFmtpLine string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodecParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2448,10 +2409,8 @@ func (_this *RtpCodecParameters) JSValue() js.Value {
 }
 
 // RtpCodecParametersFromJS is allocating a new
-// RtpCodecParameters object and copy all values from
-// input javascript object
-func RtpCodecParametersFromJS(value js.Wrapper) *RtpCodecParameters {
-	input := value.JSValue()
+// RtpCodecParameters object and copy all values in the value javascript object.
+func RtpCodecParametersFromJS(value js.Value) *RtpCodecParameters {
 	var out RtpCodecParameters
 	var (
 		value0 int    // javascript: octet {payloadType PayloadType payloadType}
@@ -2460,15 +2419,15 @@ func RtpCodecParametersFromJS(value js.Wrapper) *RtpCodecParameters {
 		value3 int    // javascript: unsigned short {channels Channels channels}
 		value4 string // javascript: DOMString {sdpFmtpLine SdpFmtpLine sdpFmtpLine}
 	)
-	value0 = (input.Get("payloadType")).Int()
+	value0 = (value.Get("payloadType")).Int()
 	out.PayloadType = value0
-	value1 = (input.Get("mimeType")).String()
+	value1 = (value.Get("mimeType")).String()
 	out.MimeType = value1
-	value2 = (uint)((input.Get("clockRate")).Int())
+	value2 = (uint)((value.Get("clockRate")).Int())
 	out.ClockRate = value2
-	value3 = (input.Get("channels")).Int()
+	value3 = (value.Get("channels")).Int()
 	out.Channels = value3
-	value4 = (input.Get("sdpFmtpLine")).String()
+	value4 = (value.Get("sdpFmtpLine")).String()
 	out.SdpFmtpLine = value4
 	return &out
 }
@@ -2478,7 +2437,7 @@ type RtpCodingParameters struct {
 	Rid string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpCodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2488,15 +2447,13 @@ func (_this *RtpCodingParameters) JSValue() js.Value {
 }
 
 // RtpCodingParametersFromJS is allocating a new
-// RtpCodingParameters object and copy all values from
-// input javascript object
-func RtpCodingParametersFromJS(value js.Wrapper) *RtpCodingParameters {
-	input := value.JSValue()
+// RtpCodingParameters object and copy all values in the value javascript object.
+func RtpCodingParametersFromJS(value js.Value) *RtpCodingParameters {
 	var out RtpCodingParameters
 	var (
 		value0 string // javascript: DOMString {rid Rid rid}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
 	return &out
 }
@@ -2508,7 +2465,7 @@ type RtpContributingSource struct {
 	AudioLevel float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpContributingSource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2522,21 +2479,19 @@ func (_this *RtpContributingSource) JSValue() js.Value {
 }
 
 // RtpContributingSourceFromJS is allocating a new
-// RtpContributingSource object and copy all values from
-// input javascript object
-func RtpContributingSourceFromJS(value js.Wrapper) *RtpContributingSource {
-	input := value.JSValue()
+// RtpContributingSource object and copy all values in the value javascript object.
+func RtpContributingSourceFromJS(value js.Value) *RtpContributingSource {
 	var out RtpContributingSource
 	var (
 		value0 float64 // javascript: double {timestamp Timestamp timestamp}
 		value1 uint    // javascript: unsigned long {source Source source}
 		value2 float64 // javascript: double {audioLevel AudioLevel audioLevel}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = (uint)((input.Get("source")).Int())
+	value1 = (uint)((value.Get("source")).Int())
 	out.Source = value1
-	value2 = (input.Get("audioLevel")).Float()
+	value2 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value2
 	return &out
 }
@@ -2546,7 +2501,7 @@ type RtpDecodingParameters struct {
 	Rid string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpDecodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2556,15 +2511,13 @@ func (_this *RtpDecodingParameters) JSValue() js.Value {
 }
 
 // RtpDecodingParametersFromJS is allocating a new
-// RtpDecodingParameters object and copy all values from
-// input javascript object
-func RtpDecodingParametersFromJS(value js.Wrapper) *RtpDecodingParameters {
-	input := value.JSValue()
+// RtpDecodingParameters object and copy all values in the value javascript object.
+func RtpDecodingParametersFromJS(value js.Value) *RtpDecodingParameters {
 	var out RtpDecodingParameters
 	var (
 		value0 string // javascript: DOMString {rid Rid rid}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
 	return &out
 }
@@ -2582,7 +2535,7 @@ type RtpEncodingParameters struct {
 	NetworkPriority       PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpEncodingParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2608,10 +2561,8 @@ func (_this *RtpEncodingParameters) JSValue() js.Value {
 }
 
 // RtpEncodingParametersFromJS is allocating a new
-// RtpEncodingParameters object and copy all values from
-// input javascript object
-func RtpEncodingParametersFromJS(value js.Wrapper) *RtpEncodingParameters {
-	input := value.JSValue()
+// RtpEncodingParameters object and copy all values in the value javascript object.
+func RtpEncodingParametersFromJS(value js.Value) *RtpEncodingParameters {
 	var out RtpEncodingParameters
 	var (
 		value0 string       // javascript: DOMString {rid Rid rid}
@@ -2624,23 +2575,23 @@ func RtpEncodingParametersFromJS(value js.Wrapper) *RtpEncodingParameters {
 		value7 float64      // javascript: double {scaleResolutionDownBy ScaleResolutionDownBy scaleResolutionDownBy}
 		value8 PriorityType // javascript: RTCPriorityType {networkPriority NetworkPriority networkPriority}
 	)
-	value0 = (input.Get("rid")).String()
+	value0 = (value.Get("rid")).String()
 	out.Rid = value0
-	value1 = (input.Get("codecPayloadType")).Int()
+	value1 = (value.Get("codecPayloadType")).Int()
 	out.CodecPayloadType = value1
-	value2 = DtxStatusFromJS(input.Get("dtx"))
+	value2 = DtxStatusFromJS(value.Get("dtx"))
 	out.Dtx = value2
-	value3 = (input.Get("active")).Bool()
+	value3 = (value.Get("active")).Bool()
 	out.Active = value3
-	value4 = (uint)((input.Get("ptime")).Int())
+	value4 = (uint)((value.Get("ptime")).Int())
 	out.Ptime = value4
-	value5 = (uint)((input.Get("maxBitrate")).Int())
+	value5 = (uint)((value.Get("maxBitrate")).Int())
 	out.MaxBitrate = value5
-	value6 = (input.Get("maxFramerate")).Float()
+	value6 = (value.Get("maxFramerate")).Float()
 	out.MaxFramerate = value6
-	value7 = (input.Get("scaleResolutionDownBy")).Float()
+	value7 = (value.Get("scaleResolutionDownBy")).Float()
 	out.ScaleResolutionDownBy = value7
-	value8 = PriorityTypeFromJS(input.Get("networkPriority"))
+	value8 = PriorityTypeFromJS(value.Get("networkPriority"))
 	out.NetworkPriority = value8
 	return &out
 }
@@ -2650,7 +2601,7 @@ type RtpHeaderExtensionCapability struct {
 	Uri string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpHeaderExtensionCapability) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2660,15 +2611,13 @@ func (_this *RtpHeaderExtensionCapability) JSValue() js.Value {
 }
 
 // RtpHeaderExtensionCapabilityFromJS is allocating a new
-// RtpHeaderExtensionCapability object and copy all values from
-// input javascript object
-func RtpHeaderExtensionCapabilityFromJS(value js.Wrapper) *RtpHeaderExtensionCapability {
-	input := value.JSValue()
+// RtpHeaderExtensionCapability object and copy all values in the value javascript object.
+func RtpHeaderExtensionCapabilityFromJS(value js.Value) *RtpHeaderExtensionCapability {
 	var out RtpHeaderExtensionCapability
 	var (
 		value0 string // javascript: DOMString {uri Uri uri}
 	)
-	value0 = (input.Get("uri")).String()
+	value0 = (value.Get("uri")).String()
 	out.Uri = value0
 	return &out
 }
@@ -2680,7 +2629,7 @@ type RtpHeaderExtensionParameters struct {
 	Encrypted bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpHeaderExtensionParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2694,21 +2643,19 @@ func (_this *RtpHeaderExtensionParameters) JSValue() js.Value {
 }
 
 // RtpHeaderExtensionParametersFromJS is allocating a new
-// RtpHeaderExtensionParameters object and copy all values from
-// input javascript object
-func RtpHeaderExtensionParametersFromJS(value js.Wrapper) *RtpHeaderExtensionParameters {
-	input := value.JSValue()
+// RtpHeaderExtensionParameters object and copy all values in the value javascript object.
+func RtpHeaderExtensionParametersFromJS(value js.Value) *RtpHeaderExtensionParameters {
 	var out RtpHeaderExtensionParameters
 	var (
 		value0 string // javascript: DOMString {uri Uri uri}
 		value1 int    // javascript: unsigned short {id Id id}
 		value2 bool   // javascript: boolean {encrypted Encrypted encrypted}
 	)
-	value0 = (input.Get("uri")).String()
+	value0 = (value.Get("uri")).String()
 	out.Uri = value0
-	value1 = (input.Get("id")).Int()
+	value1 = (value.Get("id")).Int()
 	out.Id = value1
-	value2 = (input.Get("encrypted")).Bool()
+	value2 = (value.Get("encrypted")).Bool()
 	out.Encrypted = value2
 	return &out
 }
@@ -2720,7 +2667,7 @@ type RtpParameters struct {
 	Codecs           []*RtpCodecParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2742,33 +2689,31 @@ func (_this *RtpParameters) JSValue() js.Value {
 }
 
 // RtpParametersFromJS is allocating a new
-// RtpParameters object and copy all values from
-// input javascript object
-func RtpParametersFromJS(value js.Wrapper) *RtpParameters {
-	input := value.JSValue()
+// RtpParameters object and copy all values in the value javascript object.
+func RtpParametersFromJS(value js.Value) *RtpParameters {
 	var out RtpParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
 		value1 *RtcpParameters                 // javascript: RTCRtcpParameters {rtcp Rtcp rtcp}
 		value2 []*RtpCodecParameters           // javascript: sequence<RTCRtpCodecParameters> {codecs Codecs codecs}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -2785,7 +2730,7 @@ type RtpReceiveParameters struct {
 	Encodings        []*RtpDecodingParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpReceiveParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2813,10 +2758,8 @@ func (_this *RtpReceiveParameters) JSValue() js.Value {
 }
 
 // RtpReceiveParametersFromJS is allocating a new
-// RtpReceiveParameters object and copy all values from
-// input javascript object
-func RtpReceiveParametersFromJS(value js.Wrapper) *RtpReceiveParameters {
-	input := value.JSValue()
+// RtpReceiveParameters object and copy all values in the value javascript object.
+func RtpReceiveParametersFromJS(value js.Value) *RtpReceiveParameters {
 	var out RtpReceiveParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
@@ -2824,33 +2767,33 @@ func RtpReceiveParametersFromJS(value js.Wrapper) *RtpReceiveParameters {
 		value2 []*RtpCodecParameters           // javascript: sequence<RTCRtpCodecParameters> {codecs Codecs codecs}
 		value3 []*RtpDecodingParameters        // javascript: sequence<RTCRtpDecodingParameters> {encodings Encodings encodings}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Codecs = value2
-	__length3 := input.Get("encodings").Length()
+	__length3 := value.Get("encodings").Length()
 	__array3 := make([]*RtpDecodingParameters, __length3, __length3)
 	for __idx3 := 0; __idx3 < __length3; __idx3++ {
 		var __seq_out3 *RtpDecodingParameters
-		__seq_in3 := input.Get("encodings").Index(__idx3)
+		__seq_in3 := value.Get("encodings").Index(__idx3)
 		__seq_out3 = RtpDecodingParametersFromJS(__seq_in3)
 		__array3[__idx3] = __seq_out3
 	}
@@ -2870,7 +2813,7 @@ type RtpSendParameters struct {
 	Priority              PriorityType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpSendParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2904,10 +2847,8 @@ func (_this *RtpSendParameters) JSValue() js.Value {
 }
 
 // RtpSendParametersFromJS is allocating a new
-// RtpSendParameters object and copy all values from
-// input javascript object
-func RtpSendParametersFromJS(value js.Wrapper) *RtpSendParameters {
-	input := value.JSValue()
+// RtpSendParameters object and copy all values in the value javascript object.
+func RtpSendParametersFromJS(value js.Value) *RtpSendParameters {
 	var out RtpSendParameters
 	var (
 		value0 []*RtpHeaderExtensionParameters // javascript: sequence<RTCRtpHeaderExtensionParameters> {headerExtensions HeaderExtensions headerExtensions}
@@ -2918,43 +2859,43 @@ func RtpSendParametersFromJS(value js.Wrapper) *RtpSendParameters {
 		value5 DegradationPreference           // javascript: RTCDegradationPreference {degradationPreference DegradationPreference degradationPreference}
 		value6 PriorityType                    // javascript: RTCPriorityType {priority Priority priority}
 	)
-	__length0 := input.Get("headerExtensions").Length()
+	__length0 := value.Get("headerExtensions").Length()
 	__array0 := make([]*RtpHeaderExtensionParameters, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *RtpHeaderExtensionParameters
-		__seq_in0 := input.Get("headerExtensions").Index(__idx0)
+		__seq_in0 := value.Get("headerExtensions").Index(__idx0)
 		__seq_out0 = RtpHeaderExtensionParametersFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.HeaderExtensions = value0
-	value1 = RtcpParametersFromJS(input.Get("rtcp"))
+	value1 = RtcpParametersFromJS(value.Get("rtcp"))
 	out.Rtcp = value1
-	__length2 := input.Get("codecs").Length()
+	__length2 := value.Get("codecs").Length()
 	__array2 := make([]*RtpCodecParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpCodecParameters
-		__seq_in2 := input.Get("codecs").Index(__idx2)
+		__seq_in2 := value.Get("codecs").Index(__idx2)
 		__seq_out2 = RtpCodecParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Codecs = value2
-	value3 = (input.Get("transactionId")).String()
+	value3 = (value.Get("transactionId")).String()
 	out.TransactionId = value3
-	__length4 := input.Get("encodings").Length()
+	__length4 := value.Get("encodings").Length()
 	__array4 := make([]*RtpEncodingParameters, __length4, __length4)
 	for __idx4 := 0; __idx4 < __length4; __idx4++ {
 		var __seq_out4 *RtpEncodingParameters
-		__seq_in4 := input.Get("encodings").Index(__idx4)
+		__seq_in4 := value.Get("encodings").Index(__idx4)
 		__seq_out4 = RtpEncodingParametersFromJS(__seq_in4)
 		__array4[__idx4] = __seq_out4
 	}
 	value4 = __array4
 	out.Encodings = value4
-	value5 = DegradationPreferenceFromJS(input.Get("degradationPreference"))
+	value5 = DegradationPreferenceFromJS(value.Get("degradationPreference"))
 	out.DegradationPreference = value5
-	value6 = PriorityTypeFromJS(input.Get("priority"))
+	value6 = PriorityTypeFromJS(value.Get("priority"))
 	out.Priority = value6
 	return &out
 }
@@ -2967,7 +2908,7 @@ type RtpSynchronizationSource struct {
 	VoiceActivityFlag bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpSynchronizationSource) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -2983,10 +2924,8 @@ func (_this *RtpSynchronizationSource) JSValue() js.Value {
 }
 
 // RtpSynchronizationSourceFromJS is allocating a new
-// RtpSynchronizationSource object and copy all values from
-// input javascript object
-func RtpSynchronizationSourceFromJS(value js.Wrapper) *RtpSynchronizationSource {
-	input := value.JSValue()
+// RtpSynchronizationSource object and copy all values in the value javascript object.
+func RtpSynchronizationSourceFromJS(value js.Value) *RtpSynchronizationSource {
 	var out RtpSynchronizationSource
 	var (
 		value0 float64 // javascript: double {timestamp Timestamp timestamp}
@@ -2994,13 +2933,13 @@ func RtpSynchronizationSourceFromJS(value js.Wrapper) *RtpSynchronizationSource 
 		value2 float64 // javascript: double {audioLevel AudioLevel audioLevel}
 		value3 bool    // javascript: boolean {voiceActivityFlag VoiceActivityFlag voiceActivityFlag}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = (uint)((input.Get("source")).Int())
+	value1 = (uint)((value.Get("source")).Int())
 	out.Source = value1
-	value2 = (input.Get("audioLevel")).Float()
+	value2 = (value.Get("audioLevel")).Float()
 	out.AudioLevel = value2
-	value3 = (input.Get("voiceActivityFlag")).Bool()
+	value3 = (value.Get("voiceActivityFlag")).Bool()
 	out.VoiceActivityFlag = value3
 	return &out
 }
@@ -3012,7 +2951,7 @@ type RtpTransceiverInit struct {
 	SendEncodings []*RtpEncodingParameters
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RtpTransceiverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3034,33 +2973,31 @@ func (_this *RtpTransceiverInit) JSValue() js.Value {
 }
 
 // RtpTransceiverInitFromJS is allocating a new
-// RtpTransceiverInit object and copy all values from
-// input javascript object
-func RtpTransceiverInitFromJS(value js.Wrapper) *RtpTransceiverInit {
-	input := value.JSValue()
+// RtpTransceiverInit object and copy all values in the value javascript object.
+func RtpTransceiverInitFromJS(value js.Value) *RtpTransceiverInit {
 	var out RtpTransceiverInit
 	var (
 		value0 RtpTransceiverDirection  // javascript: RTCRtpTransceiverDirection {direction Direction direction}
 		value1 []*local.MediaStream     // javascript: sequence<MediaStream> {streams Streams streams}
 		value2 []*RtpEncodingParameters // javascript: sequence<RTCRtpEncodingParameters> {sendEncodings SendEncodings sendEncodings}
 	)
-	value0 = RtpTransceiverDirectionFromJS(input.Get("direction"))
+	value0 = RtpTransceiverDirectionFromJS(value.Get("direction"))
 	out.Direction = value0
-	__length1 := input.Get("streams").Length()
+	__length1 := value.Get("streams").Length()
 	__array1 := make([]*local.MediaStream, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *local.MediaStream
-		__seq_in1 := input.Get("streams").Index(__idx1)
+		__seq_in1 := value.Get("streams").Index(__idx1)
 		__seq_out1 = local.MediaStreamFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.Streams = value1
-	__length2 := input.Get("sendEncodings").Length()
+	__length2 := value.Get("sendEncodings").Length()
 	__array2 := make([]*RtpEncodingParameters, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *RtpEncodingParameters
-		__seq_in2 := input.Get("sendEncodings").Index(__idx2)
+		__seq_in2 := value.Get("sendEncodings").Index(__idx2)
 		__seq_out2 = RtpEncodingParametersFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -3075,7 +3012,7 @@ type SessionDescriptionInit struct {
 	Sdp  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SessionDescriptionInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3087,18 +3024,16 @@ func (_this *SessionDescriptionInit) JSValue() js.Value {
 }
 
 // SessionDescriptionInitFromJS is allocating a new
-// SessionDescriptionInit object and copy all values from
-// input javascript object
-func SessionDescriptionInitFromJS(value js.Wrapper) *SessionDescriptionInit {
-	input := value.JSValue()
+// SessionDescriptionInit object and copy all values in the value javascript object.
+func SessionDescriptionInitFromJS(value js.Value) *SessionDescriptionInit {
 	var out SessionDescriptionInit
 	var (
 		value0 SdpType // javascript: RTCSdpType {type Type _type}
 		value1 string  // javascript: DOMString {sdp Sdp sdp}
 	)
-	value0 = SdpTypeFromJS(input.Get("type"))
+	value0 = SdpTypeFromJS(value.Get("type"))
 	out.Type = value0
-	value1 = (input.Get("sdp")).String()
+	value1 = (value.Get("sdp")).String()
 	out.Sdp = value1
 	return &out
 }
@@ -3110,7 +3045,7 @@ type Stats struct {
 	Id        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Stats) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3124,21 +3059,19 @@ func (_this *Stats) JSValue() js.Value {
 }
 
 // StatsFromJS is allocating a new
-// Stats object and copy all values from
-// input javascript object
-func StatsFromJS(value js.Wrapper) *Stats {
-	input := value.JSValue()
+// Stats object and copy all values in the value javascript object.
+func StatsFromJS(value js.Value) *Stats {
 	var out Stats
 	var (
 		value0 float64   // javascript: double {timestamp Timestamp timestamp}
 		value1 StatsType // javascript: RTCStatsType {type Type _type}
 		value2 string    // javascript: DOMString {id Id id}
 	)
-	value0 = (input.Get("timestamp")).Float()
+	value0 = (value.Get("timestamp")).Float()
 	out.Timestamp = value0
-	value1 = StatsTypeFromJS(input.Get("type"))
+	value1 = StatsTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = (input.Get("id")).String()
+	value2 = (value.Get("id")).String()
 	out.Id = value2
 	return &out
 }
@@ -3151,7 +3084,7 @@ type StatsEventInit struct {
 	Report     *StatsReport
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3167,10 +3100,8 @@ func (_this *StatsEventInit) JSValue() js.Value {
 }
 
 // StatsEventInitFromJS is allocating a new
-// StatsEventInit object and copy all values from
-// input javascript object
-func StatsEventInitFromJS(value js.Wrapper) *StatsEventInit {
-	input := value.JSValue()
+// StatsEventInit object and copy all values in the value javascript object.
+func StatsEventInitFromJS(value js.Value) *StatsEventInit {
 	var out StatsEventInit
 	var (
 		value0 bool         // javascript: boolean {bubbles Bubbles bubbles}
@@ -3178,13 +3109,13 @@ func StatsEventInitFromJS(value js.Wrapper) *StatsEventInit {
 		value2 bool         // javascript: boolean {composed Composed composed}
 		value3 *StatsReport // javascript: RTCStatsReport {report Report report}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = StatsReportFromJS(input.Get("report"))
+	value3 = StatsReportFromJS(value.Get("report"))
 	out.Report = value3
 	return &out
 }
@@ -3195,7 +3126,7 @@ type StatsReportEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3211,26 +3142,24 @@ func (_this *StatsReportEntryIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportEntryIteratorValueFromJS is allocating a new
-// StatsReportEntryIteratorValue object and copy all values from
-// input javascript object
-func StatsReportEntryIteratorValueFromJS(value js.Wrapper) *StatsReportEntryIteratorValue {
-	input := value.JSValue()
+// StatsReportEntryIteratorValue object and copy all values in the value javascript object.
+func StatsReportEntryIteratorValueFromJS(value js.Value) *StatsReportEntryIteratorValue {
 	var out StatsReportEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3241,7 +3170,7 @@ type StatsReportKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3253,18 +3182,16 @@ func (_this *StatsReportKeyIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportKeyIteratorValueFromJS is allocating a new
-// StatsReportKeyIteratorValue object and copy all values from
-// input javascript object
-func StatsReportKeyIteratorValueFromJS(value js.Wrapper) *StatsReportKeyIteratorValue {
-	input := value.JSValue()
+// StatsReportKeyIteratorValue object and copy all values in the value javascript object.
+func StatsReportKeyIteratorValueFromJS(value js.Value) *StatsReportKeyIteratorValue {
 	var out StatsReportKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3275,7 +3202,7 @@ type StatsReportValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StatsReportValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3287,18 +3214,16 @@ func (_this *StatsReportValueIteratorValue) JSValue() js.Value {
 }
 
 // StatsReportValueIteratorValueFromJS is allocating a new
-// StatsReportValueIteratorValue object and copy all values from
-// input javascript object
-func StatsReportValueIteratorValueFromJS(value js.Wrapper) *StatsReportValueIteratorValue {
-	input := value.JSValue()
+// StatsReportValueIteratorValue object and copy all values in the value javascript object.
+func StatsReportValueIteratorValueFromJS(value js.Value) *StatsReportValueIteratorValue {
 	var out StatsReportValueIteratorValue
 	var (
 		value0 *javascript.Object // javascript: object {value Value value}
 		value1 bool               // javascript: boolean {done Done done}
 	)
-	value0 = javascript.ObjectFromJS(input.Get("value"))
+	value0 = javascript.ObjectFromJS(value.Get("value"))
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -3314,7 +3239,7 @@ type TrackEventInit struct {
 	Transceiver *RtpTransceiver
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *TrackEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -3340,10 +3265,8 @@ func (_this *TrackEventInit) JSValue() js.Value {
 }
 
 // TrackEventInitFromJS is allocating a new
-// TrackEventInit object and copy all values from
-// input javascript object
-func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
-	input := value.JSValue()
+// TrackEventInit object and copy all values in the value javascript object.
+func TrackEventInitFromJS(value js.Value) *TrackEventInit {
 	var out TrackEventInit
 	var (
 		value0 bool                    // javascript: boolean {bubbles Bubbles bubbles}
@@ -3354,27 +3277,27 @@ func TrackEventInitFromJS(value js.Wrapper) *TrackEventInit {
 		value5 []*local.MediaStream    // javascript: sequence<MediaStream> {streams Streams streams}
 		value6 *RtpTransceiver         // javascript: RTCRtpTransceiver {transceiver Transceiver transceiver}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = RtpReceiverFromJS(input.Get("receiver"))
+	value3 = RtpReceiverFromJS(value.Get("receiver"))
 	out.Receiver = value3
-	value4 = local.MediaStreamTrackFromJS(input.Get("track"))
+	value4 = local.MediaStreamTrackFromJS(value.Get("track"))
 	out.Track = value4
-	__length5 := input.Get("streams").Length()
+	__length5 := value.Get("streams").Length()
 	__array5 := make([]*local.MediaStream, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *local.MediaStream
-		__seq_in5 := input.Get("streams").Index(__idx5)
+		__seq_in5 := value.Get("streams").Index(__idx5)
 		__seq_out5 = local.MediaStreamFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
 	value5 = __array5
 	out.Streams = value5
-	value6 = RtpTransceiverFromJS(input.Get("transceiver"))
+	value6 = RtpTransceiverFromJS(value.Get("transceiver"))
 	out.Transceiver = value6
 	return &out
 }
@@ -3389,15 +3312,19 @@ func (_this *Certificate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CertificateFromJS is casting a js.Wrapper into Certificate.
-func CertificateFromJS(value js.Wrapper) *Certificate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CertificateFromJS is casting a js.Value into Certificate.
+func CertificateFromJS(value js.Value) *Certificate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Certificate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CertificateFromJS is casting from something that holds a js.Value into Certificate.
+func CertificateFromWrapper(input core.Wrapper) *Certificate {
+	return CertificateFromJS(input.JSValue())
 }
 
 func GetSupportedAlgorithms() (_result []*Union) {
@@ -3460,15 +3387,19 @@ type DTMFSender struct {
 	domcore.EventTarget
 }
 
-// DTMFSenderFromJS is casting a js.Wrapper into DTMFSender.
-func DTMFSenderFromJS(value js.Wrapper) *DTMFSender {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DTMFSenderFromJS is casting a js.Value into DTMFSender.
+func DTMFSenderFromJS(value js.Value) *DTMFSender {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DTMFSender{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DTMFSenderFromJS is casting from something that holds a js.Value into DTMFSender.
+func DTMFSenderFromWrapper(input core.Wrapper) *DTMFSender {
+	return DTMFSenderFromJS(input.JSValue())
 }
 
 // OnToneChange returning attribute 'ontonechange' with
@@ -3569,15 +3500,19 @@ type DTMFToneChangeEvent struct {
 	domcore.Event
 }
 
-// DTMFToneChangeEventFromJS is casting a js.Wrapper into DTMFToneChangeEvent.
-func DTMFToneChangeEventFromJS(value js.Wrapper) *DTMFToneChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DTMFToneChangeEventFromJS is casting a js.Value into DTMFToneChangeEvent.
+func DTMFToneChangeEventFromJS(value js.Value) *DTMFToneChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DTMFToneChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DTMFToneChangeEventFromJS is casting from something that holds a js.Value into DTMFToneChangeEvent.
+func DTMFToneChangeEventFromWrapper(input core.Wrapper) *DTMFToneChangeEvent {
+	return DTMFToneChangeEventFromJS(input.JSValue())
 }
 
 func NewRTCDTMFToneChangeEvent(_type string, eventInitDict *DTMFToneChangeEventInit) (_result *DTMFToneChangeEvent) {
@@ -3615,15 +3550,19 @@ type DataChannel struct {
 	domcore.EventTarget
 }
 
-// DataChannelFromJS is casting a js.Wrapper into DataChannel.
-func DataChannelFromJS(value js.Wrapper) *DataChannel {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataChannelFromJS is casting a js.Value into DataChannel.
+func DataChannelFromJS(value js.Value) *DataChannel {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataChannel{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataChannelFromJS is casting from something that holds a js.Value into DataChannel.
+func DataChannelFromWrapper(input core.Wrapper) *DataChannel {
+	return DataChannelFromJS(input.JSValue())
 }
 
 // Label returning attribute 'label' with
@@ -3996,15 +3935,19 @@ type DataChannelEvent struct {
 	domcore.Event
 }
 
-// DataChannelEventFromJS is casting a js.Wrapper into DataChannelEvent.
-func DataChannelEventFromJS(value js.Wrapper) *DataChannelEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DataChannelEventFromJS is casting a js.Value into DataChannelEvent.
+func DataChannelEventFromJS(value js.Value) *DataChannelEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DataChannelEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DataChannelEventFromJS is casting from something that holds a js.Value into DataChannelEvent.
+func DataChannelEventFromWrapper(input core.Wrapper) *DataChannelEvent {
+	return DataChannelEventFromJS(input.JSValue())
 }
 
 func NewRTCDataChannelEvent(_type string, eventInitDict *DataChannelEventInit) (_result *DataChannelEvent) {
@@ -4042,15 +3985,19 @@ type DtlsTransport struct {
 	domcore.EventTarget
 }
 
-// DtlsTransportFromJS is casting a js.Wrapper into DtlsTransport.
-func DtlsTransportFromJS(value js.Wrapper) *DtlsTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DtlsTransportFromJS is casting a js.Value into DtlsTransport.
+func DtlsTransportFromJS(value js.Value) *DtlsTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DtlsTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DtlsTransportFromJS is casting from something that holds a js.Value into DtlsTransport.
+func DtlsTransportFromWrapper(input core.Wrapper) *DtlsTransport {
+	return DtlsTransportFromJS(input.JSValue())
 }
 
 // IceTransport returning attribute 'iceTransport' with
@@ -4185,15 +4132,19 @@ func (_this *Error) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ErrorFromJS is casting a js.Wrapper into Error.
-func ErrorFromJS(value js.Wrapper) *Error {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorFromJS is casting a js.Value into Error.
+func ErrorFromJS(value js.Value) *Error {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Error{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorFromJS is casting from something that holds a js.Value into Error.
+func ErrorFromWrapper(input core.Wrapper) *Error {
+	return ErrorFromJS(input.JSValue())
 }
 
 // class: RTCErrorEvent
@@ -4201,15 +4152,19 @@ type ErrorEvent struct {
 	domcore.Event
 }
 
-// ErrorEventFromJS is casting a js.Wrapper into ErrorEvent.
-func ErrorEventFromJS(value js.Wrapper) *ErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ErrorEventFromJS is casting a js.Value into ErrorEvent.
+func ErrorEventFromJS(value js.Value) *ErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ErrorEventFromJS is casting from something that holds a js.Value into ErrorEvent.
+func ErrorEventFromWrapper(input core.Wrapper) *ErrorEvent {
+	return ErrorEventFromJS(input.JSValue())
 }
 
 func NewRTCErrorEvent(_type string, eventInitDict *ErrorEventInit) (_result *ErrorEvent) {
@@ -4254,15 +4209,19 @@ func (_this *IceCandidate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// IceCandidateFromJS is casting a js.Wrapper into IceCandidate.
-func IceCandidateFromJS(value js.Wrapper) *IceCandidate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IceCandidateFromJS is casting a js.Value into IceCandidate.
+func IceCandidateFromJS(value js.Value) *IceCandidate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IceCandidate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IceCandidateFromJS is casting from something that holds a js.Value into IceCandidate.
+func IceCandidateFromWrapper(input core.Wrapper) *IceCandidate {
+	return IceCandidateFromJS(input.JSValue())
 }
 
 func NewRTCIceCandidate(candidateInitDict *IceCandidateInit) (_result *IceCandidate) {
@@ -4469,15 +4428,19 @@ type IceTransport struct {
 	domcore.EventTarget
 }
 
-// IceTransportFromJS is casting a js.Wrapper into IceTransport.
-func IceTransportFromJS(value js.Wrapper) *IceTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// IceTransportFromJS is casting a js.Value into IceTransport.
+func IceTransportFromJS(value js.Value) *IceTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &IceTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// IceTransportFromJS is casting from something that holds a js.Value into IceTransport.
+func IceTransportFromWrapper(input core.Wrapper) *IceTransport {
+	return IceTransportFromJS(input.JSValue())
 }
 
 // Role returning attribute 'role' with
@@ -4708,15 +4671,19 @@ type PeerConnection struct {
 	domcore.EventTarget
 }
 
-// PeerConnectionFromJS is casting a js.Wrapper into PeerConnection.
-func PeerConnectionFromJS(value js.Wrapper) *PeerConnection {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionFromJS is casting a js.Value into PeerConnection.
+func PeerConnectionFromJS(value js.Value) *PeerConnection {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnection{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionFromJS is casting from something that holds a js.Value into PeerConnection.
+func PeerConnectionFromWrapper(input core.Wrapper) *PeerConnection {
+	return PeerConnectionFromJS(input.JSValue())
 }
 
 func GetDefaultIceServers() (_result []*IceServer) {
@@ -5737,15 +5704,19 @@ type PeerConnectionIceErrorEvent struct {
 	domcore.Event
 }
 
-// PeerConnectionIceErrorEventFromJS is casting a js.Wrapper into PeerConnectionIceErrorEvent.
-func PeerConnectionIceErrorEventFromJS(value js.Wrapper) *PeerConnectionIceErrorEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionIceErrorEventFromJS is casting a js.Value into PeerConnectionIceErrorEvent.
+func PeerConnectionIceErrorEventFromJS(value js.Value) *PeerConnectionIceErrorEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnectionIceErrorEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionIceErrorEventFromJS is casting from something that holds a js.Value into PeerConnectionIceErrorEvent.
+func PeerConnectionIceErrorEventFromWrapper(input core.Wrapper) *PeerConnectionIceErrorEvent {
+	return PeerConnectionIceErrorEventFromJS(input.JSValue())
 }
 
 func NewRTCPeerConnectionIceErrorEvent(_type string, eventInitDict *PeerConnectionIceErrorEventInit) (_result *PeerConnectionIceErrorEvent) {
@@ -5810,15 +5781,19 @@ type PeerConnectionIceEvent struct {
 	domcore.Event
 }
 
-// PeerConnectionIceEventFromJS is casting a js.Wrapper into PeerConnectionIceEvent.
-func PeerConnectionIceEventFromJS(value js.Wrapper) *PeerConnectionIceEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PeerConnectionIceEventFromJS is casting a js.Value into PeerConnectionIceEvent.
+func PeerConnectionIceEventFromJS(value js.Value) *PeerConnectionIceEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PeerConnectionIceEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PeerConnectionIceEventFromJS is casting from something that holds a js.Value into PeerConnectionIceEvent.
+func PeerConnectionIceEventFromWrapper(input core.Wrapper) *PeerConnectionIceEvent {
+	return PeerConnectionIceEventFromJS(input.JSValue())
 }
 
 func NewRTCPeerConnectionIceEvent(_type string, eventInitDict *PeerConnectionIceEventInit) (_result *PeerConnectionIceEvent) {
@@ -5877,15 +5852,19 @@ func (_this *PromiseCertificate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCertificateFromJS is casting a js.Wrapper into PromiseCertificate.
-func PromiseCertificateFromJS(value js.Wrapper) *PromiseCertificate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCertificateFromJS is casting a js.Value into PromiseCertificate.
+func PromiseCertificateFromJS(value js.Value) *PromiseCertificate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCertificate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCertificateFromJS is casting from something that holds a js.Value into PromiseCertificate.
+func PromiseCertificateFromWrapper(input core.Wrapper) *PromiseCertificate {
+	return PromiseCertificateFromJS(input.JSValue())
 }
 
 func (_this *PromiseCertificate) Then(onFulfilled *PromiseCertificateOnFulfilled, onRejected *PromiseCertificateOnRejected) (_result *PromiseCertificate) {
@@ -5982,15 +5961,19 @@ func (_this *PromiseSessionDescriptionInit) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSessionDescriptionInitFromJS is casting a js.Wrapper into PromiseSessionDescriptionInit.
-func PromiseSessionDescriptionInitFromJS(value js.Wrapper) *PromiseSessionDescriptionInit {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSessionDescriptionInitFromJS is casting a js.Value into PromiseSessionDescriptionInit.
+func PromiseSessionDescriptionInitFromJS(value js.Value) *PromiseSessionDescriptionInit {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSessionDescriptionInit{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSessionDescriptionInitFromJS is casting from something that holds a js.Value into PromiseSessionDescriptionInit.
+func PromiseSessionDescriptionInitFromWrapper(input core.Wrapper) *PromiseSessionDescriptionInit {
+	return PromiseSessionDescriptionInitFromJS(input.JSValue())
 }
 
 func (_this *PromiseSessionDescriptionInit) Then(onFulfilled *PromiseSessionDescriptionInitOnFulfilled, onRejected *PromiseSessionDescriptionInitOnRejected) (_result *PromiseSessionDescriptionInit) {
@@ -6087,15 +6070,19 @@ func (_this *PromiseStatsReport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStatsReportFromJS is casting a js.Wrapper into PromiseStatsReport.
-func PromiseStatsReportFromJS(value js.Wrapper) *PromiseStatsReport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStatsReportFromJS is casting a js.Value into PromiseStatsReport.
+func PromiseStatsReportFromJS(value js.Value) *PromiseStatsReport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseStatsReport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStatsReportFromJS is casting from something that holds a js.Value into PromiseStatsReport.
+func PromiseStatsReportFromWrapper(input core.Wrapper) *PromiseStatsReport {
+	return PromiseStatsReportFromJS(input.JSValue())
 }
 
 func (_this *PromiseStatsReport) Then(onFulfilled *PromiseStatsReportOnFulfilled, onRejected *PromiseStatsReportOnRejected) (_result *PromiseStatsReport) {
@@ -6192,15 +6179,19 @@ func (_this *RtpReceiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpReceiverFromJS is casting a js.Wrapper into RtpReceiver.
-func RtpReceiverFromJS(value js.Wrapper) *RtpReceiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpReceiverFromJS is casting a js.Value into RtpReceiver.
+func RtpReceiverFromJS(value js.Value) *RtpReceiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpReceiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpReceiverFromJS is casting from something that holds a js.Value into RtpReceiver.
+func RtpReceiverFromWrapper(input core.Wrapper) *RtpReceiver {
+	return RtpReceiverFromJS(input.JSValue())
 }
 
 func GetCapabilities(kind string) (_result *RtpCapabilities) {
@@ -6337,15 +6328,19 @@ func (_this *RtpSender) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpSenderFromJS is casting a js.Wrapper into RtpSender.
-func RtpSenderFromJS(value js.Wrapper) *RtpSender {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpSenderFromJS is casting a js.Value into RtpSender.
+func RtpSenderFromJS(value js.Value) *RtpSender {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpSender{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpSenderFromJS is casting from something that holds a js.Value into RtpSender.
+func RtpSenderFromWrapper(input core.Wrapper) *RtpSender {
+	return RtpSenderFromJS(input.JSValue())
 }
 
 func GetCapabilities2(kind string) (_result *RtpCapabilities) {
@@ -6499,15 +6494,19 @@ func (_this *RtpTransceiver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// RtpTransceiverFromJS is casting a js.Wrapper into RtpTransceiver.
-func RtpTransceiverFromJS(value js.Wrapper) *RtpTransceiver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// RtpTransceiverFromJS is casting a js.Value into RtpTransceiver.
+func RtpTransceiverFromJS(value js.Value) *RtpTransceiver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &RtpTransceiver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// RtpTransceiverFromJS is casting from something that holds a js.Value into RtpTransceiver.
+func RtpTransceiverFromWrapper(input core.Wrapper) *RtpTransceiver {
+	return RtpTransceiverFromJS(input.JSValue())
 }
 
 // Mid returning attribute 'mid' with
@@ -6612,15 +6611,19 @@ func (_this *SctpTransport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SctpTransportFromJS is casting a js.Wrapper into SctpTransport.
-func SctpTransportFromJS(value js.Wrapper) *SctpTransport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SctpTransportFromJS is casting a js.Value into SctpTransport.
+func SctpTransportFromJS(value js.Value) *SctpTransport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SctpTransport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SctpTransportFromJS is casting from something that holds a js.Value into SctpTransport.
+func SctpTransportFromWrapper(input core.Wrapper) *SctpTransport {
+	return SctpTransportFromJS(input.JSValue())
 }
 
 // Transport returning attribute 'transport' with
@@ -6713,15 +6716,19 @@ func (_this *SessionDescription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SessionDescriptionFromJS is casting a js.Wrapper into SessionDescription.
-func SessionDescriptionFromJS(value js.Wrapper) *SessionDescription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SessionDescriptionFromJS is casting a js.Value into SessionDescription.
+func SessionDescriptionFromJS(value js.Value) *SessionDescription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SessionDescription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SessionDescriptionFromJS is casting from something that holds a js.Value into SessionDescription.
+func SessionDescriptionFromWrapper(input core.Wrapper) *SessionDescription {
+	return SessionDescriptionFromJS(input.JSValue())
 }
 
 func NewRTCSessionDescription(descriptionInitDict *SessionDescriptionInit) (_result *SessionDescription) {
@@ -6779,15 +6786,19 @@ type StatsEvent struct {
 	domcore.Event
 }
 
-// StatsEventFromJS is casting a js.Wrapper into StatsEvent.
-func StatsEventFromJS(value js.Wrapper) *StatsEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsEventFromJS is casting a js.Value into StatsEvent.
+func StatsEventFromJS(value js.Value) *StatsEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsEventFromJS is casting from something that holds a js.Value into StatsEvent.
+func StatsEventFromWrapper(input core.Wrapper) *StatsEvent {
+	return StatsEventFromJS(input.JSValue())
 }
 
 func NewRTCStatsEvent(_type string, eventInitDict *StatsEventInit) (_result *StatsEvent) {
@@ -6830,15 +6841,19 @@ func (_this *StatsReport) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportFromJS is casting a js.Wrapper into StatsReport.
-func StatsReportFromJS(value js.Wrapper) *StatsReport {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportFromJS is casting a js.Value into StatsReport.
+func StatsReportFromJS(value js.Value) *StatsReport {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReport{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportFromJS is casting from something that holds a js.Value into StatsReport.
+func StatsReportFromWrapper(input core.Wrapper) *StatsReport {
+	return StatsReportFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -6962,15 +6977,19 @@ func (_this *StatsReportEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportEntryIteratorFromJS is casting a js.Wrapper into StatsReportEntryIterator.
-func StatsReportEntryIteratorFromJS(value js.Wrapper) *StatsReportEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportEntryIteratorFromJS is casting a js.Value into StatsReportEntryIterator.
+func StatsReportEntryIteratorFromJS(value js.Value) *StatsReportEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportEntryIteratorFromJS is casting from something that holds a js.Value into StatsReportEntryIterator.
+func StatsReportEntryIteratorFromWrapper(input core.Wrapper) *StatsReportEntryIterator {
+	return StatsReportEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportEntryIterator) Next() (_result *StatsReportEntryIteratorValue) {
@@ -6997,15 +7016,19 @@ func (_this *StatsReportKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportKeyIteratorFromJS is casting a js.Wrapper into StatsReportKeyIterator.
-func StatsReportKeyIteratorFromJS(value js.Wrapper) *StatsReportKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportKeyIteratorFromJS is casting a js.Value into StatsReportKeyIterator.
+func StatsReportKeyIteratorFromJS(value js.Value) *StatsReportKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportKeyIteratorFromJS is casting from something that holds a js.Value into StatsReportKeyIterator.
+func StatsReportKeyIteratorFromWrapper(input core.Wrapper) *StatsReportKeyIterator {
+	return StatsReportKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportKeyIterator) Next() (_result *StatsReportKeyIteratorValue) {
@@ -7032,15 +7055,19 @@ func (_this *StatsReportValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StatsReportValueIteratorFromJS is casting a js.Wrapper into StatsReportValueIterator.
-func StatsReportValueIteratorFromJS(value js.Wrapper) *StatsReportValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StatsReportValueIteratorFromJS is casting a js.Value into StatsReportValueIterator.
+func StatsReportValueIteratorFromJS(value js.Value) *StatsReportValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StatsReportValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StatsReportValueIteratorFromJS is casting from something that holds a js.Value into StatsReportValueIterator.
+func StatsReportValueIteratorFromWrapper(input core.Wrapper) *StatsReportValueIterator {
+	return StatsReportValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *StatsReportValueIterator) Next() (_result *StatsReportValueIteratorValue) {
@@ -7062,15 +7089,19 @@ type TrackEvent struct {
 	domcore.Event
 }
 
-// TrackEventFromJS is casting a js.Wrapper into TrackEvent.
-func TrackEventFromJS(value js.Wrapper) *TrackEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TrackEventFromJS is casting a js.Value into TrackEvent.
+func TrackEventFromJS(value js.Value) *TrackEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TrackEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TrackEventFromJS is casting from something that holds a js.Value into TrackEvent.
+func TrackEventFromWrapper(input core.Wrapper) *TrackEvent {
+	return TrackEventFromJS(input.JSValue())
 }
 
 func NewRTCTrackEvent(_type string, eventInitDict *TrackEventInit) (_result *TrackEvent) {

--- a/media/webvtt/webvtt.go
+++ b/media/webvtt/webvtt.go
@@ -7,6 +7,7 @@ package webvtt
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/html/media"
 )
@@ -301,15 +302,19 @@ type VTTCue struct {
 	media.TextTrackCue
 }
 
-// VTTCueFromJS is casting a js.Wrapper into VTTCue.
-func VTTCueFromJS(value js.Wrapper) *VTTCue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VTTCueFromJS is casting a js.Value into VTTCue.
+func VTTCueFromJS(value js.Value) *VTTCue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VTTCue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VTTCueFromJS is casting from something that holds a js.Value into VTTCue.
+func VTTCueFromWrapper(input core.Wrapper) *VTTCue {
+	return VTTCueFromJS(input.JSValue())
 }
 
 func NewVTTCue(startTime float64, endTime float64, text string) (_result *VTTCue) {
@@ -522,15 +527,19 @@ func (_this *VTTRegion) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// VTTRegionFromJS is casting a js.Wrapper into VTTRegion.
-func VTTRegionFromJS(value js.Wrapper) *VTTRegion {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VTTRegionFromJS is casting a js.Value into VTTRegion.
+func VTTRegionFromJS(value js.Value) *VTTRegion {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VTTRegion{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VTTRegionFromJS is casting from something that holds a js.Value into VTTRegion.
+func VTTRegionFromWrapper(input core.Wrapper) *VTTRegion {
+	return VTTRegionFromJS(input.JSValue())
 }
 
 func NewVTTRegion() (_result *VTTRegion) {

--- a/media/webvtt/webvtt_js.go
+++ b/media/webvtt/webvtt_js.go
@@ -5,6 +5,7 @@ package webvtt
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom"
 	"github.com/gowebapi/webapi/html/media"
 )
@@ -299,15 +300,19 @@ type VTTCue struct {
 	media.TextTrackCue
 }
 
-// VTTCueFromJS is casting a js.Wrapper into VTTCue.
-func VTTCueFromJS(value js.Wrapper) *VTTCue {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VTTCueFromJS is casting a js.Value into VTTCue.
+func VTTCueFromJS(value js.Value) *VTTCue {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VTTCue{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VTTCueFromJS is casting from something that holds a js.Value into VTTCue.
+func VTTCueFromWrapper(input core.Wrapper) *VTTCue {
+	return VTTCueFromJS(input.JSValue())
 }
 
 func NewVTTCue(startTime float64, endTime float64, text string) (_result *VTTCue) {
@@ -520,15 +525,19 @@ func (_this *VTTRegion) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// VTTRegionFromJS is casting a js.Wrapper into VTTRegion.
-func VTTRegionFromJS(value js.Wrapper) *VTTRegion {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// VTTRegionFromJS is casting a js.Value into VTTRegion.
+func VTTRegionFromJS(value js.Value) *VTTRegion {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &VTTRegion{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// VTTRegionFromJS is casting from something that holds a js.Value into VTTRegion.
+func VTTRegionFromWrapper(input core.Wrapper) *VTTRegion {
+	return VTTRegionFromJS(input.JSValue())
 }
 
 func NewVTTRegion() (_result *VTTRegion) {

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -7,6 +7,7 @@ package notification
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -254,7 +255,7 @@ type GetNotificationOptions struct {
 	Tag string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GetNotificationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -264,15 +265,13 @@ func (_this *GetNotificationOptions) JSValue() js.Value {
 }
 
 // GetNotificationOptionsFromJS is allocating a new
-// GetNotificationOptions object and copy all values from
-// input javascript object
-func GetNotificationOptionsFromJS(value js.Wrapper) *GetNotificationOptions {
-	input := value.JSValue()
+// GetNotificationOptions object and copy all values in the value javascript object.
+func GetNotificationOptionsFromJS(value js.Value) *GetNotificationOptions {
 	var out GetNotificationOptions
 	var (
 		value0 string // javascript: DOMString {tag Tag tag}
 	)
-	value0 = (input.Get("tag")).String()
+	value0 = (value.Get("tag")).String()
 	out.Tag = value0
 	return &out
 }
@@ -284,7 +283,7 @@ type NotificationAction struct {
 	Icon   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NotificationAction) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -298,21 +297,19 @@ func (_this *NotificationAction) JSValue() js.Value {
 }
 
 // NotificationActionFromJS is allocating a new
-// NotificationAction object and copy all values from
-// input javascript object
-func NotificationActionFromJS(value js.Wrapper) *NotificationAction {
-	input := value.JSValue()
+// NotificationAction object and copy all values in the value javascript object.
+func NotificationActionFromJS(value js.Value) *NotificationAction {
 	var out NotificationAction
 	var (
 		value0 string // javascript: DOMString {action Action action}
 		value1 string // javascript: DOMString {title Title title}
 		value2 string // javascript: USVString {icon Icon icon}
 	)
-	value0 = (input.Get("action")).String()
+	value0 = (value.Get("action")).String()
 	out.Action = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
-	value2 = (input.Get("icon")).String()
+	value2 = (value.Get("icon")).String()
 	out.Icon = value2
 	return &out
 }
@@ -334,7 +331,7 @@ type Options struct {
 	Actions            []*NotificationAction
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Options) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -372,10 +369,8 @@ func (_this *Options) JSValue() js.Value {
 }
 
 // OptionsFromJS is allocating a new
-// Options object and copy all values from
-// input javascript object
-func OptionsFromJS(value js.Wrapper) *Options {
-	input := value.JSValue()
+// Options object and copy all values in the value javascript object.
+func OptionsFromJS(value js.Value) *Options {
 	var out Options
 	var (
 		value0  Direction             // javascript: NotificationDirection {dir Dir dir}
@@ -392,35 +387,35 @@ func OptionsFromJS(value js.Wrapper) *Options {
 		value11 js.Value              // javascript: any {data Data data}
 		value12 []*NotificationAction // javascript: sequence<NotificationAction> {actions Actions actions}
 	)
-	value0 = DirectionFromJS(input.Get("dir"))
+	value0 = DirectionFromJS(value.Get("dir"))
 	out.Dir = value0
-	value1 = (input.Get("lang")).String()
+	value1 = (value.Get("lang")).String()
 	out.Lang = value1
-	value2 = (input.Get("body")).String()
+	value2 = (value.Get("body")).String()
 	out.Body = value2
-	value3 = (input.Get("tag")).String()
+	value3 = (value.Get("tag")).String()
 	out.Tag = value3
-	value4 = (input.Get("image")).String()
+	value4 = (value.Get("image")).String()
 	out.Image = value4
-	value5 = (input.Get("icon")).String()
+	value5 = (value.Get("icon")).String()
 	out.Icon = value5
-	value6 = (input.Get("badge")).String()
+	value6 = (value.Get("badge")).String()
 	out.Badge = value6
-	value7 = (input.Get("timestamp")).Int()
+	value7 = (value.Get("timestamp")).Int()
 	out.Timestamp = value7
-	value8 = (input.Get("renotify")).Bool()
+	value8 = (value.Get("renotify")).Bool()
 	out.Renotify = value8
-	value9 = (input.Get("silent")).Bool()
+	value9 = (value.Get("silent")).Bool()
 	out.Silent = value9
-	value10 = (input.Get("requireInteraction")).Bool()
+	value10 = (value.Get("requireInteraction")).Bool()
 	out.RequireInteraction = value10
-	value11 = input.Get("data")
+	value11 = value.Get("data")
 	out.Data = value11
-	__length12 := input.Get("actions").Length()
+	__length12 := value.Get("actions").Length()
 	__array12 := make([]*NotificationAction, __length12, __length12)
 	for __idx12 := 0; __idx12 < __length12; __idx12++ {
 		var __seq_out12 *NotificationAction
-		__seq_in12 := input.Get("actions").Index(__idx12)
+		__seq_in12 := value.Get("actions").Index(__idx12)
 		__seq_out12 = NotificationActionFromJS(__seq_in12)
 		__array12[__idx12] = __seq_out12
 	}
@@ -434,15 +429,19 @@ type Notification struct {
 	domcore.EventTarget
 }
 
-// NotificationFromJS is casting a js.Wrapper into Notification.
-func NotificationFromJS(value js.Wrapper) *Notification {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NotificationFromJS is casting a js.Value into Notification.
+func NotificationFromJS(value js.Value) *Notification {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Notification{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NotificationFromJS is casting from something that holds a js.Value into Notification.
+func NotificationFromWrapper(input core.Wrapper) *Notification {
+	return NotificationFromJS(input.JSValue())
 }
 
 // Permission returning attribute 'permission' with
@@ -792,15 +791,19 @@ func (_this *PromisePermissionMode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionModeFromJS is casting a js.Wrapper into PromisePermissionMode.
-func PromisePermissionModeFromJS(value js.Wrapper) *PromisePermissionMode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionModeFromJS is casting a js.Value into PromisePermissionMode.
+func PromisePermissionModeFromJS(value js.Value) *PromisePermissionMode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionMode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionModeFromJS is casting from something that holds a js.Value into PromisePermissionMode.
+func PromisePermissionModeFromWrapper(input core.Wrapper) *PromisePermissionMode {
+	return PromisePermissionModeFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionMode) Then(onFulfilled *PromisePermissionModeOnFulfilled, onRejected *PromisePermissionModeOnRejected) (_result *PromisePermissionMode) {

--- a/notification/notification_js.go
+++ b/notification/notification_js.go
@@ -5,6 +5,7 @@ package notification
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -252,7 +253,7 @@ type GetNotificationOptions struct {
 	Tag string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GetNotificationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -262,15 +263,13 @@ func (_this *GetNotificationOptions) JSValue() js.Value {
 }
 
 // GetNotificationOptionsFromJS is allocating a new
-// GetNotificationOptions object and copy all values from
-// input javascript object
-func GetNotificationOptionsFromJS(value js.Wrapper) *GetNotificationOptions {
-	input := value.JSValue()
+// GetNotificationOptions object and copy all values in the value javascript object.
+func GetNotificationOptionsFromJS(value js.Value) *GetNotificationOptions {
 	var out GetNotificationOptions
 	var (
 		value0 string // javascript: DOMString {tag Tag tag}
 	)
-	value0 = (input.Get("tag")).String()
+	value0 = (value.Get("tag")).String()
 	out.Tag = value0
 	return &out
 }
@@ -282,7 +281,7 @@ type NotificationAction struct {
 	Icon   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *NotificationAction) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -296,21 +295,19 @@ func (_this *NotificationAction) JSValue() js.Value {
 }
 
 // NotificationActionFromJS is allocating a new
-// NotificationAction object and copy all values from
-// input javascript object
-func NotificationActionFromJS(value js.Wrapper) *NotificationAction {
-	input := value.JSValue()
+// NotificationAction object and copy all values in the value javascript object.
+func NotificationActionFromJS(value js.Value) *NotificationAction {
 	var out NotificationAction
 	var (
 		value0 string // javascript: DOMString {action Action action}
 		value1 string // javascript: DOMString {title Title title}
 		value2 string // javascript: USVString {icon Icon icon}
 	)
-	value0 = (input.Get("action")).String()
+	value0 = (value.Get("action")).String()
 	out.Action = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
-	value2 = (input.Get("icon")).String()
+	value2 = (value.Get("icon")).String()
 	out.Icon = value2
 	return &out
 }
@@ -332,7 +329,7 @@ type Options struct {
 	Actions            []*NotificationAction
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *Options) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -370,10 +367,8 @@ func (_this *Options) JSValue() js.Value {
 }
 
 // OptionsFromJS is allocating a new
-// Options object and copy all values from
-// input javascript object
-func OptionsFromJS(value js.Wrapper) *Options {
-	input := value.JSValue()
+// Options object and copy all values in the value javascript object.
+func OptionsFromJS(value js.Value) *Options {
 	var out Options
 	var (
 		value0  Direction             // javascript: NotificationDirection {dir Dir dir}
@@ -390,35 +385,35 @@ func OptionsFromJS(value js.Wrapper) *Options {
 		value11 js.Value              // javascript: any {data Data data}
 		value12 []*NotificationAction // javascript: sequence<NotificationAction> {actions Actions actions}
 	)
-	value0 = DirectionFromJS(input.Get("dir"))
+	value0 = DirectionFromJS(value.Get("dir"))
 	out.Dir = value0
-	value1 = (input.Get("lang")).String()
+	value1 = (value.Get("lang")).String()
 	out.Lang = value1
-	value2 = (input.Get("body")).String()
+	value2 = (value.Get("body")).String()
 	out.Body = value2
-	value3 = (input.Get("tag")).String()
+	value3 = (value.Get("tag")).String()
 	out.Tag = value3
-	value4 = (input.Get("image")).String()
+	value4 = (value.Get("image")).String()
 	out.Image = value4
-	value5 = (input.Get("icon")).String()
+	value5 = (value.Get("icon")).String()
 	out.Icon = value5
-	value6 = (input.Get("badge")).String()
+	value6 = (value.Get("badge")).String()
 	out.Badge = value6
-	value7 = (input.Get("timestamp")).Int()
+	value7 = (value.Get("timestamp")).Int()
 	out.Timestamp = value7
-	value8 = (input.Get("renotify")).Bool()
+	value8 = (value.Get("renotify")).Bool()
 	out.Renotify = value8
-	value9 = (input.Get("silent")).Bool()
+	value9 = (value.Get("silent")).Bool()
 	out.Silent = value9
-	value10 = (input.Get("requireInteraction")).Bool()
+	value10 = (value.Get("requireInteraction")).Bool()
 	out.RequireInteraction = value10
-	value11 = input.Get("data")
+	value11 = value.Get("data")
 	out.Data = value11
-	__length12 := input.Get("actions").Length()
+	__length12 := value.Get("actions").Length()
 	__array12 := make([]*NotificationAction, __length12, __length12)
 	for __idx12 := 0; __idx12 < __length12; __idx12++ {
 		var __seq_out12 *NotificationAction
-		__seq_in12 := input.Get("actions").Index(__idx12)
+		__seq_in12 := value.Get("actions").Index(__idx12)
 		__seq_out12 = NotificationActionFromJS(__seq_in12)
 		__array12[__idx12] = __seq_out12
 	}
@@ -432,15 +427,19 @@ type Notification struct {
 	domcore.EventTarget
 }
 
-// NotificationFromJS is casting a js.Wrapper into Notification.
-func NotificationFromJS(value js.Wrapper) *Notification {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NotificationFromJS is casting a js.Value into Notification.
+func NotificationFromJS(value js.Value) *Notification {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Notification{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NotificationFromJS is casting from something that holds a js.Value into Notification.
+func NotificationFromWrapper(input core.Wrapper) *Notification {
+	return NotificationFromJS(input.JSValue())
 }
 
 // Permission returning attribute 'permission' with
@@ -790,15 +789,19 @@ func (_this *PromisePermissionMode) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionModeFromJS is casting a js.Wrapper into PromisePermissionMode.
-func PromisePermissionModeFromJS(value js.Wrapper) *PromisePermissionMode {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionModeFromJS is casting a js.Value into PromisePermissionMode.
+func PromisePermissionModeFromJS(value js.Value) *PromisePermissionMode {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionMode{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionModeFromJS is casting from something that holds a js.Value into PromisePermissionMode.
+func PromisePermissionModeFromWrapper(input core.Wrapper) *PromisePermissionMode {
+	return PromisePermissionModeFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionMode) Then(onFulfilled *PromisePermissionModeOnFulfilled, onRejected *PromisePermissionModeOnRejected) (_result *PromisePermissionMode) {

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -6,6 +6,10 @@ package patch
 
 import js "github.com/gowebapi/webapi/core/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -41,15 +45,19 @@ func (_this *ByteString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ByteStringFromJS is casting a js.Wrapper into ByteString.
-func ByteStringFromJS(value js.Wrapper) *ByteString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ByteStringFromJS is casting a js.Value into ByteString.
+func ByteStringFromJS(value js.Value) *ByteString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ByteString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ByteStringFromJS is casting from something that holds a js.Value into ByteString.
+func ByteStringFromWrapper(input core.Wrapper) *ByteString {
+	return ByteStringFromJS(input.JSValue())
 }
 
 // class: OverconstrainedError
@@ -62,15 +70,19 @@ func (_this *OverconstrainedError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OverconstrainedErrorFromJS is casting a js.Wrapper into OverconstrainedError.
-func OverconstrainedErrorFromJS(value js.Wrapper) *OverconstrainedError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OverconstrainedErrorFromJS is casting a js.Value into OverconstrainedError.
+func OverconstrainedErrorFromJS(value js.Value) *OverconstrainedError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OverconstrainedError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OverconstrainedErrorFromJS is casting from something that holds a js.Value into OverconstrainedError.
+func OverconstrainedErrorFromWrapper(input core.Wrapper) *OverconstrainedError {
+	return OverconstrainedErrorFromJS(input.JSValue())
 }
 
 // class: ReadableStream
@@ -83,15 +95,19 @@ func (_this *ReadableStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReadableStreamFromJS is casting a js.Wrapper into ReadableStream.
-func ReadableStreamFromJS(value js.Wrapper) *ReadableStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReadableStreamFromJS is casting a js.Value into ReadableStream.
+func ReadableStreamFromJS(value js.Value) *ReadableStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReadableStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReadableStreamFromJS is casting from something that holds a js.Value into ReadableStream.
+func ReadableStreamFromWrapper(input core.Wrapper) *ReadableStream {
+	return ReadableStreamFromJS(input.JSValue())
 }
 
 // class: Uint8ClampedArray
@@ -104,13 +120,17 @@ func (_this *Uint8ClampedArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint8ClampedArrayFromJS is casting a js.Wrapper into Uint8ClampedArray.
-func Uint8ClampedArrayFromJS(value js.Wrapper) *Uint8ClampedArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint8ClampedArrayFromJS is casting a js.Value into Uint8ClampedArray.
+func Uint8ClampedArrayFromJS(value js.Value) *Uint8ClampedArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint8ClampedArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint8ClampedArrayFromJS is casting from something that holds a js.Value into Uint8ClampedArray.
+func Uint8ClampedArrayFromWrapper(input core.Wrapper) *Uint8ClampedArray {
+	return Uint8ClampedArrayFromJS(input.JSValue())
 }

--- a/patch/patch_js.go
+++ b/patch/patch_js.go
@@ -4,6 +4,10 @@ package patch
 
 import "syscall/js"
 
+import (
+	"github.com/gowebapi/webapi/core"
+)
+
 // using following types:
 
 // source idl files:
@@ -39,15 +43,19 @@ func (_this *ByteString) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ByteStringFromJS is casting a js.Wrapper into ByteString.
-func ByteStringFromJS(value js.Wrapper) *ByteString {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ByteStringFromJS is casting a js.Value into ByteString.
+func ByteStringFromJS(value js.Value) *ByteString {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ByteString{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ByteStringFromJS is casting from something that holds a js.Value into ByteString.
+func ByteStringFromWrapper(input core.Wrapper) *ByteString {
+	return ByteStringFromJS(input.JSValue())
 }
 
 // class: OverconstrainedError
@@ -60,15 +68,19 @@ func (_this *OverconstrainedError) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// OverconstrainedErrorFromJS is casting a js.Wrapper into OverconstrainedError.
-func OverconstrainedErrorFromJS(value js.Wrapper) *OverconstrainedError {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// OverconstrainedErrorFromJS is casting a js.Value into OverconstrainedError.
+func OverconstrainedErrorFromJS(value js.Value) *OverconstrainedError {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &OverconstrainedError{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// OverconstrainedErrorFromJS is casting from something that holds a js.Value into OverconstrainedError.
+func OverconstrainedErrorFromWrapper(input core.Wrapper) *OverconstrainedError {
+	return OverconstrainedErrorFromJS(input.JSValue())
 }
 
 // class: ReadableStream
@@ -81,15 +93,19 @@ func (_this *ReadableStream) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReadableStreamFromJS is casting a js.Wrapper into ReadableStream.
-func ReadableStreamFromJS(value js.Wrapper) *ReadableStream {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReadableStreamFromJS is casting a js.Value into ReadableStream.
+func ReadableStreamFromJS(value js.Value) *ReadableStream {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReadableStream{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReadableStreamFromJS is casting from something that holds a js.Value into ReadableStream.
+func ReadableStreamFromWrapper(input core.Wrapper) *ReadableStream {
+	return ReadableStreamFromJS(input.JSValue())
 }
 
 // class: Uint8ClampedArray
@@ -102,13 +118,17 @@ func (_this *Uint8ClampedArray) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// Uint8ClampedArrayFromJS is casting a js.Wrapper into Uint8ClampedArray.
-func Uint8ClampedArrayFromJS(value js.Wrapper) *Uint8ClampedArray {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// Uint8ClampedArrayFromJS is casting a js.Value into Uint8ClampedArray.
+func Uint8ClampedArrayFromJS(value js.Value) *Uint8ClampedArray {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Uint8ClampedArray{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// Uint8ClampedArrayFromJS is casting from something that holds a js.Value into Uint8ClampedArray.
+func Uint8ClampedArrayFromWrapper(input core.Wrapper) *Uint8ClampedArray {
+	return Uint8ClampedArrayFromJS(input.JSValue())
 }

--- a/payment/basiccard/basiccard.go
+++ b/payment/basiccard/basiccard.go
@@ -42,7 +42,7 @@ type BasicCardChangeDetails struct {
 	BillingAddress *request.PaymentAddress
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardChangeDetails) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -52,16 +52,14 @@ func (_this *BasicCardChangeDetails) JSValue() js.Value {
 }
 
 // BasicCardChangeDetailsFromJS is allocating a new
-// BasicCardChangeDetails object and copy all values from
-// input javascript object
-func BasicCardChangeDetailsFromJS(value js.Wrapper) *BasicCardChangeDetails {
-	input := value.JSValue()
+// BasicCardChangeDetails object and copy all values in the value javascript object.
+func BasicCardChangeDetailsFromJS(value js.Value) *BasicCardChangeDetails {
 	var out BasicCardChangeDetails
 	var (
 		value0 *request.PaymentAddress // javascript: PaymentAddress {billingAddress BillingAddress billingAddress}
 	)
-	if input.Get("billingAddress").Type() != js.TypeNull && input.Get("billingAddress").Type() != js.TypeUndefined {
-		value0 = request.PaymentAddressFromJS(input.Get("billingAddress"))
+	if value.Get("billingAddress").Type() != js.TypeNull && value.Get("billingAddress").Type() != js.TypeUndefined {
+		value0 = request.PaymentAddressFromJS(value.Get("billingAddress"))
 	}
 	out.BillingAddress = value0
 	return &out
@@ -77,7 +75,7 @@ type BasicCardErrors struct {
 	BillingAddress   *request.AddressErrors
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -97,10 +95,8 @@ func (_this *BasicCardErrors) JSValue() js.Value {
 }
 
 // BasicCardErrorsFromJS is allocating a new
-// BasicCardErrors object and copy all values from
-// input javascript object
-func BasicCardErrorsFromJS(value js.Wrapper) *BasicCardErrors {
-	input := value.JSValue()
+// BasicCardErrors object and copy all values in the value javascript object.
+func BasicCardErrorsFromJS(value js.Value) *BasicCardErrors {
 	var out BasicCardErrors
 	var (
 		value0 string                 // javascript: DOMString {cardNumber CardNumber cardNumber}
@@ -110,17 +106,17 @@ func BasicCardErrorsFromJS(value js.Wrapper) *BasicCardErrors {
 		value4 string                 // javascript: DOMString {expiryYear ExpiryYear expiryYear}
 		value5 *request.AddressErrors // javascript: AddressErrors {billingAddress BillingAddress billingAddress}
 	)
-	value0 = (input.Get("cardNumber")).String()
+	value0 = (value.Get("cardNumber")).String()
 	out.CardNumber = value0
-	value1 = (input.Get("cardholderName")).String()
+	value1 = (value.Get("cardholderName")).String()
 	out.CardholderName = value1
-	value2 = (input.Get("cardSecurityCode")).String()
+	value2 = (value.Get("cardSecurityCode")).String()
 	out.CardSecurityCode = value2
-	value3 = (input.Get("expiryMonth")).String()
+	value3 = (value.Get("expiryMonth")).String()
 	out.ExpiryMonth = value3
-	value4 = (input.Get("expiryYear")).String()
+	value4 = (value.Get("expiryYear")).String()
 	out.ExpiryYear = value4
-	value5 = request.AddressErrorsFromJS(input.Get("billingAddress"))
+	value5 = request.AddressErrorsFromJS(value.Get("billingAddress"))
 	out.BillingAddress = value5
 	return &out
 }
@@ -130,7 +126,7 @@ type BasicCardRequest struct {
 	SupportedNetworks []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardRequest) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -144,19 +140,17 @@ func (_this *BasicCardRequest) JSValue() js.Value {
 }
 
 // BasicCardRequestFromJS is allocating a new
-// BasicCardRequest object and copy all values from
-// input javascript object
-func BasicCardRequestFromJS(value js.Wrapper) *BasicCardRequest {
-	input := value.JSValue()
+// BasicCardRequest object and copy all values in the value javascript object.
+func BasicCardRequestFromJS(value js.Value) *BasicCardRequest {
 	var out BasicCardRequest
 	var (
 		value0 []string // javascript: sequence<DOMString> {supportedNetworks SupportedNetworks supportedNetworks}
 	)
-	__length0 := input.Get("supportedNetworks").Length()
+	__length0 := value.Get("supportedNetworks").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("supportedNetworks").Index(__idx0)
+		__seq_in0 := value.Get("supportedNetworks").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
@@ -175,7 +169,7 @@ type BasicCardResponse struct {
 	BillingAddress   *request.PaymentAddress
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -195,10 +189,8 @@ func (_this *BasicCardResponse) JSValue() js.Value {
 }
 
 // BasicCardResponseFromJS is allocating a new
-// BasicCardResponse object and copy all values from
-// input javascript object
-func BasicCardResponseFromJS(value js.Wrapper) *BasicCardResponse {
-	input := value.JSValue()
+// BasicCardResponse object and copy all values in the value javascript object.
+func BasicCardResponseFromJS(value js.Value) *BasicCardResponse {
 	var out BasicCardResponse
 	var (
 		value0 string                  // javascript: DOMString {cardNumber CardNumber cardNumber}
@@ -208,18 +200,18 @@ func BasicCardResponseFromJS(value js.Wrapper) *BasicCardResponse {
 		value4 string                  // javascript: DOMString {expiryYear ExpiryYear expiryYear}
 		value5 *request.PaymentAddress // javascript: PaymentAddress {billingAddress BillingAddress billingAddress}
 	)
-	value0 = (input.Get("cardNumber")).String()
+	value0 = (value.Get("cardNumber")).String()
 	out.CardNumber = value0
-	value1 = (input.Get("cardholderName")).String()
+	value1 = (value.Get("cardholderName")).String()
 	out.CardholderName = value1
-	value2 = (input.Get("cardSecurityCode")).String()
+	value2 = (value.Get("cardSecurityCode")).String()
 	out.CardSecurityCode = value2
-	value3 = (input.Get("expiryMonth")).String()
+	value3 = (value.Get("expiryMonth")).String()
 	out.ExpiryMonth = value3
-	value4 = (input.Get("expiryYear")).String()
+	value4 = (value.Get("expiryYear")).String()
 	out.ExpiryYear = value4
-	if input.Get("billingAddress").Type() != js.TypeNull && input.Get("billingAddress").Type() != js.TypeUndefined {
-		value5 = request.PaymentAddressFromJS(input.Get("billingAddress"))
+	if value.Get("billingAddress").Type() != js.TypeNull && value.Get("billingAddress").Type() != js.TypeUndefined {
+		value5 = request.PaymentAddressFromJS(value.Get("billingAddress"))
 	}
 	out.BillingAddress = value5
 	return &out

--- a/payment/basiccard/basiccard_js.go
+++ b/payment/basiccard/basiccard_js.go
@@ -40,7 +40,7 @@ type BasicCardChangeDetails struct {
 	BillingAddress *request.PaymentAddress
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardChangeDetails) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -50,16 +50,14 @@ func (_this *BasicCardChangeDetails) JSValue() js.Value {
 }
 
 // BasicCardChangeDetailsFromJS is allocating a new
-// BasicCardChangeDetails object and copy all values from
-// input javascript object
-func BasicCardChangeDetailsFromJS(value js.Wrapper) *BasicCardChangeDetails {
-	input := value.JSValue()
+// BasicCardChangeDetails object and copy all values in the value javascript object.
+func BasicCardChangeDetailsFromJS(value js.Value) *BasicCardChangeDetails {
 	var out BasicCardChangeDetails
 	var (
 		value0 *request.PaymentAddress // javascript: PaymentAddress {billingAddress BillingAddress billingAddress}
 	)
-	if input.Get("billingAddress").Type() != js.TypeNull && input.Get("billingAddress").Type() != js.TypeUndefined {
-		value0 = request.PaymentAddressFromJS(input.Get("billingAddress"))
+	if value.Get("billingAddress").Type() != js.TypeNull && value.Get("billingAddress").Type() != js.TypeUndefined {
+		value0 = request.PaymentAddressFromJS(value.Get("billingAddress"))
 	}
 	out.BillingAddress = value0
 	return &out
@@ -75,7 +73,7 @@ type BasicCardErrors struct {
 	BillingAddress   *request.AddressErrors
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -95,10 +93,8 @@ func (_this *BasicCardErrors) JSValue() js.Value {
 }
 
 // BasicCardErrorsFromJS is allocating a new
-// BasicCardErrors object and copy all values from
-// input javascript object
-func BasicCardErrorsFromJS(value js.Wrapper) *BasicCardErrors {
-	input := value.JSValue()
+// BasicCardErrors object and copy all values in the value javascript object.
+func BasicCardErrorsFromJS(value js.Value) *BasicCardErrors {
 	var out BasicCardErrors
 	var (
 		value0 string                 // javascript: DOMString {cardNumber CardNumber cardNumber}
@@ -108,17 +104,17 @@ func BasicCardErrorsFromJS(value js.Wrapper) *BasicCardErrors {
 		value4 string                 // javascript: DOMString {expiryYear ExpiryYear expiryYear}
 		value5 *request.AddressErrors // javascript: AddressErrors {billingAddress BillingAddress billingAddress}
 	)
-	value0 = (input.Get("cardNumber")).String()
+	value0 = (value.Get("cardNumber")).String()
 	out.CardNumber = value0
-	value1 = (input.Get("cardholderName")).String()
+	value1 = (value.Get("cardholderName")).String()
 	out.CardholderName = value1
-	value2 = (input.Get("cardSecurityCode")).String()
+	value2 = (value.Get("cardSecurityCode")).String()
 	out.CardSecurityCode = value2
-	value3 = (input.Get("expiryMonth")).String()
+	value3 = (value.Get("expiryMonth")).String()
 	out.ExpiryMonth = value3
-	value4 = (input.Get("expiryYear")).String()
+	value4 = (value.Get("expiryYear")).String()
 	out.ExpiryYear = value4
-	value5 = request.AddressErrorsFromJS(input.Get("billingAddress"))
+	value5 = request.AddressErrorsFromJS(value.Get("billingAddress"))
 	out.BillingAddress = value5
 	return &out
 }
@@ -128,7 +124,7 @@ type BasicCardRequest struct {
 	SupportedNetworks []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardRequest) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -142,19 +138,17 @@ func (_this *BasicCardRequest) JSValue() js.Value {
 }
 
 // BasicCardRequestFromJS is allocating a new
-// BasicCardRequest object and copy all values from
-// input javascript object
-func BasicCardRequestFromJS(value js.Wrapper) *BasicCardRequest {
-	input := value.JSValue()
+// BasicCardRequest object and copy all values in the value javascript object.
+func BasicCardRequestFromJS(value js.Value) *BasicCardRequest {
 	var out BasicCardRequest
 	var (
 		value0 []string // javascript: sequence<DOMString> {supportedNetworks SupportedNetworks supportedNetworks}
 	)
-	__length0 := input.Get("supportedNetworks").Length()
+	__length0 := value.Get("supportedNetworks").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("supportedNetworks").Index(__idx0)
+		__seq_in0 := value.Get("supportedNetworks").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
@@ -173,7 +167,7 @@ type BasicCardResponse struct {
 	BillingAddress   *request.PaymentAddress
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BasicCardResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -193,10 +187,8 @@ func (_this *BasicCardResponse) JSValue() js.Value {
 }
 
 // BasicCardResponseFromJS is allocating a new
-// BasicCardResponse object and copy all values from
-// input javascript object
-func BasicCardResponseFromJS(value js.Wrapper) *BasicCardResponse {
-	input := value.JSValue()
+// BasicCardResponse object and copy all values in the value javascript object.
+func BasicCardResponseFromJS(value js.Value) *BasicCardResponse {
 	var out BasicCardResponse
 	var (
 		value0 string                  // javascript: DOMString {cardNumber CardNumber cardNumber}
@@ -206,18 +198,18 @@ func BasicCardResponseFromJS(value js.Wrapper) *BasicCardResponse {
 		value4 string                  // javascript: DOMString {expiryYear ExpiryYear expiryYear}
 		value5 *request.PaymentAddress // javascript: PaymentAddress {billingAddress BillingAddress billingAddress}
 	)
-	value0 = (input.Get("cardNumber")).String()
+	value0 = (value.Get("cardNumber")).String()
 	out.CardNumber = value0
-	value1 = (input.Get("cardholderName")).String()
+	value1 = (value.Get("cardholderName")).String()
 	out.CardholderName = value1
-	value2 = (input.Get("cardSecurityCode")).String()
+	value2 = (value.Get("cardSecurityCode")).String()
 	out.CardSecurityCode = value2
-	value3 = (input.Get("expiryMonth")).String()
+	value3 = (value.Get("expiryMonth")).String()
 	out.ExpiryMonth = value3
-	value4 = (input.Get("expiryYear")).String()
+	value4 = (value.Get("expiryYear")).String()
 	out.ExpiryYear = value4
-	if input.Get("billingAddress").Type() != js.TypeNull && input.Get("billingAddress").Type() != js.TypeUndefined {
-		value5 = request.PaymentAddressFromJS(input.Get("billingAddress"))
+	if value.Get("billingAddress").Type() != js.TypeNull && value.Get("billingAddress").Type() != js.TypeUndefined {
+		value5 = request.PaymentAddressFromJS(value.Get("billingAddress"))
 	}
 	out.BillingAddress = value5
 	return &out

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -7,6 +7,7 @@ package payment
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/payment/request"
@@ -222,7 +223,7 @@ type CanMakePaymentEventInit struct {
 	MethodData           []*request.PaymentMethodData
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CanMakePaymentEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -246,10 +247,8 @@ func (_this *CanMakePaymentEventInit) JSValue() js.Value {
 }
 
 // CanMakePaymentEventInitFromJS is allocating a new
-// CanMakePaymentEventInit object and copy all values from
-// input javascript object
-func CanMakePaymentEventInitFromJS(value js.Wrapper) *CanMakePaymentEventInit {
-	input := value.JSValue()
+// CanMakePaymentEventInit object and copy all values in the value javascript object.
+func CanMakePaymentEventInitFromJS(value js.Value) *CanMakePaymentEventInit {
 	var out CanMakePaymentEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -259,21 +258,21 @@ func CanMakePaymentEventInitFromJS(value js.Wrapper) *CanMakePaymentEventInit {
 		value4 string                       // javascript: USVString {paymentRequestOrigin PaymentRequestOrigin paymentRequestOrigin}
 		value5 []*request.PaymentMethodData // javascript: sequence<PaymentMethodData> {methodData MethodData methodData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("topOrigin")).String()
+	value3 = (value.Get("topOrigin")).String()
 	out.TopOrigin = value3
-	value4 = (input.Get("paymentRequestOrigin")).String()
+	value4 = (value.Get("paymentRequestOrigin")).String()
 	out.PaymentRequestOrigin = value4
-	__length5 := input.Get("methodData").Length()
+	__length5 := value.Get("methodData").Length()
 	__array5 := make([]*request.PaymentMethodData, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *request.PaymentMethodData
-		__seq_in5 := input.Get("methodData").Index(__idx5)
+		__seq_in5 := value.Get("methodData").Index(__idx5)
 		__seq_out5 = request.PaymentMethodDataFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
@@ -289,7 +288,7 @@ type ImageObject struct {
 	Type  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -303,21 +302,19 @@ func (_this *ImageObject) JSValue() js.Value {
 }
 
 // ImageObjectFromJS is allocating a new
-// ImageObject object and copy all values from
-// input javascript object
-func ImageObjectFromJS(value js.Wrapper) *ImageObject {
-	input := value.JSValue()
+// ImageObject object and copy all values in the value javascript object.
+func ImageObjectFromJS(value js.Value) *ImageObject {
 	var out ImageObject
 	var (
 		value0 string // javascript: USVString {src Src src}
 		value1 string // javascript: DOMString {sizes Sizes sizes}
 		value2 string // javascript: DOMString {type Type _type}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
 	return &out
 }
@@ -328,7 +325,7 @@ type PaymentHandlerResponse struct {
 	Details    *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentHandlerResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -340,18 +337,16 @@ func (_this *PaymentHandlerResponse) JSValue() js.Value {
 }
 
 // PaymentHandlerResponseFromJS is allocating a new
-// PaymentHandlerResponse object and copy all values from
-// input javascript object
-func PaymentHandlerResponseFromJS(value js.Wrapper) *PaymentHandlerResponse {
-	input := value.JSValue()
+// PaymentHandlerResponse object and copy all values in the value javascript object.
+func PaymentHandlerResponseFromJS(value js.Value) *PaymentHandlerResponse {
 	var out PaymentHandlerResponse
 	var (
 		value0 string             // javascript: DOMString {methodName MethodName methodName}
 		value1 *javascript.Object // javascript: object {details Details details}
 	)
-	value0 = (input.Get("methodName")).String()
+	value0 = (value.Get("methodName")).String()
 	out.MethodName = value0
-	value1 = javascript.ObjectFromJS(input.Get("details"))
+	value1 = javascript.ObjectFromJS(value.Get("details"))
 	out.Details = value1
 	return &out
 }
@@ -364,7 +359,7 @@ type PaymentInstrument struct {
 	Capabilities *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentInstrument) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -384,10 +379,8 @@ func (_this *PaymentInstrument) JSValue() js.Value {
 }
 
 // PaymentInstrumentFromJS is allocating a new
-// PaymentInstrument object and copy all values from
-// input javascript object
-func PaymentInstrumentFromJS(value js.Wrapper) *PaymentInstrument {
-	input := value.JSValue()
+// PaymentInstrument object and copy all values in the value javascript object.
+func PaymentInstrumentFromJS(value js.Value) *PaymentInstrument {
 	var out PaymentInstrument
 	var (
 		value0 string             // javascript: DOMString {name Name name}
@@ -395,21 +388,21 @@ func PaymentInstrumentFromJS(value js.Wrapper) *PaymentInstrument {
 		value2 string             // javascript: DOMString {method Method method}
 		value3 *javascript.Object // javascript: object {capabilities Capabilities capabilities}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	__length1 := input.Get("icons").Length()
+	__length1 := value.Get("icons").Length()
 	__array1 := make([]*ImageObject, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *ImageObject
-		__seq_in1 := input.Get("icons").Index(__idx1)
+		__seq_in1 := value.Get("icons").Index(__idx1)
 		__seq_out1 = ImageObjectFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.Icons = value1
-	value2 = (input.Get("method")).String()
+	value2 = (value.Get("method")).String()
 	out.Method = value2
-	value3 = javascript.ObjectFromJS(input.Get("capabilities"))
+	value3 = javascript.ObjectFromJS(value.Get("capabilities"))
 	out.Capabilities = value3
 	return &out
 }
@@ -422,7 +415,7 @@ type PaymentMethodChangeResponse struct {
 	PaymentMethodErrors *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodChangeResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -438,10 +431,8 @@ func (_this *PaymentMethodChangeResponse) JSValue() js.Value {
 }
 
 // PaymentMethodChangeResponseFromJS is allocating a new
-// PaymentMethodChangeResponse object and copy all values from
-// input javascript object
-func PaymentMethodChangeResponseFromJS(value js.Wrapper) *PaymentMethodChangeResponse {
-	input := value.JSValue()
+// PaymentMethodChangeResponse object and copy all values in the value javascript object.
+func PaymentMethodChangeResponseFromJS(value js.Value) *PaymentMethodChangeResponse {
 	var out PaymentMethodChangeResponse
 	var (
 		value0 string                         // javascript: DOMString {error Error _error}
@@ -449,13 +440,13 @@ func PaymentMethodChangeResponseFromJS(value js.Wrapper) *PaymentMethodChangeRes
 		value2 *javascript.FrozenArray        // javascript: FrozenArray {modifiers Modifiers modifiers}
 		value3 *javascript.Object             // javascript: object {paymentMethodErrors PaymentMethodErrors paymentMethodErrors}
 	)
-	value0 = (input.Get("error")).String()
+	value0 = (value.Get("error")).String()
 	out.Error = value0
-	value1 = request.PaymentCurrencyAmountFromJS(input.Get("total"))
+	value1 = request.PaymentCurrencyAmountFromJS(value.Get("total"))
 	out.Total = value1
-	value2 = javascript.FrozenArrayFromJS(input.Get("modifiers"))
+	value2 = javascript.FrozenArrayFromJS(value.Get("modifiers"))
 	out.Modifiers = value2
-	value3 = javascript.ObjectFromJS(input.Get("paymentMethodErrors"))
+	value3 = javascript.ObjectFromJS(value.Get("paymentMethodErrors"))
 	out.PaymentMethodErrors = value3
 	return &out
 }
@@ -474,7 +465,7 @@ type PaymentRequestEventInit struct {
 	InstrumentKey        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentRequestEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -510,10 +501,8 @@ func (_this *PaymentRequestEventInit) JSValue() js.Value {
 }
 
 // PaymentRequestEventInitFromJS is allocating a new
-// PaymentRequestEventInit object and copy all values from
-// input javascript object
-func PaymentRequestEventInitFromJS(value js.Wrapper) *PaymentRequestEventInit {
-	input := value.JSValue()
+// PaymentRequestEventInit object and copy all values in the value javascript object.
+func PaymentRequestEventInitFromJS(value js.Value) *PaymentRequestEventInit {
 	var out PaymentRequestEventInit
 	var (
 		value0 bool                              // javascript: boolean {bubbles Bubbles bubbles}
@@ -527,41 +516,41 @@ func PaymentRequestEventInitFromJS(value js.Wrapper) *PaymentRequestEventInit {
 		value8 []*request.PaymentDetailsModifier // javascript: sequence<PaymentDetailsModifier> {modifiers Modifiers modifiers}
 		value9 string                            // javascript: DOMString {instrumentKey InstrumentKey instrumentKey}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("topOrigin")).String()
+	value3 = (value.Get("topOrigin")).String()
 	out.TopOrigin = value3
-	value4 = (input.Get("paymentRequestOrigin")).String()
+	value4 = (value.Get("paymentRequestOrigin")).String()
 	out.PaymentRequestOrigin = value4
-	value5 = (input.Get("paymentRequestId")).String()
+	value5 = (value.Get("paymentRequestId")).String()
 	out.PaymentRequestId = value5
-	__length6 := input.Get("methodData").Length()
+	__length6 := value.Get("methodData").Length()
 	__array6 := make([]*request.PaymentMethodData, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 *request.PaymentMethodData
-		__seq_in6 := input.Get("methodData").Index(__idx6)
+		__seq_in6 := value.Get("methodData").Index(__idx6)
 		__seq_out6 = request.PaymentMethodDataFromJS(__seq_in6)
 		__array6[__idx6] = __seq_out6
 	}
 	value6 = __array6
 	out.MethodData = value6
-	value7 = request.PaymentCurrencyAmountFromJS(input.Get("total"))
+	value7 = request.PaymentCurrencyAmountFromJS(value.Get("total"))
 	out.Total = value7
-	__length8 := input.Get("modifiers").Length()
+	__length8 := value.Get("modifiers").Length()
 	__array8 := make([]*request.PaymentDetailsModifier, __length8, __length8)
 	for __idx8 := 0; __idx8 < __length8; __idx8++ {
 		var __seq_out8 *request.PaymentDetailsModifier
-		__seq_in8 := input.Get("modifiers").Index(__idx8)
+		__seq_in8 := value.Get("modifiers").Index(__idx8)
 		__seq_out8 = request.PaymentDetailsModifierFromJS(__seq_in8)
 		__array8[__idx8] = __seq_out8
 	}
 	value8 = __array8
 	out.Modifiers = value8
-	value9 = (input.Get("instrumentKey")).String()
+	value9 = (value.Get("instrumentKey")).String()
 	out.InstrumentKey = value9
 	return &out
 }
@@ -571,15 +560,19 @@ type CanMakePaymentEvent struct {
 	domcore.ExtendableEvent
 }
 
-// CanMakePaymentEventFromJS is casting a js.Wrapper into CanMakePaymentEvent.
-func CanMakePaymentEventFromJS(value js.Wrapper) *CanMakePaymentEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanMakePaymentEventFromJS is casting a js.Value into CanMakePaymentEvent.
+func CanMakePaymentEventFromJS(value js.Value) *CanMakePaymentEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanMakePaymentEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanMakePaymentEventFromJS is casting from something that holds a js.Value into CanMakePaymentEvent.
+func CanMakePaymentEventFromWrapper(input core.Wrapper) *CanMakePaymentEvent {
+	return CanMakePaymentEventFromJS(input.JSValue())
 }
 
 func NewCanMakePaymentEvent(_type string, eventInitDict *CanMakePaymentEventInit) (_result *CanMakePaymentEvent) {
@@ -652,15 +645,19 @@ func (_this *PaymentInstruments) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentInstrumentsFromJS is casting a js.Wrapper into PaymentInstruments.
-func PaymentInstrumentsFromJS(value js.Wrapper) *PaymentInstruments {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentInstrumentsFromJS is casting a js.Value into PaymentInstruments.
+func PaymentInstrumentsFromJS(value js.Value) *PaymentInstruments {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentInstruments{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentInstrumentsFromJS is casting from something that holds a js.Value into PaymentInstruments.
+func PaymentInstrumentsFromWrapper(input core.Wrapper) *PaymentInstruments {
+	return PaymentInstrumentsFromJS(input.JSValue())
 }
 
 func (_this *PaymentInstruments) Delete(instrumentKey string) (_result *javascript.PromiseBool) {
@@ -772,15 +769,19 @@ func (_this *PaymentManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentManagerFromJS is casting a js.Wrapper into PaymentManager.
-func PaymentManagerFromJS(value js.Wrapper) *PaymentManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentManagerFromJS is casting a js.Value into PaymentManager.
+func PaymentManagerFromJS(value js.Value) *PaymentManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentManagerFromJS is casting from something that holds a js.Value into PaymentManager.
+func PaymentManagerFromWrapper(input core.Wrapper) *PaymentManager {
+	return PaymentManagerFromJS(input.JSValue())
 }
 
 // Instruments returning attribute 'instruments' with
@@ -813,15 +814,19 @@ type PaymentRequestEvent struct {
 	domcore.ExtendableEvent
 }
 
-// PaymentRequestEventFromJS is casting a js.Wrapper into PaymentRequestEvent.
-func PaymentRequestEventFromJS(value js.Wrapper) *PaymentRequestEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestEventFromJS is casting a js.Value into PaymentRequestEvent.
+func PaymentRequestEventFromJS(value js.Value) *PaymentRequestEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequestEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestEventFromJS is casting from something that holds a js.Value into PaymentRequestEvent.
+func PaymentRequestEventFromWrapper(input core.Wrapper) *PaymentRequestEvent {
+	return PaymentRequestEventFromJS(input.JSValue())
 }
 
 func NewPaymentRequestEvent(_type string, eventInitDict *PaymentRequestEventInit) (_result *PaymentRequestEvent) {
@@ -978,15 +983,19 @@ func (_this *PromiseNilPaymentMethodChangeResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilPaymentMethodChangeResponseFromJS is casting a js.Wrapper into PromiseNilPaymentMethodChangeResponse.
-func PromiseNilPaymentMethodChangeResponseFromJS(value js.Wrapper) *PromiseNilPaymentMethodChangeResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilPaymentMethodChangeResponseFromJS is casting a js.Value into PromiseNilPaymentMethodChangeResponse.
+func PromiseNilPaymentMethodChangeResponseFromJS(value js.Value) *PromiseNilPaymentMethodChangeResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilPaymentMethodChangeResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilPaymentMethodChangeResponseFromJS is casting from something that holds a js.Value into PromiseNilPaymentMethodChangeResponse.
+func PromiseNilPaymentMethodChangeResponseFromWrapper(input core.Wrapper) *PromiseNilPaymentMethodChangeResponse {
+	return PromiseNilPaymentMethodChangeResponseFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilPaymentMethodChangeResponse) Then(onFulfilled *PromiseNilPaymentMethodChangeResponseOnFulfilled, onRejected *PromiseNilPaymentMethodChangeResponseOnRejected) (_result *PromiseNilPaymentMethodChangeResponse) {
@@ -1083,15 +1092,19 @@ func (_this *PromisePaymentHandlerResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentHandlerResponseFromJS is casting a js.Wrapper into PromisePaymentHandlerResponse.
-func PromisePaymentHandlerResponseFromJS(value js.Wrapper) *PromisePaymentHandlerResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentHandlerResponseFromJS is casting a js.Value into PromisePaymentHandlerResponse.
+func PromisePaymentHandlerResponseFromJS(value js.Value) *PromisePaymentHandlerResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentHandlerResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentHandlerResponseFromJS is casting from something that holds a js.Value into PromisePaymentHandlerResponse.
+func PromisePaymentHandlerResponseFromWrapper(input core.Wrapper) *PromisePaymentHandlerResponse {
+	return PromisePaymentHandlerResponseFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentHandlerResponse) Then(onFulfilled *PromisePaymentHandlerResponseOnFulfilled, onRejected *PromisePaymentHandlerResponseOnRejected) (_result *PromisePaymentHandlerResponse) {

--- a/payment/payment_js.go
+++ b/payment/payment_js.go
@@ -5,6 +5,7 @@ package payment
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 	"github.com/gowebapi/webapi/payment/request"
@@ -220,7 +221,7 @@ type CanMakePaymentEventInit struct {
 	MethodData           []*request.PaymentMethodData
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CanMakePaymentEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -244,10 +245,8 @@ func (_this *CanMakePaymentEventInit) JSValue() js.Value {
 }
 
 // CanMakePaymentEventInitFromJS is allocating a new
-// CanMakePaymentEventInit object and copy all values from
-// input javascript object
-func CanMakePaymentEventInitFromJS(value js.Wrapper) *CanMakePaymentEventInit {
-	input := value.JSValue()
+// CanMakePaymentEventInit object and copy all values in the value javascript object.
+func CanMakePaymentEventInitFromJS(value js.Value) *CanMakePaymentEventInit {
 	var out CanMakePaymentEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -257,21 +256,21 @@ func CanMakePaymentEventInitFromJS(value js.Wrapper) *CanMakePaymentEventInit {
 		value4 string                       // javascript: USVString {paymentRequestOrigin PaymentRequestOrigin paymentRequestOrigin}
 		value5 []*request.PaymentMethodData // javascript: sequence<PaymentMethodData> {methodData MethodData methodData}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("topOrigin")).String()
+	value3 = (value.Get("topOrigin")).String()
 	out.TopOrigin = value3
-	value4 = (input.Get("paymentRequestOrigin")).String()
+	value4 = (value.Get("paymentRequestOrigin")).String()
 	out.PaymentRequestOrigin = value4
-	__length5 := input.Get("methodData").Length()
+	__length5 := value.Get("methodData").Length()
 	__array5 := make([]*request.PaymentMethodData, __length5, __length5)
 	for __idx5 := 0; __idx5 < __length5; __idx5++ {
 		var __seq_out5 *request.PaymentMethodData
-		__seq_in5 := input.Get("methodData").Index(__idx5)
+		__seq_in5 := value.Get("methodData").Index(__idx5)
 		__seq_out5 = request.PaymentMethodDataFromJS(__seq_in5)
 		__array5[__idx5] = __seq_out5
 	}
@@ -287,7 +286,7 @@ type ImageObject struct {
 	Type  string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ImageObject) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -301,21 +300,19 @@ func (_this *ImageObject) JSValue() js.Value {
 }
 
 // ImageObjectFromJS is allocating a new
-// ImageObject object and copy all values from
-// input javascript object
-func ImageObjectFromJS(value js.Wrapper) *ImageObject {
-	input := value.JSValue()
+// ImageObject object and copy all values in the value javascript object.
+func ImageObjectFromJS(value js.Value) *ImageObject {
 	var out ImageObject
 	var (
 		value0 string // javascript: USVString {src Src src}
 		value1 string // javascript: DOMString {sizes Sizes sizes}
 		value2 string // javascript: DOMString {type Type _type}
 	)
-	value0 = (input.Get("src")).String()
+	value0 = (value.Get("src")).String()
 	out.Src = value0
-	value1 = (input.Get("sizes")).String()
+	value1 = (value.Get("sizes")).String()
 	out.Sizes = value1
-	value2 = (input.Get("type")).String()
+	value2 = (value.Get("type")).String()
 	out.Type = value2
 	return &out
 }
@@ -326,7 +323,7 @@ type PaymentHandlerResponse struct {
 	Details    *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentHandlerResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -338,18 +335,16 @@ func (_this *PaymentHandlerResponse) JSValue() js.Value {
 }
 
 // PaymentHandlerResponseFromJS is allocating a new
-// PaymentHandlerResponse object and copy all values from
-// input javascript object
-func PaymentHandlerResponseFromJS(value js.Wrapper) *PaymentHandlerResponse {
-	input := value.JSValue()
+// PaymentHandlerResponse object and copy all values in the value javascript object.
+func PaymentHandlerResponseFromJS(value js.Value) *PaymentHandlerResponse {
 	var out PaymentHandlerResponse
 	var (
 		value0 string             // javascript: DOMString {methodName MethodName methodName}
 		value1 *javascript.Object // javascript: object {details Details details}
 	)
-	value0 = (input.Get("methodName")).String()
+	value0 = (value.Get("methodName")).String()
 	out.MethodName = value0
-	value1 = javascript.ObjectFromJS(input.Get("details"))
+	value1 = javascript.ObjectFromJS(value.Get("details"))
 	out.Details = value1
 	return &out
 }
@@ -362,7 +357,7 @@ type PaymentInstrument struct {
 	Capabilities *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentInstrument) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -382,10 +377,8 @@ func (_this *PaymentInstrument) JSValue() js.Value {
 }
 
 // PaymentInstrumentFromJS is allocating a new
-// PaymentInstrument object and copy all values from
-// input javascript object
-func PaymentInstrumentFromJS(value js.Wrapper) *PaymentInstrument {
-	input := value.JSValue()
+// PaymentInstrument object and copy all values in the value javascript object.
+func PaymentInstrumentFromJS(value js.Value) *PaymentInstrument {
 	var out PaymentInstrument
 	var (
 		value0 string             // javascript: DOMString {name Name name}
@@ -393,21 +386,21 @@ func PaymentInstrumentFromJS(value js.Wrapper) *PaymentInstrument {
 		value2 string             // javascript: DOMString {method Method method}
 		value3 *javascript.Object // javascript: object {capabilities Capabilities capabilities}
 	)
-	value0 = (input.Get("name")).String()
+	value0 = (value.Get("name")).String()
 	out.Name = value0
-	__length1 := input.Get("icons").Length()
+	__length1 := value.Get("icons").Length()
 	__array1 := make([]*ImageObject, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *ImageObject
-		__seq_in1 := input.Get("icons").Index(__idx1)
+		__seq_in1 := value.Get("icons").Index(__idx1)
 		__seq_out1 = ImageObjectFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.Icons = value1
-	value2 = (input.Get("method")).String()
+	value2 = (value.Get("method")).String()
 	out.Method = value2
-	value3 = javascript.ObjectFromJS(input.Get("capabilities"))
+	value3 = javascript.ObjectFromJS(value.Get("capabilities"))
 	out.Capabilities = value3
 	return &out
 }
@@ -420,7 +413,7 @@ type PaymentMethodChangeResponse struct {
 	PaymentMethodErrors *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodChangeResponse) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -436,10 +429,8 @@ func (_this *PaymentMethodChangeResponse) JSValue() js.Value {
 }
 
 // PaymentMethodChangeResponseFromJS is allocating a new
-// PaymentMethodChangeResponse object and copy all values from
-// input javascript object
-func PaymentMethodChangeResponseFromJS(value js.Wrapper) *PaymentMethodChangeResponse {
-	input := value.JSValue()
+// PaymentMethodChangeResponse object and copy all values in the value javascript object.
+func PaymentMethodChangeResponseFromJS(value js.Value) *PaymentMethodChangeResponse {
 	var out PaymentMethodChangeResponse
 	var (
 		value0 string                         // javascript: DOMString {error Error _error}
@@ -447,13 +438,13 @@ func PaymentMethodChangeResponseFromJS(value js.Wrapper) *PaymentMethodChangeRes
 		value2 *javascript.FrozenArray        // javascript: FrozenArray {modifiers Modifiers modifiers}
 		value3 *javascript.Object             // javascript: object {paymentMethodErrors PaymentMethodErrors paymentMethodErrors}
 	)
-	value0 = (input.Get("error")).String()
+	value0 = (value.Get("error")).String()
 	out.Error = value0
-	value1 = request.PaymentCurrencyAmountFromJS(input.Get("total"))
+	value1 = request.PaymentCurrencyAmountFromJS(value.Get("total"))
 	out.Total = value1
-	value2 = javascript.FrozenArrayFromJS(input.Get("modifiers"))
+	value2 = javascript.FrozenArrayFromJS(value.Get("modifiers"))
 	out.Modifiers = value2
-	value3 = javascript.ObjectFromJS(input.Get("paymentMethodErrors"))
+	value3 = javascript.ObjectFromJS(value.Get("paymentMethodErrors"))
 	out.PaymentMethodErrors = value3
 	return &out
 }
@@ -472,7 +463,7 @@ type PaymentRequestEventInit struct {
 	InstrumentKey        string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentRequestEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -508,10 +499,8 @@ func (_this *PaymentRequestEventInit) JSValue() js.Value {
 }
 
 // PaymentRequestEventInitFromJS is allocating a new
-// PaymentRequestEventInit object and copy all values from
-// input javascript object
-func PaymentRequestEventInitFromJS(value js.Wrapper) *PaymentRequestEventInit {
-	input := value.JSValue()
+// PaymentRequestEventInit object and copy all values in the value javascript object.
+func PaymentRequestEventInitFromJS(value js.Value) *PaymentRequestEventInit {
 	var out PaymentRequestEventInit
 	var (
 		value0 bool                              // javascript: boolean {bubbles Bubbles bubbles}
@@ -525,41 +514,41 @@ func PaymentRequestEventInitFromJS(value js.Wrapper) *PaymentRequestEventInit {
 		value8 []*request.PaymentDetailsModifier // javascript: sequence<PaymentDetailsModifier> {modifiers Modifiers modifiers}
 		value9 string                            // javascript: DOMString {instrumentKey InstrumentKey instrumentKey}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("topOrigin")).String()
+	value3 = (value.Get("topOrigin")).String()
 	out.TopOrigin = value3
-	value4 = (input.Get("paymentRequestOrigin")).String()
+	value4 = (value.Get("paymentRequestOrigin")).String()
 	out.PaymentRequestOrigin = value4
-	value5 = (input.Get("paymentRequestId")).String()
+	value5 = (value.Get("paymentRequestId")).String()
 	out.PaymentRequestId = value5
-	__length6 := input.Get("methodData").Length()
+	__length6 := value.Get("methodData").Length()
 	__array6 := make([]*request.PaymentMethodData, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 *request.PaymentMethodData
-		__seq_in6 := input.Get("methodData").Index(__idx6)
+		__seq_in6 := value.Get("methodData").Index(__idx6)
 		__seq_out6 = request.PaymentMethodDataFromJS(__seq_in6)
 		__array6[__idx6] = __seq_out6
 	}
 	value6 = __array6
 	out.MethodData = value6
-	value7 = request.PaymentCurrencyAmountFromJS(input.Get("total"))
+	value7 = request.PaymentCurrencyAmountFromJS(value.Get("total"))
 	out.Total = value7
-	__length8 := input.Get("modifiers").Length()
+	__length8 := value.Get("modifiers").Length()
 	__array8 := make([]*request.PaymentDetailsModifier, __length8, __length8)
 	for __idx8 := 0; __idx8 < __length8; __idx8++ {
 		var __seq_out8 *request.PaymentDetailsModifier
-		__seq_in8 := input.Get("modifiers").Index(__idx8)
+		__seq_in8 := value.Get("modifiers").Index(__idx8)
 		__seq_out8 = request.PaymentDetailsModifierFromJS(__seq_in8)
 		__array8[__idx8] = __seq_out8
 	}
 	value8 = __array8
 	out.Modifiers = value8
-	value9 = (input.Get("instrumentKey")).String()
+	value9 = (value.Get("instrumentKey")).String()
 	out.InstrumentKey = value9
 	return &out
 }
@@ -569,15 +558,19 @@ type CanMakePaymentEvent struct {
 	domcore.ExtendableEvent
 }
 
-// CanMakePaymentEventFromJS is casting a js.Wrapper into CanMakePaymentEvent.
-func CanMakePaymentEventFromJS(value js.Wrapper) *CanMakePaymentEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CanMakePaymentEventFromJS is casting a js.Value into CanMakePaymentEvent.
+func CanMakePaymentEventFromJS(value js.Value) *CanMakePaymentEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CanMakePaymentEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CanMakePaymentEventFromJS is casting from something that holds a js.Value into CanMakePaymentEvent.
+func CanMakePaymentEventFromWrapper(input core.Wrapper) *CanMakePaymentEvent {
+	return CanMakePaymentEventFromJS(input.JSValue())
 }
 
 func NewCanMakePaymentEvent(_type string, eventInitDict *CanMakePaymentEventInit) (_result *CanMakePaymentEvent) {
@@ -650,15 +643,19 @@ func (_this *PaymentInstruments) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentInstrumentsFromJS is casting a js.Wrapper into PaymentInstruments.
-func PaymentInstrumentsFromJS(value js.Wrapper) *PaymentInstruments {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentInstrumentsFromJS is casting a js.Value into PaymentInstruments.
+func PaymentInstrumentsFromJS(value js.Value) *PaymentInstruments {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentInstruments{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentInstrumentsFromJS is casting from something that holds a js.Value into PaymentInstruments.
+func PaymentInstrumentsFromWrapper(input core.Wrapper) *PaymentInstruments {
+	return PaymentInstrumentsFromJS(input.JSValue())
 }
 
 func (_this *PaymentInstruments) Delete(instrumentKey string) (_result *javascript.PromiseBool) {
@@ -770,15 +767,19 @@ func (_this *PaymentManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentManagerFromJS is casting a js.Wrapper into PaymentManager.
-func PaymentManagerFromJS(value js.Wrapper) *PaymentManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentManagerFromJS is casting a js.Value into PaymentManager.
+func PaymentManagerFromJS(value js.Value) *PaymentManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentManagerFromJS is casting from something that holds a js.Value into PaymentManager.
+func PaymentManagerFromWrapper(input core.Wrapper) *PaymentManager {
+	return PaymentManagerFromJS(input.JSValue())
 }
 
 // Instruments returning attribute 'instruments' with
@@ -811,15 +812,19 @@ type PaymentRequestEvent struct {
 	domcore.ExtendableEvent
 }
 
-// PaymentRequestEventFromJS is casting a js.Wrapper into PaymentRequestEvent.
-func PaymentRequestEventFromJS(value js.Wrapper) *PaymentRequestEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestEventFromJS is casting a js.Value into PaymentRequestEvent.
+func PaymentRequestEventFromJS(value js.Value) *PaymentRequestEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequestEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestEventFromJS is casting from something that holds a js.Value into PaymentRequestEvent.
+func PaymentRequestEventFromWrapper(input core.Wrapper) *PaymentRequestEvent {
+	return PaymentRequestEventFromJS(input.JSValue())
 }
 
 func NewPaymentRequestEvent(_type string, eventInitDict *PaymentRequestEventInit) (_result *PaymentRequestEvent) {
@@ -976,15 +981,19 @@ func (_this *PromiseNilPaymentMethodChangeResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilPaymentMethodChangeResponseFromJS is casting a js.Wrapper into PromiseNilPaymentMethodChangeResponse.
-func PromiseNilPaymentMethodChangeResponseFromJS(value js.Wrapper) *PromiseNilPaymentMethodChangeResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilPaymentMethodChangeResponseFromJS is casting a js.Value into PromiseNilPaymentMethodChangeResponse.
+func PromiseNilPaymentMethodChangeResponseFromJS(value js.Value) *PromiseNilPaymentMethodChangeResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilPaymentMethodChangeResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilPaymentMethodChangeResponseFromJS is casting from something that holds a js.Value into PromiseNilPaymentMethodChangeResponse.
+func PromiseNilPaymentMethodChangeResponseFromWrapper(input core.Wrapper) *PromiseNilPaymentMethodChangeResponse {
+	return PromiseNilPaymentMethodChangeResponseFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilPaymentMethodChangeResponse) Then(onFulfilled *PromiseNilPaymentMethodChangeResponseOnFulfilled, onRejected *PromiseNilPaymentMethodChangeResponseOnRejected) (_result *PromiseNilPaymentMethodChangeResponse) {
@@ -1081,15 +1090,19 @@ func (_this *PromisePaymentHandlerResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentHandlerResponseFromJS is casting a js.Wrapper into PromisePaymentHandlerResponse.
-func PromisePaymentHandlerResponseFromJS(value js.Wrapper) *PromisePaymentHandlerResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentHandlerResponseFromJS is casting a js.Value into PromisePaymentHandlerResponse.
+func PromisePaymentHandlerResponseFromJS(value js.Value) *PromisePaymentHandlerResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentHandlerResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentHandlerResponseFromJS is casting from something that holds a js.Value into PromisePaymentHandlerResponse.
+func PromisePaymentHandlerResponseFromWrapper(input core.Wrapper) *PromisePaymentHandlerResponse {
+	return PromisePaymentHandlerResponseFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentHandlerResponse) Then(onFulfilled *PromisePaymentHandlerResponseOnFulfilled, onRejected *PromisePaymentHandlerResponseOnRejected) (_result *PromisePaymentHandlerResponse) {

--- a/payment/request/request.go
+++ b/payment/request/request.go
@@ -7,6 +7,7 @@ package request
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -307,7 +308,7 @@ type AddressErrors struct {
 	SortingCode       string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddressErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -335,10 +336,8 @@ func (_this *AddressErrors) JSValue() js.Value {
 }
 
 // AddressErrorsFromJS is allocating a new
-// AddressErrors object and copy all values from
-// input javascript object
-func AddressErrorsFromJS(value js.Wrapper) *AddressErrors {
-	input := value.JSValue()
+// AddressErrors object and copy all values in the value javascript object.
+func AddressErrorsFromJS(value js.Value) *AddressErrors {
 	var out AddressErrors
 	var (
 		value0 string // javascript: DOMString {addressLine AddressLine addressLine}
@@ -352,25 +351,25 @@ func AddressErrorsFromJS(value js.Wrapper) *AddressErrors {
 		value8 string // javascript: DOMString {region Region region}
 		value9 string // javascript: DOMString {sortingCode SortingCode sortingCode}
 	)
-	value0 = (input.Get("addressLine")).String()
+	value0 = (value.Get("addressLine")).String()
 	out.AddressLine = value0
-	value1 = (input.Get("city")).String()
+	value1 = (value.Get("city")).String()
 	out.City = value1
-	value2 = (input.Get("country")).String()
+	value2 = (value.Get("country")).String()
 	out.Country = value2
-	value3 = (input.Get("dependentLocality")).String()
+	value3 = (value.Get("dependentLocality")).String()
 	out.DependentLocality = value3
-	value4 = (input.Get("organization")).String()
+	value4 = (value.Get("organization")).String()
 	out.Organization = value4
-	value5 = (input.Get("phone")).String()
+	value5 = (value.Get("phone")).String()
 	out.Phone = value5
-	value6 = (input.Get("postalCode")).String()
+	value6 = (value.Get("postalCode")).String()
 	out.PostalCode = value6
-	value7 = (input.Get("recipient")).String()
+	value7 = (value.Get("recipient")).String()
 	out.Recipient = value7
-	value8 = (input.Get("region")).String()
+	value8 = (value.Get("region")).String()
 	out.Region = value8
-	value9 = (input.Get("sortingCode")).String()
+	value9 = (value.Get("sortingCode")).String()
 	out.SortingCode = value9
 	return &out
 }
@@ -389,7 +388,7 @@ type AddressInit struct {
 	Phone             string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddressInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -421,10 +420,8 @@ func (_this *AddressInit) JSValue() js.Value {
 }
 
 // AddressInitFromJS is allocating a new
-// AddressInit object and copy all values from
-// input javascript object
-func AddressInitFromJS(value js.Wrapper) *AddressInit {
-	input := value.JSValue()
+// AddressInit object and copy all values in the value javascript object.
+func AddressInitFromJS(value js.Value) *AddressInit {
 	var out AddressInit
 	var (
 		value0 string   // javascript: DOMString {country Country country}
@@ -438,33 +435,33 @@ func AddressInitFromJS(value js.Wrapper) *AddressInit {
 		value8 string   // javascript: DOMString {recipient Recipient recipient}
 		value9 string   // javascript: DOMString {phone Phone phone}
 	)
-	value0 = (input.Get("country")).String()
+	value0 = (value.Get("country")).String()
 	out.Country = value0
-	__length1 := input.Get("addressLine").Length()
+	__length1 := value.Get("addressLine").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("addressLine").Index(__idx1)
+		__seq_in1 := value.Get("addressLine").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.AddressLine = value1
-	value2 = (input.Get("region")).String()
+	value2 = (value.Get("region")).String()
 	out.Region = value2
-	value3 = (input.Get("city")).String()
+	value3 = (value.Get("city")).String()
 	out.City = value3
-	value4 = (input.Get("dependentLocality")).String()
+	value4 = (value.Get("dependentLocality")).String()
 	out.DependentLocality = value4
-	value5 = (input.Get("postalCode")).String()
+	value5 = (value.Get("postalCode")).String()
 	out.PostalCode = value5
-	value6 = (input.Get("sortingCode")).String()
+	value6 = (value.Get("sortingCode")).String()
 	out.SortingCode = value6
-	value7 = (input.Get("organization")).String()
+	value7 = (value.Get("organization")).String()
 	out.Organization = value7
-	value8 = (input.Get("recipient")).String()
+	value8 = (value.Get("recipient")).String()
 	out.Recipient = value8
-	value9 = (input.Get("phone")).String()
+	value9 = (value.Get("phone")).String()
 	out.Phone = value9
 	return &out
 }
@@ -478,7 +475,7 @@ type MerchantValidationEventInit struct {
 	ValidationURL string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MerchantValidationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -496,10 +493,8 @@ func (_this *MerchantValidationEventInit) JSValue() js.Value {
 }
 
 // MerchantValidationEventInitFromJS is allocating a new
-// MerchantValidationEventInit object and copy all values from
-// input javascript object
-func MerchantValidationEventInitFromJS(value js.Wrapper) *MerchantValidationEventInit {
-	input := value.JSValue()
+// MerchantValidationEventInit object and copy all values in the value javascript object.
+func MerchantValidationEventInitFromJS(value js.Value) *MerchantValidationEventInit {
 	var out MerchantValidationEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -508,15 +503,15 @@ func MerchantValidationEventInitFromJS(value js.Wrapper) *MerchantValidationEven
 		value3 string // javascript: DOMString {methodName MethodName methodName}
 		value4 string // javascript: USVString {validationURL ValidationURL validationURL}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("methodName")).String()
+	value3 = (value.Get("methodName")).String()
 	out.MethodName = value3
-	value4 = (input.Get("validationURL")).String()
+	value4 = (value.Get("validationURL")).String()
 	out.ValidationURL = value4
 	return &out
 }
@@ -528,7 +523,7 @@ type PayerErrors struct {
 	Phone string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PayerErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -542,21 +537,19 @@ func (_this *PayerErrors) JSValue() js.Value {
 }
 
 // PayerErrorsFromJS is allocating a new
-// PayerErrors object and copy all values from
-// input javascript object
-func PayerErrorsFromJS(value js.Wrapper) *PayerErrors {
-	input := value.JSValue()
+// PayerErrors object and copy all values in the value javascript object.
+func PayerErrorsFromJS(value js.Value) *PayerErrors {
 	var out PayerErrors
 	var (
 		value0 string // javascript: DOMString {email Email email}
 		value1 string // javascript: DOMString {name Name name}
 		value2 string // javascript: DOMString {phone Phone phone}
 	)
-	value0 = (input.Get("email")).String()
+	value0 = (value.Get("email")).String()
 	out.Email = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("phone")).String()
+	value2 = (value.Get("phone")).String()
 	out.Phone = value2
 	return &out
 }
@@ -567,7 +560,7 @@ type PaymentCurrencyAmount struct {
 	Value    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentCurrencyAmount) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -579,18 +572,16 @@ func (_this *PaymentCurrencyAmount) JSValue() js.Value {
 }
 
 // PaymentCurrencyAmountFromJS is allocating a new
-// PaymentCurrencyAmount object and copy all values from
-// input javascript object
-func PaymentCurrencyAmountFromJS(value js.Wrapper) *PaymentCurrencyAmount {
-	input := value.JSValue()
+// PaymentCurrencyAmount object and copy all values in the value javascript object.
+func PaymentCurrencyAmountFromJS(value js.Value) *PaymentCurrencyAmount {
 	var out PaymentCurrencyAmount
 	var (
 		value0 string // javascript: DOMString {currency Currency currency}
 		value1 string // javascript: DOMString {value Value value}
 	)
-	value0 = (input.Get("currency")).String()
+	value0 = (value.Get("currency")).String()
 	out.Currency = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -602,7 +593,7 @@ type PaymentDetailsBase struct {
 	Modifiers       []*PaymentDetailsModifier
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsBase) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -628,41 +619,39 @@ func (_this *PaymentDetailsBase) JSValue() js.Value {
 }
 
 // PaymentDetailsBaseFromJS is allocating a new
-// PaymentDetailsBase object and copy all values from
-// input javascript object
-func PaymentDetailsBaseFromJS(value js.Wrapper) *PaymentDetailsBase {
-	input := value.JSValue()
+// PaymentDetailsBase object and copy all values in the value javascript object.
+func PaymentDetailsBaseFromJS(value js.Value) *PaymentDetailsBase {
 	var out PaymentDetailsBase
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
 		value1 []*PaymentShippingOption  // javascript: sequence<PaymentShippingOption> {shippingOptions ShippingOptions shippingOptions}
 		value2 []*PaymentDetailsModifier // javascript: sequence<PaymentDetailsModifier> {modifiers Modifiers modifiers}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -680,7 +669,7 @@ type PaymentDetailsInit struct {
 	Total           *PaymentItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -710,10 +699,8 @@ func (_this *PaymentDetailsInit) JSValue() js.Value {
 }
 
 // PaymentDetailsInitFromJS is allocating a new
-// PaymentDetailsInit object and copy all values from
-// input javascript object
-func PaymentDetailsInitFromJS(value js.Wrapper) *PaymentDetailsInit {
-	input := value.JSValue()
+// PaymentDetailsInit object and copy all values in the value javascript object.
+func PaymentDetailsInitFromJS(value js.Value) *PaymentDetailsInit {
 	var out PaymentDetailsInit
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
@@ -722,39 +709,39 @@ func PaymentDetailsInitFromJS(value js.Wrapper) *PaymentDetailsInit {
 		value3 string                    // javascript: DOMString {id Id id}
 		value4 *PaymentItem              // javascript: PaymentItem {total Total total}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Modifiers = value2
-	value3 = (input.Get("id")).String()
+	value3 = (value.Get("id")).String()
 	out.Id = value3
-	value4 = PaymentItemFromJS(input.Get("total"))
+	value4 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value4
 	return &out
 }
@@ -767,7 +754,7 @@ type PaymentDetailsModifier struct {
 	Data                   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsModifier) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -787,10 +774,8 @@ func (_this *PaymentDetailsModifier) JSValue() js.Value {
 }
 
 // PaymentDetailsModifierFromJS is allocating a new
-// PaymentDetailsModifier object and copy all values from
-// input javascript object
-func PaymentDetailsModifierFromJS(value js.Wrapper) *PaymentDetailsModifier {
-	input := value.JSValue()
+// PaymentDetailsModifier object and copy all values in the value javascript object.
+func PaymentDetailsModifierFromJS(value js.Value) *PaymentDetailsModifier {
 	var out PaymentDetailsModifier
 	var (
 		value0 string             // javascript: DOMString {supportedMethods SupportedMethods supportedMethods}
@@ -798,21 +783,21 @@ func PaymentDetailsModifierFromJS(value js.Wrapper) *PaymentDetailsModifier {
 		value2 []*PaymentItem     // javascript: sequence<PaymentItem> {additionalDisplayItems AdditionalDisplayItems additionalDisplayItems}
 		value3 *javascript.Object // javascript: object {data Data data}
 	)
-	value0 = (input.Get("supportedMethods")).String()
+	value0 = (value.Get("supportedMethods")).String()
 	out.SupportedMethods = value0
-	value1 = PaymentItemFromJS(input.Get("total"))
+	value1 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value1
-	__length2 := input.Get("additionalDisplayItems").Length()
+	__length2 := value.Get("additionalDisplayItems").Length()
 	__array2 := make([]*PaymentItem, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentItem
-		__seq_in2 := input.Get("additionalDisplayItems").Index(__idx2)
+		__seq_in2 := value.Get("additionalDisplayItems").Index(__idx2)
 		__seq_out2 = PaymentItemFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.AdditionalDisplayItems = value2
-	value3 = javascript.ObjectFromJS(input.Get("data"))
+	value3 = javascript.ObjectFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -829,7 +814,7 @@ type PaymentDetailsUpdate struct {
 	PaymentMethodErrors   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsUpdate) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -865,10 +850,8 @@ func (_this *PaymentDetailsUpdate) JSValue() js.Value {
 }
 
 // PaymentDetailsUpdateFromJS is allocating a new
-// PaymentDetailsUpdate object and copy all values from
-// input javascript object
-func PaymentDetailsUpdateFromJS(value js.Wrapper) *PaymentDetailsUpdate {
-	input := value.JSValue()
+// PaymentDetailsUpdate object and copy all values in the value javascript object.
+func PaymentDetailsUpdateFromJS(value js.Value) *PaymentDetailsUpdate {
 	var out PaymentDetailsUpdate
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
@@ -880,45 +863,45 @@ func PaymentDetailsUpdateFromJS(value js.Wrapper) *PaymentDetailsUpdate {
 		value6 *PayerErrors              // javascript: PayerErrors {payerErrors PayerErrors payerErrors}
 		value7 *javascript.Object        // javascript: object {paymentMethodErrors PaymentMethodErrors paymentMethodErrors}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Modifiers = value2
-	value3 = (input.Get("error")).String()
+	value3 = (value.Get("error")).String()
 	out.Error = value3
-	value4 = PaymentItemFromJS(input.Get("total"))
+	value4 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value4
-	value5 = AddressErrorsFromJS(input.Get("shippingAddressErrors"))
+	value5 = AddressErrorsFromJS(value.Get("shippingAddressErrors"))
 	out.ShippingAddressErrors = value5
-	value6 = PayerErrorsFromJS(input.Get("payerErrors"))
+	value6 = PayerErrorsFromJS(value.Get("payerErrors"))
 	out.PayerErrors = value6
-	value7 = javascript.ObjectFromJS(input.Get("paymentMethodErrors"))
+	value7 = javascript.ObjectFromJS(value.Get("paymentMethodErrors"))
 	out.PaymentMethodErrors = value7
 	return &out
 }
@@ -930,7 +913,7 @@ type PaymentItem struct {
 	Pending bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentItem) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -944,21 +927,19 @@ func (_this *PaymentItem) JSValue() js.Value {
 }
 
 // PaymentItemFromJS is allocating a new
-// PaymentItem object and copy all values from
-// input javascript object
-func PaymentItemFromJS(value js.Wrapper) *PaymentItem {
-	input := value.JSValue()
+// PaymentItem object and copy all values in the value javascript object.
+func PaymentItemFromJS(value js.Value) *PaymentItem {
 	var out PaymentItem
 	var (
 		value0 string                 // javascript: DOMString {label Label label}
 		value1 *PaymentCurrencyAmount // javascript: PaymentCurrencyAmount {amount Amount amount}
 		value2 bool                   // javascript: boolean {pending Pending pending}
 	)
-	value0 = (input.Get("label")).String()
+	value0 = (value.Get("label")).String()
 	out.Label = value0
-	value1 = PaymentCurrencyAmountFromJS(input.Get("amount"))
+	value1 = PaymentCurrencyAmountFromJS(value.Get("amount"))
 	out.Amount = value1
-	value2 = (input.Get("pending")).Bool()
+	value2 = (value.Get("pending")).Bool()
 	out.Pending = value2
 	return &out
 }
@@ -972,7 +953,7 @@ type PaymentMethodChangeEventInit struct {
 	MethodDetails *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -990,10 +971,8 @@ func (_this *PaymentMethodChangeEventInit) JSValue() js.Value {
 }
 
 // PaymentMethodChangeEventInitFromJS is allocating a new
-// PaymentMethodChangeEventInit object and copy all values from
-// input javascript object
-func PaymentMethodChangeEventInitFromJS(value js.Wrapper) *PaymentMethodChangeEventInit {
-	input := value.JSValue()
+// PaymentMethodChangeEventInit object and copy all values in the value javascript object.
+func PaymentMethodChangeEventInitFromJS(value js.Value) *PaymentMethodChangeEventInit {
 	var out PaymentMethodChangeEventInit
 	var (
 		value0 bool               // javascript: boolean {bubbles Bubbles bubbles}
@@ -1002,16 +981,16 @@ func PaymentMethodChangeEventInitFromJS(value js.Wrapper) *PaymentMethodChangeEv
 		value3 string             // javascript: DOMString {methodName MethodName methodName}
 		value4 *javascript.Object // javascript: object {methodDetails MethodDetails methodDetails}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("methodName")).String()
+	value3 = (value.Get("methodName")).String()
 	out.MethodName = value3
-	if input.Get("methodDetails").Type() != js.TypeNull && input.Get("methodDetails").Type() != js.TypeUndefined {
-		value4 = javascript.ObjectFromJS(input.Get("methodDetails"))
+	if value.Get("methodDetails").Type() != js.TypeNull && value.Get("methodDetails").Type() != js.TypeUndefined {
+		value4 = javascript.ObjectFromJS(value.Get("methodDetails"))
 	}
 	out.MethodDetails = value4
 	return &out
@@ -1023,7 +1002,7 @@ type PaymentMethodData struct {
 	Data             *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1035,18 +1014,16 @@ func (_this *PaymentMethodData) JSValue() js.Value {
 }
 
 // PaymentMethodDataFromJS is allocating a new
-// PaymentMethodData object and copy all values from
-// input javascript object
-func PaymentMethodDataFromJS(value js.Wrapper) *PaymentMethodData {
-	input := value.JSValue()
+// PaymentMethodData object and copy all values in the value javascript object.
+func PaymentMethodDataFromJS(value js.Value) *PaymentMethodData {
 	var out PaymentMethodData
 	var (
 		value0 string             // javascript: DOMString {supportedMethods SupportedMethods supportedMethods}
 		value1 *javascript.Object // javascript: object {data Data data}
 	)
-	value0 = (input.Get("supportedMethods")).String()
+	value0 = (value.Get("supportedMethods")).String()
 	out.SupportedMethods = value0
-	value1 = javascript.ObjectFromJS(input.Get("data"))
+	value1 = javascript.ObjectFromJS(value.Get("data"))
 	out.Data = value1
 	return &out
 }
@@ -1061,7 +1038,7 @@ type PaymentOptions struct {
 	ShippingType          PaymentShippingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1081,10 +1058,8 @@ func (_this *PaymentOptions) JSValue() js.Value {
 }
 
 // PaymentOptionsFromJS is allocating a new
-// PaymentOptions object and copy all values from
-// input javascript object
-func PaymentOptionsFromJS(value js.Wrapper) *PaymentOptions {
-	input := value.JSValue()
+// PaymentOptions object and copy all values in the value javascript object.
+func PaymentOptionsFromJS(value js.Value) *PaymentOptions {
 	var out PaymentOptions
 	var (
 		value0 bool                // javascript: boolean {requestPayerName RequestPayerName requestPayerName}
@@ -1094,17 +1069,17 @@ func PaymentOptionsFromJS(value js.Wrapper) *PaymentOptions {
 		value4 bool                // javascript: boolean {requestShipping RequestShipping requestShipping}
 		value5 PaymentShippingType // javascript: PaymentShippingType {shippingType ShippingType shippingType}
 	)
-	value0 = (input.Get("requestPayerName")).Bool()
+	value0 = (value.Get("requestPayerName")).Bool()
 	out.RequestPayerName = value0
-	value1 = (input.Get("requestBillingAddress")).Bool()
+	value1 = (value.Get("requestBillingAddress")).Bool()
 	out.RequestBillingAddress = value1
-	value2 = (input.Get("requestPayerEmail")).Bool()
+	value2 = (value.Get("requestPayerEmail")).Bool()
 	out.RequestPayerEmail = value2
-	value3 = (input.Get("requestPayerPhone")).Bool()
+	value3 = (value.Get("requestPayerPhone")).Bool()
 	out.RequestPayerPhone = value3
-	value4 = (input.Get("requestShipping")).Bool()
+	value4 = (value.Get("requestShipping")).Bool()
 	out.RequestShipping = value4
-	value5 = PaymentShippingTypeFromJS(input.Get("shippingType"))
+	value5 = PaymentShippingTypeFromJS(value.Get("shippingType"))
 	out.ShippingType = value5
 	return &out
 }
@@ -1116,7 +1091,7 @@ type PaymentRequestUpdateEventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentRequestUpdateEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1130,21 +1105,19 @@ func (_this *PaymentRequestUpdateEventInit) JSValue() js.Value {
 }
 
 // PaymentRequestUpdateEventInitFromJS is allocating a new
-// PaymentRequestUpdateEventInit object and copy all values from
-// input javascript object
-func PaymentRequestUpdateEventInitFromJS(value js.Wrapper) *PaymentRequestUpdateEventInit {
-	input := value.JSValue()
+// PaymentRequestUpdateEventInit object and copy all values in the value javascript object.
+func PaymentRequestUpdateEventInitFromJS(value js.Value) *PaymentRequestUpdateEventInit {
 	var out PaymentRequestUpdateEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -1157,7 +1130,7 @@ type PaymentShippingOption struct {
 	Selected bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentShippingOption) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1173,10 +1146,8 @@ func (_this *PaymentShippingOption) JSValue() js.Value {
 }
 
 // PaymentShippingOptionFromJS is allocating a new
-// PaymentShippingOption object and copy all values from
-// input javascript object
-func PaymentShippingOptionFromJS(value js.Wrapper) *PaymentShippingOption {
-	input := value.JSValue()
+// PaymentShippingOption object and copy all values in the value javascript object.
+func PaymentShippingOptionFromJS(value js.Value) *PaymentShippingOption {
 	var out PaymentShippingOption
 	var (
 		value0 string                 // javascript: DOMString {id Id id}
@@ -1184,13 +1155,13 @@ func PaymentShippingOptionFromJS(value js.Wrapper) *PaymentShippingOption {
 		value2 *PaymentCurrencyAmount // javascript: PaymentCurrencyAmount {amount Amount amount}
 		value3 bool                   // javascript: boolean {selected Selected selected}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("label")).String()
+	value1 = (value.Get("label")).String()
 	out.Label = value1
-	value2 = PaymentCurrencyAmountFromJS(input.Get("amount"))
+	value2 = PaymentCurrencyAmountFromJS(value.Get("amount"))
 	out.Amount = value2
-	value3 = (input.Get("selected")).Bool()
+	value3 = (value.Get("selected")).Bool()
 	out.Selected = value3
 	return &out
 }
@@ -1203,7 +1174,7 @@ type PaymentValidationErrors struct {
 	PaymentMethod   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentValidationErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1219,10 +1190,8 @@ func (_this *PaymentValidationErrors) JSValue() js.Value {
 }
 
 // PaymentValidationErrorsFromJS is allocating a new
-// PaymentValidationErrors object and copy all values from
-// input javascript object
-func PaymentValidationErrorsFromJS(value js.Wrapper) *PaymentValidationErrors {
-	input := value.JSValue()
+// PaymentValidationErrors object and copy all values in the value javascript object.
+func PaymentValidationErrorsFromJS(value js.Value) *PaymentValidationErrors {
 	var out PaymentValidationErrors
 	var (
 		value0 *PayerErrors       // javascript: PayerErrors {payer Payer payer}
@@ -1230,13 +1199,13 @@ func PaymentValidationErrorsFromJS(value js.Wrapper) *PaymentValidationErrors {
 		value2 string             // javascript: DOMString {error Error _error}
 		value3 *javascript.Object // javascript: object {paymentMethod PaymentMethod paymentMethod}
 	)
-	value0 = PayerErrorsFromJS(input.Get("payer"))
+	value0 = PayerErrorsFromJS(value.Get("payer"))
 	out.Payer = value0
-	value1 = AddressErrorsFromJS(input.Get("shippingAddress"))
+	value1 = AddressErrorsFromJS(value.Get("shippingAddress"))
 	out.ShippingAddress = value1
-	value2 = (input.Get("error")).String()
+	value2 = (value.Get("error")).String()
 	out.Error = value2
-	value3 = javascript.ObjectFromJS(input.Get("paymentMethod"))
+	value3 = javascript.ObjectFromJS(value.Get("paymentMethod"))
 	out.PaymentMethod = value3
 	return &out
 }
@@ -1246,15 +1215,19 @@ type MerchantValidationEvent struct {
 	domcore.Event
 }
 
-// MerchantValidationEventFromJS is casting a js.Wrapper into MerchantValidationEvent.
-func MerchantValidationEventFromJS(value js.Wrapper) *MerchantValidationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MerchantValidationEventFromJS is casting a js.Value into MerchantValidationEvent.
+func MerchantValidationEventFromJS(value js.Value) *MerchantValidationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MerchantValidationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MerchantValidationEventFromJS is casting from something that holds a js.Value into MerchantValidationEvent.
+func MerchantValidationEventFromWrapper(input core.Wrapper) *MerchantValidationEvent {
+	return MerchantValidationEventFromJS(input.JSValue())
 }
 
 func NewMerchantValidationEvent(_type string, eventInitDict *MerchantValidationEventInit) (_result *MerchantValidationEvent) {
@@ -1320,15 +1293,19 @@ func (_this *PaymentAddress) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentAddressFromJS is casting a js.Wrapper into PaymentAddress.
-func PaymentAddressFromJS(value js.Wrapper) *PaymentAddress {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentAddressFromJS is casting a js.Value into PaymentAddress.
+func PaymentAddressFromJS(value js.Value) *PaymentAddress {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentAddress{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentAddressFromJS is casting from something that holds a js.Value into PaymentAddress.
+func PaymentAddressFromWrapper(input core.Wrapper) *PaymentAddress {
+	return PaymentAddressFromJS(input.JSValue())
 }
 
 // City returning attribute 'city' with
@@ -1440,15 +1417,19 @@ type PaymentMethodChangeEvent struct {
 	PaymentRequestUpdateEvent
 }
 
-// PaymentMethodChangeEventFromJS is casting a js.Wrapper into PaymentMethodChangeEvent.
-func PaymentMethodChangeEventFromJS(value js.Wrapper) *PaymentMethodChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentMethodChangeEventFromJS is casting a js.Value into PaymentMethodChangeEvent.
+func PaymentMethodChangeEventFromJS(value js.Value) *PaymentMethodChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentMethodChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentMethodChangeEventFromJS is casting from something that holds a js.Value into PaymentMethodChangeEvent.
+func PaymentMethodChangeEventFromWrapper(input core.Wrapper) *PaymentMethodChangeEvent {
+	return PaymentMethodChangeEventFromJS(input.JSValue())
 }
 
 func NewPaymentMethodChangeEvent(_type string, eventInitDict *PaymentMethodChangeEventInit) (_result *PaymentMethodChangeEvent) {
@@ -1499,15 +1480,19 @@ type PaymentRequest struct {
 	domcore.EventTarget
 }
 
-// PaymentRequestFromJS is casting a js.Wrapper into PaymentRequest.
-func PaymentRequestFromJS(value js.Wrapper) *PaymentRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestFromJS is casting a js.Value into PaymentRequest.
+func PaymentRequestFromJS(value js.Value) *PaymentRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestFromJS is casting from something that holds a js.Value into PaymentRequest.
+func PaymentRequestFromWrapper(input core.Wrapper) *PaymentRequest {
+	return PaymentRequestFromJS(input.JSValue())
 }
 
 func NewPaymentRequest(methodData []*PaymentMethodData, details *PaymentDetailsInit, options *PaymentOptions) (_result *PaymentRequest) {
@@ -1786,15 +1771,19 @@ type PaymentRequestUpdateEvent struct {
 	domcore.Event
 }
 
-// PaymentRequestUpdateEventFromJS is casting a js.Wrapper into PaymentRequestUpdateEvent.
-func PaymentRequestUpdateEventFromJS(value js.Wrapper) *PaymentRequestUpdateEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestUpdateEventFromJS is casting a js.Value into PaymentRequestUpdateEvent.
+func PaymentRequestUpdateEventFromJS(value js.Value) *PaymentRequestUpdateEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequestUpdateEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestUpdateEventFromJS is casting from something that holds a js.Value into PaymentRequestUpdateEvent.
+func PaymentRequestUpdateEventFromWrapper(input core.Wrapper) *PaymentRequestUpdateEvent {
+	return PaymentRequestUpdateEventFromJS(input.JSValue())
 }
 
 func NewPaymentRequestUpdateEvent(_type string, eventInitDict *PaymentRequestUpdateEventInit) (_result *PaymentRequestUpdateEvent) {
@@ -1837,15 +1826,19 @@ type PaymentResponse struct {
 	domcore.EventTarget
 }
 
-// PaymentResponseFromJS is casting a js.Wrapper into PaymentResponse.
-func PaymentResponseFromJS(value js.Wrapper) *PaymentResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentResponseFromJS is casting a js.Value into PaymentResponse.
+func PaymentResponseFromJS(value js.Value) *PaymentResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentResponseFromJS is casting from something that holds a js.Value into PaymentResponse.
+func PaymentResponseFromWrapper(input core.Wrapper) *PaymentResponse {
+	return PaymentResponseFromJS(input.JSValue())
 }
 
 // RequestId returning attribute 'requestId' with
@@ -2037,15 +2030,19 @@ func (_this *PromisePaymentDetailsUpdate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentDetailsUpdateFromJS is casting a js.Wrapper into PromisePaymentDetailsUpdate.
-func PromisePaymentDetailsUpdateFromJS(value js.Wrapper) *PromisePaymentDetailsUpdate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentDetailsUpdateFromJS is casting a js.Value into PromisePaymentDetailsUpdate.
+func PromisePaymentDetailsUpdateFromJS(value js.Value) *PromisePaymentDetailsUpdate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentDetailsUpdate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentDetailsUpdateFromJS is casting from something that holds a js.Value into PromisePaymentDetailsUpdate.
+func PromisePaymentDetailsUpdateFromWrapper(input core.Wrapper) *PromisePaymentDetailsUpdate {
+	return PromisePaymentDetailsUpdateFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentDetailsUpdate) Then(onFulfilled *PromisePaymentDetailsUpdateOnFulfilled, onRejected *PromisePaymentDetailsUpdateOnRejected) (_result *PromisePaymentDetailsUpdate) {
@@ -2142,15 +2139,19 @@ func (_this *PromisePaymentResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentResponseFromJS is casting a js.Wrapper into PromisePaymentResponse.
-func PromisePaymentResponseFromJS(value js.Wrapper) *PromisePaymentResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentResponseFromJS is casting a js.Value into PromisePaymentResponse.
+func PromisePaymentResponseFromJS(value js.Value) *PromisePaymentResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentResponseFromJS is casting from something that holds a js.Value into PromisePaymentResponse.
+func PromisePaymentResponseFromWrapper(input core.Wrapper) *PromisePaymentResponse {
+	return PromisePaymentResponseFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentResponse) Then(onFulfilled *PromisePaymentResponseOnFulfilled, onRejected *PromisePaymentResponseOnRejected) (_result *PromisePaymentResponse) {

--- a/payment/request/request_js.go
+++ b/payment/request/request_js.go
@@ -5,6 +5,7 @@ package request
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -305,7 +306,7 @@ type AddressErrors struct {
 	SortingCode       string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddressErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -333,10 +334,8 @@ func (_this *AddressErrors) JSValue() js.Value {
 }
 
 // AddressErrorsFromJS is allocating a new
-// AddressErrors object and copy all values from
-// input javascript object
-func AddressErrorsFromJS(value js.Wrapper) *AddressErrors {
-	input := value.JSValue()
+// AddressErrors object and copy all values in the value javascript object.
+func AddressErrorsFromJS(value js.Value) *AddressErrors {
 	var out AddressErrors
 	var (
 		value0 string // javascript: DOMString {addressLine AddressLine addressLine}
@@ -350,25 +349,25 @@ func AddressErrorsFromJS(value js.Wrapper) *AddressErrors {
 		value8 string // javascript: DOMString {region Region region}
 		value9 string // javascript: DOMString {sortingCode SortingCode sortingCode}
 	)
-	value0 = (input.Get("addressLine")).String()
+	value0 = (value.Get("addressLine")).String()
 	out.AddressLine = value0
-	value1 = (input.Get("city")).String()
+	value1 = (value.Get("city")).String()
 	out.City = value1
-	value2 = (input.Get("country")).String()
+	value2 = (value.Get("country")).String()
 	out.Country = value2
-	value3 = (input.Get("dependentLocality")).String()
+	value3 = (value.Get("dependentLocality")).String()
 	out.DependentLocality = value3
-	value4 = (input.Get("organization")).String()
+	value4 = (value.Get("organization")).String()
 	out.Organization = value4
-	value5 = (input.Get("phone")).String()
+	value5 = (value.Get("phone")).String()
 	out.Phone = value5
-	value6 = (input.Get("postalCode")).String()
+	value6 = (value.Get("postalCode")).String()
 	out.PostalCode = value6
-	value7 = (input.Get("recipient")).String()
+	value7 = (value.Get("recipient")).String()
 	out.Recipient = value7
-	value8 = (input.Get("region")).String()
+	value8 = (value.Get("region")).String()
 	out.Region = value8
-	value9 = (input.Get("sortingCode")).String()
+	value9 = (value.Get("sortingCode")).String()
 	out.SortingCode = value9
 	return &out
 }
@@ -387,7 +386,7 @@ type AddressInit struct {
 	Phone             string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *AddressInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -419,10 +418,8 @@ func (_this *AddressInit) JSValue() js.Value {
 }
 
 // AddressInitFromJS is allocating a new
-// AddressInit object and copy all values from
-// input javascript object
-func AddressInitFromJS(value js.Wrapper) *AddressInit {
-	input := value.JSValue()
+// AddressInit object and copy all values in the value javascript object.
+func AddressInitFromJS(value js.Value) *AddressInit {
 	var out AddressInit
 	var (
 		value0 string   // javascript: DOMString {country Country country}
@@ -436,33 +433,33 @@ func AddressInitFromJS(value js.Wrapper) *AddressInit {
 		value8 string   // javascript: DOMString {recipient Recipient recipient}
 		value9 string   // javascript: DOMString {phone Phone phone}
 	)
-	value0 = (input.Get("country")).String()
+	value0 = (value.Get("country")).String()
 	out.Country = value0
-	__length1 := input.Get("addressLine").Length()
+	__length1 := value.Get("addressLine").Length()
 	__array1 := make([]string, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 string
-		__seq_in1 := input.Get("addressLine").Index(__idx1)
+		__seq_in1 := value.Get("addressLine").Index(__idx1)
 		__seq_out1 = (__seq_in1).String()
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.AddressLine = value1
-	value2 = (input.Get("region")).String()
+	value2 = (value.Get("region")).String()
 	out.Region = value2
-	value3 = (input.Get("city")).String()
+	value3 = (value.Get("city")).String()
 	out.City = value3
-	value4 = (input.Get("dependentLocality")).String()
+	value4 = (value.Get("dependentLocality")).String()
 	out.DependentLocality = value4
-	value5 = (input.Get("postalCode")).String()
+	value5 = (value.Get("postalCode")).String()
 	out.PostalCode = value5
-	value6 = (input.Get("sortingCode")).String()
+	value6 = (value.Get("sortingCode")).String()
 	out.SortingCode = value6
-	value7 = (input.Get("organization")).String()
+	value7 = (value.Get("organization")).String()
 	out.Organization = value7
-	value8 = (input.Get("recipient")).String()
+	value8 = (value.Get("recipient")).String()
 	out.Recipient = value8
-	value9 = (input.Get("phone")).String()
+	value9 = (value.Get("phone")).String()
 	out.Phone = value9
 	return &out
 }
@@ -476,7 +473,7 @@ type MerchantValidationEventInit struct {
 	ValidationURL string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MerchantValidationEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -494,10 +491,8 @@ func (_this *MerchantValidationEventInit) JSValue() js.Value {
 }
 
 // MerchantValidationEventInitFromJS is allocating a new
-// MerchantValidationEventInit object and copy all values from
-// input javascript object
-func MerchantValidationEventInitFromJS(value js.Wrapper) *MerchantValidationEventInit {
-	input := value.JSValue()
+// MerchantValidationEventInit object and copy all values in the value javascript object.
+func MerchantValidationEventInitFromJS(value js.Value) *MerchantValidationEventInit {
 	var out MerchantValidationEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -506,15 +501,15 @@ func MerchantValidationEventInitFromJS(value js.Wrapper) *MerchantValidationEven
 		value3 string // javascript: DOMString {methodName MethodName methodName}
 		value4 string // javascript: USVString {validationURL ValidationURL validationURL}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("methodName")).String()
+	value3 = (value.Get("methodName")).String()
 	out.MethodName = value3
-	value4 = (input.Get("validationURL")).String()
+	value4 = (value.Get("validationURL")).String()
 	out.ValidationURL = value4
 	return &out
 }
@@ -526,7 +521,7 @@ type PayerErrors struct {
 	Phone string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PayerErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -540,21 +535,19 @@ func (_this *PayerErrors) JSValue() js.Value {
 }
 
 // PayerErrorsFromJS is allocating a new
-// PayerErrors object and copy all values from
-// input javascript object
-func PayerErrorsFromJS(value js.Wrapper) *PayerErrors {
-	input := value.JSValue()
+// PayerErrors object and copy all values in the value javascript object.
+func PayerErrorsFromJS(value js.Value) *PayerErrors {
 	var out PayerErrors
 	var (
 		value0 string // javascript: DOMString {email Email email}
 		value1 string // javascript: DOMString {name Name name}
 		value2 string // javascript: DOMString {phone Phone phone}
 	)
-	value0 = (input.Get("email")).String()
+	value0 = (value.Get("email")).String()
 	out.Email = value0
-	value1 = (input.Get("name")).String()
+	value1 = (value.Get("name")).String()
 	out.Name = value1
-	value2 = (input.Get("phone")).String()
+	value2 = (value.Get("phone")).String()
 	out.Phone = value2
 	return &out
 }
@@ -565,7 +558,7 @@ type PaymentCurrencyAmount struct {
 	Value    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentCurrencyAmount) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -577,18 +570,16 @@ func (_this *PaymentCurrencyAmount) JSValue() js.Value {
 }
 
 // PaymentCurrencyAmountFromJS is allocating a new
-// PaymentCurrencyAmount object and copy all values from
-// input javascript object
-func PaymentCurrencyAmountFromJS(value js.Wrapper) *PaymentCurrencyAmount {
-	input := value.JSValue()
+// PaymentCurrencyAmount object and copy all values in the value javascript object.
+func PaymentCurrencyAmountFromJS(value js.Value) *PaymentCurrencyAmount {
 	var out PaymentCurrencyAmount
 	var (
 		value0 string // javascript: DOMString {currency Currency currency}
 		value1 string // javascript: DOMString {value Value value}
 	)
-	value0 = (input.Get("currency")).String()
+	value0 = (value.Get("currency")).String()
 	out.Currency = value0
-	value1 = (input.Get("value")).String()
+	value1 = (value.Get("value")).String()
 	out.Value = value1
 	return &out
 }
@@ -600,7 +591,7 @@ type PaymentDetailsBase struct {
 	Modifiers       []*PaymentDetailsModifier
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsBase) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -626,41 +617,39 @@ func (_this *PaymentDetailsBase) JSValue() js.Value {
 }
 
 // PaymentDetailsBaseFromJS is allocating a new
-// PaymentDetailsBase object and copy all values from
-// input javascript object
-func PaymentDetailsBaseFromJS(value js.Wrapper) *PaymentDetailsBase {
-	input := value.JSValue()
+// PaymentDetailsBase object and copy all values in the value javascript object.
+func PaymentDetailsBaseFromJS(value js.Value) *PaymentDetailsBase {
 	var out PaymentDetailsBase
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
 		value1 []*PaymentShippingOption  // javascript: sequence<PaymentShippingOption> {shippingOptions ShippingOptions shippingOptions}
 		value2 []*PaymentDetailsModifier // javascript: sequence<PaymentDetailsModifier> {modifiers Modifiers modifiers}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
@@ -678,7 +667,7 @@ type PaymentDetailsInit struct {
 	Total           *PaymentItem
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -708,10 +697,8 @@ func (_this *PaymentDetailsInit) JSValue() js.Value {
 }
 
 // PaymentDetailsInitFromJS is allocating a new
-// PaymentDetailsInit object and copy all values from
-// input javascript object
-func PaymentDetailsInitFromJS(value js.Wrapper) *PaymentDetailsInit {
-	input := value.JSValue()
+// PaymentDetailsInit object and copy all values in the value javascript object.
+func PaymentDetailsInitFromJS(value js.Value) *PaymentDetailsInit {
 	var out PaymentDetailsInit
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
@@ -720,39 +707,39 @@ func PaymentDetailsInitFromJS(value js.Wrapper) *PaymentDetailsInit {
 		value3 string                    // javascript: DOMString {id Id id}
 		value4 *PaymentItem              // javascript: PaymentItem {total Total total}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Modifiers = value2
-	value3 = (input.Get("id")).String()
+	value3 = (value.Get("id")).String()
 	out.Id = value3
-	value4 = PaymentItemFromJS(input.Get("total"))
+	value4 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value4
 	return &out
 }
@@ -765,7 +752,7 @@ type PaymentDetailsModifier struct {
 	Data                   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsModifier) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -785,10 +772,8 @@ func (_this *PaymentDetailsModifier) JSValue() js.Value {
 }
 
 // PaymentDetailsModifierFromJS is allocating a new
-// PaymentDetailsModifier object and copy all values from
-// input javascript object
-func PaymentDetailsModifierFromJS(value js.Wrapper) *PaymentDetailsModifier {
-	input := value.JSValue()
+// PaymentDetailsModifier object and copy all values in the value javascript object.
+func PaymentDetailsModifierFromJS(value js.Value) *PaymentDetailsModifier {
 	var out PaymentDetailsModifier
 	var (
 		value0 string             // javascript: DOMString {supportedMethods SupportedMethods supportedMethods}
@@ -796,21 +781,21 @@ func PaymentDetailsModifierFromJS(value js.Wrapper) *PaymentDetailsModifier {
 		value2 []*PaymentItem     // javascript: sequence<PaymentItem> {additionalDisplayItems AdditionalDisplayItems additionalDisplayItems}
 		value3 *javascript.Object // javascript: object {data Data data}
 	)
-	value0 = (input.Get("supportedMethods")).String()
+	value0 = (value.Get("supportedMethods")).String()
 	out.SupportedMethods = value0
-	value1 = PaymentItemFromJS(input.Get("total"))
+	value1 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value1
-	__length2 := input.Get("additionalDisplayItems").Length()
+	__length2 := value.Get("additionalDisplayItems").Length()
 	__array2 := make([]*PaymentItem, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentItem
-		__seq_in2 := input.Get("additionalDisplayItems").Index(__idx2)
+		__seq_in2 := value.Get("additionalDisplayItems").Index(__idx2)
 		__seq_out2 = PaymentItemFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.AdditionalDisplayItems = value2
-	value3 = javascript.ObjectFromJS(input.Get("data"))
+	value3 = javascript.ObjectFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -827,7 +812,7 @@ type PaymentDetailsUpdate struct {
 	PaymentMethodErrors   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentDetailsUpdate) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -863,10 +848,8 @@ func (_this *PaymentDetailsUpdate) JSValue() js.Value {
 }
 
 // PaymentDetailsUpdateFromJS is allocating a new
-// PaymentDetailsUpdate object and copy all values from
-// input javascript object
-func PaymentDetailsUpdateFromJS(value js.Wrapper) *PaymentDetailsUpdate {
-	input := value.JSValue()
+// PaymentDetailsUpdate object and copy all values in the value javascript object.
+func PaymentDetailsUpdateFromJS(value js.Value) *PaymentDetailsUpdate {
 	var out PaymentDetailsUpdate
 	var (
 		value0 []*PaymentItem            // javascript: sequence<PaymentItem> {displayItems DisplayItems displayItems}
@@ -878,45 +861,45 @@ func PaymentDetailsUpdateFromJS(value js.Wrapper) *PaymentDetailsUpdate {
 		value6 *PayerErrors              // javascript: PayerErrors {payerErrors PayerErrors payerErrors}
 		value7 *javascript.Object        // javascript: object {paymentMethodErrors PaymentMethodErrors paymentMethodErrors}
 	)
-	__length0 := input.Get("displayItems").Length()
+	__length0 := value.Get("displayItems").Length()
 	__array0 := make([]*PaymentItem, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *PaymentItem
-		__seq_in0 := input.Get("displayItems").Index(__idx0)
+		__seq_in0 := value.Get("displayItems").Index(__idx0)
 		__seq_out0 = PaymentItemFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.DisplayItems = value0
-	__length1 := input.Get("shippingOptions").Length()
+	__length1 := value.Get("shippingOptions").Length()
 	__array1 := make([]*PaymentShippingOption, __length1, __length1)
 	for __idx1 := 0; __idx1 < __length1; __idx1++ {
 		var __seq_out1 *PaymentShippingOption
-		__seq_in1 := input.Get("shippingOptions").Index(__idx1)
+		__seq_in1 := value.Get("shippingOptions").Index(__idx1)
 		__seq_out1 = PaymentShippingOptionFromJS(__seq_in1)
 		__array1[__idx1] = __seq_out1
 	}
 	value1 = __array1
 	out.ShippingOptions = value1
-	__length2 := input.Get("modifiers").Length()
+	__length2 := value.Get("modifiers").Length()
 	__array2 := make([]*PaymentDetailsModifier, __length2, __length2)
 	for __idx2 := 0; __idx2 < __length2; __idx2++ {
 		var __seq_out2 *PaymentDetailsModifier
-		__seq_in2 := input.Get("modifiers").Index(__idx2)
+		__seq_in2 := value.Get("modifiers").Index(__idx2)
 		__seq_out2 = PaymentDetailsModifierFromJS(__seq_in2)
 		__array2[__idx2] = __seq_out2
 	}
 	value2 = __array2
 	out.Modifiers = value2
-	value3 = (input.Get("error")).String()
+	value3 = (value.Get("error")).String()
 	out.Error = value3
-	value4 = PaymentItemFromJS(input.Get("total"))
+	value4 = PaymentItemFromJS(value.Get("total"))
 	out.Total = value4
-	value5 = AddressErrorsFromJS(input.Get("shippingAddressErrors"))
+	value5 = AddressErrorsFromJS(value.Get("shippingAddressErrors"))
 	out.ShippingAddressErrors = value5
-	value6 = PayerErrorsFromJS(input.Get("payerErrors"))
+	value6 = PayerErrorsFromJS(value.Get("payerErrors"))
 	out.PayerErrors = value6
-	value7 = javascript.ObjectFromJS(input.Get("paymentMethodErrors"))
+	value7 = javascript.ObjectFromJS(value.Get("paymentMethodErrors"))
 	out.PaymentMethodErrors = value7
 	return &out
 }
@@ -928,7 +911,7 @@ type PaymentItem struct {
 	Pending bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentItem) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -942,21 +925,19 @@ func (_this *PaymentItem) JSValue() js.Value {
 }
 
 // PaymentItemFromJS is allocating a new
-// PaymentItem object and copy all values from
-// input javascript object
-func PaymentItemFromJS(value js.Wrapper) *PaymentItem {
-	input := value.JSValue()
+// PaymentItem object and copy all values in the value javascript object.
+func PaymentItemFromJS(value js.Value) *PaymentItem {
 	var out PaymentItem
 	var (
 		value0 string                 // javascript: DOMString {label Label label}
 		value1 *PaymentCurrencyAmount // javascript: PaymentCurrencyAmount {amount Amount amount}
 		value2 bool                   // javascript: boolean {pending Pending pending}
 	)
-	value0 = (input.Get("label")).String()
+	value0 = (value.Get("label")).String()
 	out.Label = value0
-	value1 = PaymentCurrencyAmountFromJS(input.Get("amount"))
+	value1 = PaymentCurrencyAmountFromJS(value.Get("amount"))
 	out.Amount = value1
-	value2 = (input.Get("pending")).Bool()
+	value2 = (value.Get("pending")).Bool()
 	out.Pending = value2
 	return &out
 }
@@ -970,7 +951,7 @@ type PaymentMethodChangeEventInit struct {
 	MethodDetails *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodChangeEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -988,10 +969,8 @@ func (_this *PaymentMethodChangeEventInit) JSValue() js.Value {
 }
 
 // PaymentMethodChangeEventInitFromJS is allocating a new
-// PaymentMethodChangeEventInit object and copy all values from
-// input javascript object
-func PaymentMethodChangeEventInitFromJS(value js.Wrapper) *PaymentMethodChangeEventInit {
-	input := value.JSValue()
+// PaymentMethodChangeEventInit object and copy all values in the value javascript object.
+func PaymentMethodChangeEventInitFromJS(value js.Value) *PaymentMethodChangeEventInit {
 	var out PaymentMethodChangeEventInit
 	var (
 		value0 bool               // javascript: boolean {bubbles Bubbles bubbles}
@@ -1000,16 +979,16 @@ func PaymentMethodChangeEventInitFromJS(value js.Wrapper) *PaymentMethodChangeEv
 		value3 string             // javascript: DOMString {methodName MethodName methodName}
 		value4 *javascript.Object // javascript: object {methodDetails MethodDetails methodDetails}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("methodName")).String()
+	value3 = (value.Get("methodName")).String()
 	out.MethodName = value3
-	if input.Get("methodDetails").Type() != js.TypeNull && input.Get("methodDetails").Type() != js.TypeUndefined {
-		value4 = javascript.ObjectFromJS(input.Get("methodDetails"))
+	if value.Get("methodDetails").Type() != js.TypeNull && value.Get("methodDetails").Type() != js.TypeUndefined {
+		value4 = javascript.ObjectFromJS(value.Get("methodDetails"))
 	}
 	out.MethodDetails = value4
 	return &out
@@ -1021,7 +1000,7 @@ type PaymentMethodData struct {
 	Data             *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentMethodData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1033,18 +1012,16 @@ func (_this *PaymentMethodData) JSValue() js.Value {
 }
 
 // PaymentMethodDataFromJS is allocating a new
-// PaymentMethodData object and copy all values from
-// input javascript object
-func PaymentMethodDataFromJS(value js.Wrapper) *PaymentMethodData {
-	input := value.JSValue()
+// PaymentMethodData object and copy all values in the value javascript object.
+func PaymentMethodDataFromJS(value js.Value) *PaymentMethodData {
 	var out PaymentMethodData
 	var (
 		value0 string             // javascript: DOMString {supportedMethods SupportedMethods supportedMethods}
 		value1 *javascript.Object // javascript: object {data Data data}
 	)
-	value0 = (input.Get("supportedMethods")).String()
+	value0 = (value.Get("supportedMethods")).String()
 	out.SupportedMethods = value0
-	value1 = javascript.ObjectFromJS(input.Get("data"))
+	value1 = javascript.ObjectFromJS(value.Get("data"))
 	out.Data = value1
 	return &out
 }
@@ -1059,7 +1036,7 @@ type PaymentOptions struct {
 	ShippingType          PaymentShippingType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1079,10 +1056,8 @@ func (_this *PaymentOptions) JSValue() js.Value {
 }
 
 // PaymentOptionsFromJS is allocating a new
-// PaymentOptions object and copy all values from
-// input javascript object
-func PaymentOptionsFromJS(value js.Wrapper) *PaymentOptions {
-	input := value.JSValue()
+// PaymentOptions object and copy all values in the value javascript object.
+func PaymentOptionsFromJS(value js.Value) *PaymentOptions {
 	var out PaymentOptions
 	var (
 		value0 bool                // javascript: boolean {requestPayerName RequestPayerName requestPayerName}
@@ -1092,17 +1067,17 @@ func PaymentOptionsFromJS(value js.Wrapper) *PaymentOptions {
 		value4 bool                // javascript: boolean {requestShipping RequestShipping requestShipping}
 		value5 PaymentShippingType // javascript: PaymentShippingType {shippingType ShippingType shippingType}
 	)
-	value0 = (input.Get("requestPayerName")).Bool()
+	value0 = (value.Get("requestPayerName")).Bool()
 	out.RequestPayerName = value0
-	value1 = (input.Get("requestBillingAddress")).Bool()
+	value1 = (value.Get("requestBillingAddress")).Bool()
 	out.RequestBillingAddress = value1
-	value2 = (input.Get("requestPayerEmail")).Bool()
+	value2 = (value.Get("requestPayerEmail")).Bool()
 	out.RequestPayerEmail = value2
-	value3 = (input.Get("requestPayerPhone")).Bool()
+	value3 = (value.Get("requestPayerPhone")).Bool()
 	out.RequestPayerPhone = value3
-	value4 = (input.Get("requestShipping")).Bool()
+	value4 = (value.Get("requestShipping")).Bool()
 	out.RequestShipping = value4
-	value5 = PaymentShippingTypeFromJS(input.Get("shippingType"))
+	value5 = PaymentShippingTypeFromJS(value.Get("shippingType"))
 	out.ShippingType = value5
 	return &out
 }
@@ -1114,7 +1089,7 @@ type PaymentRequestUpdateEventInit struct {
 	Composed   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentRequestUpdateEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1128,21 +1103,19 @@ func (_this *PaymentRequestUpdateEventInit) JSValue() js.Value {
 }
 
 // PaymentRequestUpdateEventInitFromJS is allocating a new
-// PaymentRequestUpdateEventInit object and copy all values from
-// input javascript object
-func PaymentRequestUpdateEventInitFromJS(value js.Wrapper) *PaymentRequestUpdateEventInit {
-	input := value.JSValue()
+// PaymentRequestUpdateEventInit object and copy all values in the value javascript object.
+func PaymentRequestUpdateEventInitFromJS(value js.Value) *PaymentRequestUpdateEventInit {
 	var out PaymentRequestUpdateEventInit
 	var (
 		value0 bool // javascript: boolean {bubbles Bubbles bubbles}
 		value1 bool // javascript: boolean {cancelable Cancelable cancelable}
 		value2 bool // javascript: boolean {composed Composed composed}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
 	return &out
 }
@@ -1155,7 +1128,7 @@ type PaymentShippingOption struct {
 	Selected bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentShippingOption) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1171,10 +1144,8 @@ func (_this *PaymentShippingOption) JSValue() js.Value {
 }
 
 // PaymentShippingOptionFromJS is allocating a new
-// PaymentShippingOption object and copy all values from
-// input javascript object
-func PaymentShippingOptionFromJS(value js.Wrapper) *PaymentShippingOption {
-	input := value.JSValue()
+// PaymentShippingOption object and copy all values in the value javascript object.
+func PaymentShippingOptionFromJS(value js.Value) *PaymentShippingOption {
 	var out PaymentShippingOption
 	var (
 		value0 string                 // javascript: DOMString {id Id id}
@@ -1182,13 +1153,13 @@ func PaymentShippingOptionFromJS(value js.Wrapper) *PaymentShippingOption {
 		value2 *PaymentCurrencyAmount // javascript: PaymentCurrencyAmount {amount Amount amount}
 		value3 bool                   // javascript: boolean {selected Selected selected}
 	)
-	value0 = (input.Get("id")).String()
+	value0 = (value.Get("id")).String()
 	out.Id = value0
-	value1 = (input.Get("label")).String()
+	value1 = (value.Get("label")).String()
 	out.Label = value1
-	value2 = PaymentCurrencyAmountFromJS(input.Get("amount"))
+	value2 = PaymentCurrencyAmountFromJS(value.Get("amount"))
 	out.Amount = value2
-	value3 = (input.Get("selected")).Bool()
+	value3 = (value.Get("selected")).Bool()
 	out.Selected = value3
 	return &out
 }
@@ -1201,7 +1172,7 @@ type PaymentValidationErrors struct {
 	PaymentMethod   *javascript.Object
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *PaymentValidationErrors) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1217,10 +1188,8 @@ func (_this *PaymentValidationErrors) JSValue() js.Value {
 }
 
 // PaymentValidationErrorsFromJS is allocating a new
-// PaymentValidationErrors object and copy all values from
-// input javascript object
-func PaymentValidationErrorsFromJS(value js.Wrapper) *PaymentValidationErrors {
-	input := value.JSValue()
+// PaymentValidationErrors object and copy all values in the value javascript object.
+func PaymentValidationErrorsFromJS(value js.Value) *PaymentValidationErrors {
 	var out PaymentValidationErrors
 	var (
 		value0 *PayerErrors       // javascript: PayerErrors {payer Payer payer}
@@ -1228,13 +1197,13 @@ func PaymentValidationErrorsFromJS(value js.Wrapper) *PaymentValidationErrors {
 		value2 string             // javascript: DOMString {error Error _error}
 		value3 *javascript.Object // javascript: object {paymentMethod PaymentMethod paymentMethod}
 	)
-	value0 = PayerErrorsFromJS(input.Get("payer"))
+	value0 = PayerErrorsFromJS(value.Get("payer"))
 	out.Payer = value0
-	value1 = AddressErrorsFromJS(input.Get("shippingAddress"))
+	value1 = AddressErrorsFromJS(value.Get("shippingAddress"))
 	out.ShippingAddress = value1
-	value2 = (input.Get("error")).String()
+	value2 = (value.Get("error")).String()
 	out.Error = value2
-	value3 = javascript.ObjectFromJS(input.Get("paymentMethod"))
+	value3 = javascript.ObjectFromJS(value.Get("paymentMethod"))
 	out.PaymentMethod = value3
 	return &out
 }
@@ -1244,15 +1213,19 @@ type MerchantValidationEvent struct {
 	domcore.Event
 }
 
-// MerchantValidationEventFromJS is casting a js.Wrapper into MerchantValidationEvent.
-func MerchantValidationEventFromJS(value js.Wrapper) *MerchantValidationEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MerchantValidationEventFromJS is casting a js.Value into MerchantValidationEvent.
+func MerchantValidationEventFromJS(value js.Value) *MerchantValidationEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MerchantValidationEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MerchantValidationEventFromJS is casting from something that holds a js.Value into MerchantValidationEvent.
+func MerchantValidationEventFromWrapper(input core.Wrapper) *MerchantValidationEvent {
+	return MerchantValidationEventFromJS(input.JSValue())
 }
 
 func NewMerchantValidationEvent(_type string, eventInitDict *MerchantValidationEventInit) (_result *MerchantValidationEvent) {
@@ -1318,15 +1291,19 @@ func (_this *PaymentAddress) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PaymentAddressFromJS is casting a js.Wrapper into PaymentAddress.
-func PaymentAddressFromJS(value js.Wrapper) *PaymentAddress {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentAddressFromJS is casting a js.Value into PaymentAddress.
+func PaymentAddressFromJS(value js.Value) *PaymentAddress {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentAddress{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentAddressFromJS is casting from something that holds a js.Value into PaymentAddress.
+func PaymentAddressFromWrapper(input core.Wrapper) *PaymentAddress {
+	return PaymentAddressFromJS(input.JSValue())
 }
 
 // City returning attribute 'city' with
@@ -1438,15 +1415,19 @@ type PaymentMethodChangeEvent struct {
 	PaymentRequestUpdateEvent
 }
 
-// PaymentMethodChangeEventFromJS is casting a js.Wrapper into PaymentMethodChangeEvent.
-func PaymentMethodChangeEventFromJS(value js.Wrapper) *PaymentMethodChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentMethodChangeEventFromJS is casting a js.Value into PaymentMethodChangeEvent.
+func PaymentMethodChangeEventFromJS(value js.Value) *PaymentMethodChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentMethodChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentMethodChangeEventFromJS is casting from something that holds a js.Value into PaymentMethodChangeEvent.
+func PaymentMethodChangeEventFromWrapper(input core.Wrapper) *PaymentMethodChangeEvent {
+	return PaymentMethodChangeEventFromJS(input.JSValue())
 }
 
 func NewPaymentMethodChangeEvent(_type string, eventInitDict *PaymentMethodChangeEventInit) (_result *PaymentMethodChangeEvent) {
@@ -1497,15 +1478,19 @@ type PaymentRequest struct {
 	domcore.EventTarget
 }
 
-// PaymentRequestFromJS is casting a js.Wrapper into PaymentRequest.
-func PaymentRequestFromJS(value js.Wrapper) *PaymentRequest {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestFromJS is casting a js.Value into PaymentRequest.
+func PaymentRequestFromJS(value js.Value) *PaymentRequest {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequest{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestFromJS is casting from something that holds a js.Value into PaymentRequest.
+func PaymentRequestFromWrapper(input core.Wrapper) *PaymentRequest {
+	return PaymentRequestFromJS(input.JSValue())
 }
 
 func NewPaymentRequest(methodData []*PaymentMethodData, details *PaymentDetailsInit, options *PaymentOptions) (_result *PaymentRequest) {
@@ -1784,15 +1769,19 @@ type PaymentRequestUpdateEvent struct {
 	domcore.Event
 }
 
-// PaymentRequestUpdateEventFromJS is casting a js.Wrapper into PaymentRequestUpdateEvent.
-func PaymentRequestUpdateEventFromJS(value js.Wrapper) *PaymentRequestUpdateEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentRequestUpdateEventFromJS is casting a js.Value into PaymentRequestUpdateEvent.
+func PaymentRequestUpdateEventFromJS(value js.Value) *PaymentRequestUpdateEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentRequestUpdateEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentRequestUpdateEventFromJS is casting from something that holds a js.Value into PaymentRequestUpdateEvent.
+func PaymentRequestUpdateEventFromWrapper(input core.Wrapper) *PaymentRequestUpdateEvent {
+	return PaymentRequestUpdateEventFromJS(input.JSValue())
 }
 
 func NewPaymentRequestUpdateEvent(_type string, eventInitDict *PaymentRequestUpdateEventInit) (_result *PaymentRequestUpdateEvent) {
@@ -1835,15 +1824,19 @@ type PaymentResponse struct {
 	domcore.EventTarget
 }
 
-// PaymentResponseFromJS is casting a js.Wrapper into PaymentResponse.
-func PaymentResponseFromJS(value js.Wrapper) *PaymentResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PaymentResponseFromJS is casting a js.Value into PaymentResponse.
+func PaymentResponseFromJS(value js.Value) *PaymentResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PaymentResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PaymentResponseFromJS is casting from something that holds a js.Value into PaymentResponse.
+func PaymentResponseFromWrapper(input core.Wrapper) *PaymentResponse {
+	return PaymentResponseFromJS(input.JSValue())
 }
 
 // RequestId returning attribute 'requestId' with
@@ -2035,15 +2028,19 @@ func (_this *PromisePaymentDetailsUpdate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentDetailsUpdateFromJS is casting a js.Wrapper into PromisePaymentDetailsUpdate.
-func PromisePaymentDetailsUpdateFromJS(value js.Wrapper) *PromisePaymentDetailsUpdate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentDetailsUpdateFromJS is casting a js.Value into PromisePaymentDetailsUpdate.
+func PromisePaymentDetailsUpdateFromJS(value js.Value) *PromisePaymentDetailsUpdate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentDetailsUpdate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentDetailsUpdateFromJS is casting from something that holds a js.Value into PromisePaymentDetailsUpdate.
+func PromisePaymentDetailsUpdateFromWrapper(input core.Wrapper) *PromisePaymentDetailsUpdate {
+	return PromisePaymentDetailsUpdateFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentDetailsUpdate) Then(onFulfilled *PromisePaymentDetailsUpdateOnFulfilled, onRejected *PromisePaymentDetailsUpdateOnRejected) (_result *PromisePaymentDetailsUpdate) {
@@ -2140,15 +2137,19 @@ func (_this *PromisePaymentResponse) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePaymentResponseFromJS is casting a js.Wrapper into PromisePaymentResponse.
-func PromisePaymentResponseFromJS(value js.Wrapper) *PromisePaymentResponse {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePaymentResponseFromJS is casting a js.Value into PromisePaymentResponse.
+func PromisePaymentResponseFromJS(value js.Value) *PromisePaymentResponse {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePaymentResponse{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePaymentResponseFromJS is casting from something that holds a js.Value into PromisePaymentResponse.
+func PromisePaymentResponseFromWrapper(input core.Wrapper) *PromisePaymentResponse {
+	return PromisePaymentResponseFromJS(input.JSValue())
 }
 
 func (_this *PromisePaymentResponse) Then(onFulfilled *PromisePaymentResponseOnFulfilled, onRejected *PromisePaymentResponseOnRejected) (_result *PromisePaymentResponse) {

--- a/performance/performance.go
+++ b/performance/performance.go
@@ -7,6 +7,7 @@ package performance
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -202,7 +203,7 @@ type EventCountsEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -218,26 +219,24 @@ func (_this *EventCountsEntryIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsEntryIteratorValueFromJS is allocating a new
-// EventCountsEntryIteratorValue object and copy all values from
-// input javascript object
-func EventCountsEntryIteratorValueFromJS(value js.Wrapper) *EventCountsEntryIteratorValue {
-	input := value.JSValue()
+// EventCountsEntryIteratorValue object and copy all values in the value javascript object.
+func EventCountsEntryIteratorValueFromJS(value js.Value) *EventCountsEntryIteratorValue {
 	var out EventCountsEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -248,7 +247,7 @@ type EventCountsKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -260,18 +259,16 @@ func (_this *EventCountsKeyIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsKeyIteratorValueFromJS is allocating a new
-// EventCountsKeyIteratorValue object and copy all values from
-// input javascript object
-func EventCountsKeyIteratorValueFromJS(value js.Wrapper) *EventCountsKeyIteratorValue {
-	input := value.JSValue()
+// EventCountsKeyIteratorValue object and copy all values in the value javascript object.
+func EventCountsKeyIteratorValueFromJS(value js.Value) *EventCountsKeyIteratorValue {
 	var out EventCountsKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -282,7 +279,7 @@ type EventCountsValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -294,18 +291,16 @@ func (_this *EventCountsValueIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsValueIteratorValueFromJS is allocating a new
-// EventCountsValueIteratorValue object and copy all values from
-// input javascript object
-func EventCountsValueIteratorValueFromJS(value js.Wrapper) *EventCountsValueIteratorValue {
-	input := value.JSValue()
+// EventCountsValueIteratorValue object and copy all values in the value javascript object.
+func EventCountsValueIteratorValueFromJS(value js.Value) *EventCountsValueIteratorValue {
 	var out EventCountsValueIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -316,7 +311,7 @@ type MarkOptions struct {
 	StartTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MarkOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -328,18 +323,16 @@ func (_this *MarkOptions) JSValue() js.Value {
 }
 
 // MarkOptionsFromJS is allocating a new
-// MarkOptions object and copy all values from
-// input javascript object
-func MarkOptionsFromJS(value js.Wrapper) *MarkOptions {
-	input := value.JSValue()
+// MarkOptions object and copy all values in the value javascript object.
+func MarkOptionsFromJS(value js.Value) *MarkOptions {
 	var out MarkOptions
 	var (
 		value0 js.Value // javascript: any {detail Detail detail}
 		value1 float64  // javascript: double {startTime StartTime startTime}
 	)
-	value0 = input.Get("detail")
+	value0 = value.Get("detail")
 	out.Detail = value0
-	value1 = (input.Get("startTime")).Float()
+	value1 = (value.Get("startTime")).Float()
 	out.StartTime = value1
 	return &out
 }
@@ -352,7 +345,7 @@ type MeasureOptions struct {
 	EndTime   *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MeasureOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -368,10 +361,8 @@ func (_this *MeasureOptions) JSValue() js.Value {
 }
 
 // MeasureOptionsFromJS is allocating a new
-// MeasureOptions object and copy all values from
-// input javascript object
-func MeasureOptionsFromJS(value js.Wrapper) *MeasureOptions {
-	input := value.JSValue()
+// MeasureOptions object and copy all values in the value javascript object.
+func MeasureOptionsFromJS(value js.Value) *MeasureOptions {
 	var out MeasureOptions
 	var (
 		value0 js.Value // javascript: any {detail Detail detail}
@@ -379,13 +370,13 @@ func MeasureOptionsFromJS(value js.Wrapper) *MeasureOptions {
 		value2 float64  // javascript: double {duration Duration duration}
 		value3 *Union   // javascript: Union {endTime EndTime endTime}
 	)
-	value0 = input.Get("detail")
+	value0 = value.Get("detail")
 	out.Detail = value0
-	value1 = UnionFromJS(input.Get("startTime"))
+	value1 = UnionFromJS(value.Get("startTime"))
 	out.StartTime = value1
-	value2 = (input.Get("duration")).Float()
+	value2 = (value.Get("duration")).Float()
 	out.Duration = value2
-	value3 = UnionFromJS(input.Get("endTime"))
+	value3 = UnionFromJS(value.Get("endTime"))
 	out.EndTime = value3
 	return &out
 }
@@ -397,7 +388,7 @@ type ObserverInit struct {
 	Buffered   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -415,29 +406,27 @@ func (_this *ObserverInit) JSValue() js.Value {
 }
 
 // ObserverInitFromJS is allocating a new
-// ObserverInit object and copy all values from
-// input javascript object
-func ObserverInitFromJS(value js.Wrapper) *ObserverInit {
-	input := value.JSValue()
+// ObserverInit object and copy all values in the value javascript object.
+func ObserverInitFromJS(value js.Value) *ObserverInit {
 	var out ObserverInit
 	var (
 		value0 []string // javascript: sequence<DOMString> {entryTypes EntryTypes entryTypes}
 		value1 string   // javascript: DOMString {type Type _type}
 		value2 bool     // javascript: boolean {buffered Buffered buffered}
 	)
-	__length0 := input.Get("entryTypes").Length()
+	__length0 := value.Get("entryTypes").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("entryTypes").Index(__idx0)
+		__seq_in0 := value.Get("entryTypes").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.EntryTypes = value0
-	value1 = (input.Get("type")).String()
+	value1 = (value.Get("type")).String()
 	out.Type = value1
-	value2 = (input.Get("buffered")).Bool()
+	value2 = (value.Get("buffered")).Bool()
 	out.Buffered = value2
 	return &out
 }
@@ -452,15 +441,19 @@ func (_this *Entry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EntryFromJS is casting a js.Wrapper into Entry.
-func EntryFromJS(value js.Wrapper) *Entry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EntryFromJS is casting a js.Value into Entry.
+func EntryFromJS(value js.Value) *Entry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Entry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EntryFromJS is casting from something that holds a js.Value into Entry.
+func EntryFromWrapper(input core.Wrapper) *Entry {
+	return EntryFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -523,15 +516,19 @@ func (_this *EventCounts) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsFromJS is casting a js.Wrapper into EventCounts.
-func EventCountsFromJS(value js.Wrapper) *EventCounts {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsFromJS is casting a js.Value into EventCounts.
+func EventCountsFromJS(value js.Value) *EventCounts {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCounts{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsFromJS is casting from something that holds a js.Value into EventCounts.
+func EventCountsFromWrapper(input core.Wrapper) *EventCounts {
+	return EventCountsFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -656,15 +653,19 @@ func (_this *EventCountsEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsEntryIteratorFromJS is casting a js.Wrapper into EventCountsEntryIterator.
-func EventCountsEntryIteratorFromJS(value js.Wrapper) *EventCountsEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsEntryIteratorFromJS is casting a js.Value into EventCountsEntryIterator.
+func EventCountsEntryIteratorFromJS(value js.Value) *EventCountsEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsEntryIteratorFromJS is casting from something that holds a js.Value into EventCountsEntryIterator.
+func EventCountsEntryIteratorFromWrapper(input core.Wrapper) *EventCountsEntryIterator {
+	return EventCountsEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsEntryIterator) Next() (_result *EventCountsEntryIteratorValue) {
@@ -691,15 +692,19 @@ func (_this *EventCountsKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsKeyIteratorFromJS is casting a js.Wrapper into EventCountsKeyIterator.
-func EventCountsKeyIteratorFromJS(value js.Wrapper) *EventCountsKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsKeyIteratorFromJS is casting a js.Value into EventCountsKeyIterator.
+func EventCountsKeyIteratorFromJS(value js.Value) *EventCountsKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsKeyIteratorFromJS is casting from something that holds a js.Value into EventCountsKeyIterator.
+func EventCountsKeyIteratorFromWrapper(input core.Wrapper) *EventCountsKeyIterator {
+	return EventCountsKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsKeyIterator) Next() (_result *EventCountsKeyIteratorValue) {
@@ -726,15 +731,19 @@ func (_this *EventCountsValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsValueIteratorFromJS is casting a js.Wrapper into EventCountsValueIterator.
-func EventCountsValueIteratorFromJS(value js.Wrapper) *EventCountsValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsValueIteratorFromJS is casting a js.Value into EventCountsValueIterator.
+func EventCountsValueIteratorFromJS(value js.Value) *EventCountsValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsValueIteratorFromJS is casting from something that holds a js.Value into EventCountsValueIterator.
+func EventCountsValueIteratorFromWrapper(input core.Wrapper) *EventCountsValueIterator {
+	return EventCountsValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsValueIterator) Next() (_result *EventCountsValueIteratorValue) {
@@ -756,15 +765,19 @@ type EventTiming struct {
 	Entry
 }
 
-// EventTimingFromJS is casting a js.Wrapper into EventTiming.
-func EventTimingFromJS(value js.Wrapper) *EventTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventTimingFromJS is casting a js.Value into EventTiming.
+func EventTimingFromJS(value js.Value) *EventTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventTimingFromJS is casting from something that holds a js.Value into EventTiming.
+func EventTimingFromWrapper(input core.Wrapper) *EventTiming {
+	return EventTimingFromJS(input.JSValue())
 }
 
 // ProcessingStart returning attribute 'processingStart' with
@@ -799,15 +812,19 @@ type LongTaskTiming struct {
 	Entry
 }
 
-// LongTaskTimingFromJS is casting a js.Wrapper into LongTaskTiming.
-func LongTaskTimingFromJS(value js.Wrapper) *LongTaskTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LongTaskTimingFromJS is casting a js.Value into LongTaskTiming.
+func LongTaskTimingFromJS(value js.Value) *LongTaskTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LongTaskTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LongTaskTimingFromJS is casting from something that holds a js.Value into LongTaskTiming.
+func LongTaskTimingFromWrapper(input core.Wrapper) *LongTaskTiming {
+	return LongTaskTimingFromJS(input.JSValue())
 }
 
 // Attribution returning attribute 'attribution' with
@@ -824,15 +841,19 @@ type Mark struct {
 	Entry
 }
 
-// MarkFromJS is casting a js.Wrapper into Mark.
-func MarkFromJS(value js.Wrapper) *Mark {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MarkFromJS is casting a js.Value into Mark.
+func MarkFromJS(value js.Value) *Mark {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Mark{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MarkFromJS is casting from something that holds a js.Value into Mark.
+func MarkFromWrapper(input core.Wrapper) *Mark {
+	return MarkFromJS(input.JSValue())
 }
 
 func NewPerformanceMark(markName string, markOptions *MarkOptions) (_result *Mark) {
@@ -872,15 +893,19 @@ type Measure struct {
 	Entry
 }
 
-// MeasureFromJS is casting a js.Wrapper into Measure.
-func MeasureFromJS(value js.Wrapper) *Measure {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MeasureFromJS is casting a js.Value into Measure.
+func MeasureFromJS(value js.Value) *Measure {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Measure{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MeasureFromJS is casting from something that holds a js.Value into Measure.
+func MeasureFromWrapper(input core.Wrapper) *Measure {
+	return MeasureFromJS(input.JSValue())
 }
 
 // Detail returning attribute 'detail' with
@@ -902,15 +927,19 @@ func (_this *Navigation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NavigationFromJS is casting a js.Wrapper into Navigation.
-func NavigationFromJS(value js.Wrapper) *Navigation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigationFromJS is casting a js.Value into Navigation.
+func NavigationFromJS(value js.Value) *Navigation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Navigation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigationFromJS is casting from something that holds a js.Value into Navigation.
+func NavigationFromWrapper(input core.Wrapper) *Navigation {
+	return NavigationFromJS(input.JSValue())
 }
 
 const (
@@ -957,15 +986,19 @@ type NavigationTiming struct {
 	ResourceTiming
 }
 
-// NavigationTimingFromJS is casting a js.Wrapper into NavigationTiming.
-func NavigationTimingFromJS(value js.Wrapper) *NavigationTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigationTimingFromJS is casting a js.Value into NavigationTiming.
+func NavigationTimingFromJS(value js.Value) *NavigationTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NavigationTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigationTimingFromJS is casting from something that holds a js.Value into NavigationTiming.
+func NavigationTimingFromWrapper(input core.Wrapper) *NavigationTiming {
+	return NavigationTimingFromJS(input.JSValue())
 }
 
 // UnloadEventStart returning attribute 'unloadEventStart' with
@@ -1082,15 +1115,19 @@ func (_this *Observer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObserverFromJS is casting a js.Wrapper into Observer.
-func ObserverFromJS(value js.Wrapper) *Observer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObserverFromJS is casting a js.Value into Observer.
+func ObserverFromJS(value js.Value) *Observer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Observer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObserverFromJS is casting from something that holds a js.Value into Observer.
+func ObserverFromWrapper(input core.Wrapper) *Observer {
+	return ObserverFromJS(input.JSValue())
 }
 
 // SupportedEntryTypes returning attribute 'supportedEntryTypes' with
@@ -1181,15 +1218,19 @@ func (_this *ObserverEntryList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObserverEntryListFromJS is casting a js.Wrapper into ObserverEntryList.
-func ObserverEntryListFromJS(value js.Wrapper) *ObserverEntryList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObserverEntryListFromJS is casting a js.Value into ObserverEntryList.
+func ObserverEntryListFromJS(value js.Value) *ObserverEntryList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ObserverEntryList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObserverEntryListFromJS is casting from something that holds a js.Value into ObserverEntryList.
+func ObserverEntryListFromWrapper(input core.Wrapper) *ObserverEntryList {
+	return ObserverEntryListFromJS(input.JSValue())
 }
 
 func (_this *ObserverEntryList) GetEntries() (_result []*Entry) {
@@ -1280,15 +1321,19 @@ type Performance struct {
 	domcore.EventTarget
 }
 
-// PerformanceFromJS is casting a js.Wrapper into Performance.
-func PerformanceFromJS(value js.Wrapper) *Performance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PerformanceFromJS is casting a js.Value into Performance.
+func PerformanceFromJS(value js.Value) *Performance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Performance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PerformanceFromJS is casting from something that holds a js.Value into Performance.
+func PerformanceFromWrapper(input core.Wrapper) *Performance {
+	return PerformanceFromJS(input.JSValue())
 }
 
 // TimeOrigin returning attribute 'timeOrigin' with
@@ -1600,15 +1645,19 @@ type PerformancePaintTiming struct {
 	Entry
 }
 
-// PerformancePaintTimingFromJS is casting a js.Wrapper into PerformancePaintTiming.
-func PerformancePaintTimingFromJS(value js.Wrapper) *PerformancePaintTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PerformancePaintTimingFromJS is casting a js.Value into PerformancePaintTiming.
+func PerformancePaintTimingFromJS(value js.Value) *PerformancePaintTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PerformancePaintTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PerformancePaintTimingFromJS is casting from something that holds a js.Value into PerformancePaintTiming.
+func PerformancePaintTimingFromWrapper(input core.Wrapper) *PerformancePaintTiming {
+	return PerformancePaintTimingFromJS(input.JSValue())
 }
 
 // class: PerformanceResourceTiming
@@ -1616,15 +1665,19 @@ type ResourceTiming struct {
 	Entry
 }
 
-// ResourceTimingFromJS is casting a js.Wrapper into ResourceTiming.
-func ResourceTimingFromJS(value js.Wrapper) *ResourceTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResourceTimingFromJS is casting a js.Value into ResourceTiming.
+func ResourceTimingFromJS(value js.Value) *ResourceTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResourceTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResourceTimingFromJS is casting from something that holds a js.Value into ResourceTiming.
+func ResourceTimingFromWrapper(input core.Wrapper) *ResourceTiming {
+	return ResourceTimingFromJS(input.JSValue())
 }
 
 // InitiatorType returning attribute 'initiatorType' with
@@ -1813,15 +1866,19 @@ func (_this *ServerTiming) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServerTimingFromJS is casting a js.Wrapper into ServerTiming.
-func ServerTimingFromJS(value js.Wrapper) *ServerTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServerTimingFromJS is casting a js.Value into ServerTiming.
+func ServerTimingFromJS(value js.Value) *ServerTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServerTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServerTimingFromJS is casting from something that holds a js.Value into ServerTiming.
+func ServerTimingFromWrapper(input core.Wrapper) *ServerTiming {
+	return ServerTimingFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1870,15 +1927,19 @@ type TaskAttributionTiming struct {
 	Entry
 }
 
-// TaskAttributionTimingFromJS is casting a js.Wrapper into TaskAttributionTiming.
-func TaskAttributionTimingFromJS(value js.Wrapper) *TaskAttributionTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TaskAttributionTimingFromJS is casting a js.Value into TaskAttributionTiming.
+func TaskAttributionTimingFromJS(value js.Value) *TaskAttributionTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TaskAttributionTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TaskAttributionTimingFromJS is casting from something that holds a js.Value into TaskAttributionTiming.
+func TaskAttributionTimingFromWrapper(input core.Wrapper) *TaskAttributionTiming {
+	return TaskAttributionTimingFromJS(input.JSValue())
 }
 
 // ContainerType returning attribute 'containerType' with
@@ -1927,15 +1988,19 @@ func (_this *Timing) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TimingFromJS is casting a js.Wrapper into Timing.
-func TimingFromJS(value js.Wrapper) *Timing {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TimingFromJS is casting a js.Value into Timing.
+func TimingFromJS(value js.Value) *Timing {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Timing{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TimingFromJS is casting from something that holds a js.Value into Timing.
+func TimingFromWrapper(input core.Wrapper) *Timing {
+	return TimingFromJS(input.JSValue())
 }
 
 // NavigationStart returning attribute 'navigationStart' with

--- a/performance/performance_js.go
+++ b/performance/performance_js.go
@@ -5,6 +5,7 @@ package performance
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -200,7 +201,7 @@ type EventCountsEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -216,26 +217,24 @@ func (_this *EventCountsEntryIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsEntryIteratorValueFromJS is allocating a new
-// EventCountsEntryIteratorValue object and copy all values from
-// input javascript object
-func EventCountsEntryIteratorValueFromJS(value js.Wrapper) *EventCountsEntryIteratorValue {
-	input := value.JSValue()
+// EventCountsEntryIteratorValue object and copy all values in the value javascript object.
+func EventCountsEntryIteratorValueFromJS(value js.Value) *EventCountsEntryIteratorValue {
 	var out EventCountsEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -246,7 +245,7 @@ type EventCountsKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -258,18 +257,16 @@ func (_this *EventCountsKeyIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsKeyIteratorValueFromJS is allocating a new
-// EventCountsKeyIteratorValue object and copy all values from
-// input javascript object
-func EventCountsKeyIteratorValueFromJS(value js.Wrapper) *EventCountsKeyIteratorValue {
-	input := value.JSValue()
+// EventCountsKeyIteratorValue object and copy all values in the value javascript object.
+func EventCountsKeyIteratorValueFromJS(value js.Value) *EventCountsKeyIteratorValue {
 	var out EventCountsKeyIteratorValue
 	var (
 		value0 string // javascript: DOMString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -280,7 +277,7 @@ type EventCountsValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventCountsValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -292,18 +289,16 @@ func (_this *EventCountsValueIteratorValue) JSValue() js.Value {
 }
 
 // EventCountsValueIteratorValueFromJS is allocating a new
-// EventCountsValueIteratorValue object and copy all values from
-// input javascript object
-func EventCountsValueIteratorValueFromJS(value js.Wrapper) *EventCountsValueIteratorValue {
-	input := value.JSValue()
+// EventCountsValueIteratorValue object and copy all values in the value javascript object.
+func EventCountsValueIteratorValueFromJS(value js.Value) *EventCountsValueIteratorValue {
 	var out EventCountsValueIteratorValue
 	var (
 		value0 uint // javascript: unsigned long {value Value value}
 		value1 bool // javascript: boolean {done Done done}
 	)
-	value0 = (uint)((input.Get("value")).Int())
+	value0 = (uint)((value.Get("value")).Int())
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -314,7 +309,7 @@ type MarkOptions struct {
 	StartTime float64
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MarkOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -326,18 +321,16 @@ func (_this *MarkOptions) JSValue() js.Value {
 }
 
 // MarkOptionsFromJS is allocating a new
-// MarkOptions object and copy all values from
-// input javascript object
-func MarkOptionsFromJS(value js.Wrapper) *MarkOptions {
-	input := value.JSValue()
+// MarkOptions object and copy all values in the value javascript object.
+func MarkOptionsFromJS(value js.Value) *MarkOptions {
 	var out MarkOptions
 	var (
 		value0 js.Value // javascript: any {detail Detail detail}
 		value1 float64  // javascript: double {startTime StartTime startTime}
 	)
-	value0 = input.Get("detail")
+	value0 = value.Get("detail")
 	out.Detail = value0
-	value1 = (input.Get("startTime")).Float()
+	value1 = (value.Get("startTime")).Float()
 	out.StartTime = value1
 	return &out
 }
@@ -350,7 +343,7 @@ type MeasureOptions struct {
 	EndTime   *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MeasureOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -366,10 +359,8 @@ func (_this *MeasureOptions) JSValue() js.Value {
 }
 
 // MeasureOptionsFromJS is allocating a new
-// MeasureOptions object and copy all values from
-// input javascript object
-func MeasureOptionsFromJS(value js.Wrapper) *MeasureOptions {
-	input := value.JSValue()
+// MeasureOptions object and copy all values in the value javascript object.
+func MeasureOptionsFromJS(value js.Value) *MeasureOptions {
 	var out MeasureOptions
 	var (
 		value0 js.Value // javascript: any {detail Detail detail}
@@ -377,13 +368,13 @@ func MeasureOptionsFromJS(value js.Wrapper) *MeasureOptions {
 		value2 float64  // javascript: double {duration Duration duration}
 		value3 *Union   // javascript: Union {endTime EndTime endTime}
 	)
-	value0 = input.Get("detail")
+	value0 = value.Get("detail")
 	out.Detail = value0
-	value1 = UnionFromJS(input.Get("startTime"))
+	value1 = UnionFromJS(value.Get("startTime"))
 	out.StartTime = value1
-	value2 = (input.Get("duration")).Float()
+	value2 = (value.Get("duration")).Float()
 	out.Duration = value2
-	value3 = UnionFromJS(input.Get("endTime"))
+	value3 = UnionFromJS(value.Get("endTime"))
 	out.EndTime = value3
 	return &out
 }
@@ -395,7 +386,7 @@ type ObserverInit struct {
 	Buffered   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -413,29 +404,27 @@ func (_this *ObserverInit) JSValue() js.Value {
 }
 
 // ObserverInitFromJS is allocating a new
-// ObserverInit object and copy all values from
-// input javascript object
-func ObserverInitFromJS(value js.Wrapper) *ObserverInit {
-	input := value.JSValue()
+// ObserverInit object and copy all values in the value javascript object.
+func ObserverInitFromJS(value js.Value) *ObserverInit {
 	var out ObserverInit
 	var (
 		value0 []string // javascript: sequence<DOMString> {entryTypes EntryTypes entryTypes}
 		value1 string   // javascript: DOMString {type Type _type}
 		value2 bool     // javascript: boolean {buffered Buffered buffered}
 	)
-	__length0 := input.Get("entryTypes").Length()
+	__length0 := value.Get("entryTypes").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("entryTypes").Index(__idx0)
+		__seq_in0 := value.Get("entryTypes").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.EntryTypes = value0
-	value1 = (input.Get("type")).String()
+	value1 = (value.Get("type")).String()
 	out.Type = value1
-	value2 = (input.Get("buffered")).Bool()
+	value2 = (value.Get("buffered")).Bool()
 	out.Buffered = value2
 	return &out
 }
@@ -450,15 +439,19 @@ func (_this *Entry) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EntryFromJS is casting a js.Wrapper into Entry.
-func EntryFromJS(value js.Wrapper) *Entry {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EntryFromJS is casting a js.Value into Entry.
+func EntryFromJS(value js.Value) *Entry {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Entry{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EntryFromJS is casting from something that holds a js.Value into Entry.
+func EntryFromWrapper(input core.Wrapper) *Entry {
+	return EntryFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -521,15 +514,19 @@ func (_this *EventCounts) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsFromJS is casting a js.Wrapper into EventCounts.
-func EventCountsFromJS(value js.Wrapper) *EventCounts {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsFromJS is casting a js.Value into EventCounts.
+func EventCountsFromJS(value js.Value) *EventCounts {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCounts{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsFromJS is casting from something that holds a js.Value into EventCounts.
+func EventCountsFromWrapper(input core.Wrapper) *EventCounts {
+	return EventCountsFromJS(input.JSValue())
 }
 
 // Size returning attribute 'size' with
@@ -654,15 +651,19 @@ func (_this *EventCountsEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsEntryIteratorFromJS is casting a js.Wrapper into EventCountsEntryIterator.
-func EventCountsEntryIteratorFromJS(value js.Wrapper) *EventCountsEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsEntryIteratorFromJS is casting a js.Value into EventCountsEntryIterator.
+func EventCountsEntryIteratorFromJS(value js.Value) *EventCountsEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsEntryIteratorFromJS is casting from something that holds a js.Value into EventCountsEntryIterator.
+func EventCountsEntryIteratorFromWrapper(input core.Wrapper) *EventCountsEntryIterator {
+	return EventCountsEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsEntryIterator) Next() (_result *EventCountsEntryIteratorValue) {
@@ -689,15 +690,19 @@ func (_this *EventCountsKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsKeyIteratorFromJS is casting a js.Wrapper into EventCountsKeyIterator.
-func EventCountsKeyIteratorFromJS(value js.Wrapper) *EventCountsKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsKeyIteratorFromJS is casting a js.Value into EventCountsKeyIterator.
+func EventCountsKeyIteratorFromJS(value js.Value) *EventCountsKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsKeyIteratorFromJS is casting from something that holds a js.Value into EventCountsKeyIterator.
+func EventCountsKeyIteratorFromWrapper(input core.Wrapper) *EventCountsKeyIterator {
+	return EventCountsKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsKeyIterator) Next() (_result *EventCountsKeyIteratorValue) {
@@ -724,15 +729,19 @@ func (_this *EventCountsValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// EventCountsValueIteratorFromJS is casting a js.Wrapper into EventCountsValueIterator.
-func EventCountsValueIteratorFromJS(value js.Wrapper) *EventCountsValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventCountsValueIteratorFromJS is casting a js.Value into EventCountsValueIterator.
+func EventCountsValueIteratorFromJS(value js.Value) *EventCountsValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventCountsValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventCountsValueIteratorFromJS is casting from something that holds a js.Value into EventCountsValueIterator.
+func EventCountsValueIteratorFromWrapper(input core.Wrapper) *EventCountsValueIterator {
+	return EventCountsValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *EventCountsValueIterator) Next() (_result *EventCountsValueIteratorValue) {
@@ -754,15 +763,19 @@ type EventTiming struct {
 	Entry
 }
 
-// EventTimingFromJS is casting a js.Wrapper into EventTiming.
-func EventTimingFromJS(value js.Wrapper) *EventTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventTimingFromJS is casting a js.Value into EventTiming.
+func EventTimingFromJS(value js.Value) *EventTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &EventTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventTimingFromJS is casting from something that holds a js.Value into EventTiming.
+func EventTimingFromWrapper(input core.Wrapper) *EventTiming {
+	return EventTimingFromJS(input.JSValue())
 }
 
 // ProcessingStart returning attribute 'processingStart' with
@@ -797,15 +810,19 @@ type LongTaskTiming struct {
 	Entry
 }
 
-// LongTaskTimingFromJS is casting a js.Wrapper into LongTaskTiming.
-func LongTaskTimingFromJS(value js.Wrapper) *LongTaskTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// LongTaskTimingFromJS is casting a js.Value into LongTaskTiming.
+func LongTaskTimingFromJS(value js.Value) *LongTaskTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &LongTaskTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// LongTaskTimingFromJS is casting from something that holds a js.Value into LongTaskTiming.
+func LongTaskTimingFromWrapper(input core.Wrapper) *LongTaskTiming {
+	return LongTaskTimingFromJS(input.JSValue())
 }
 
 // Attribution returning attribute 'attribution' with
@@ -822,15 +839,19 @@ type Mark struct {
 	Entry
 }
 
-// MarkFromJS is casting a js.Wrapper into Mark.
-func MarkFromJS(value js.Wrapper) *Mark {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MarkFromJS is casting a js.Value into Mark.
+func MarkFromJS(value js.Value) *Mark {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Mark{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MarkFromJS is casting from something that holds a js.Value into Mark.
+func MarkFromWrapper(input core.Wrapper) *Mark {
+	return MarkFromJS(input.JSValue())
 }
 
 func NewPerformanceMark(markName string, markOptions *MarkOptions) (_result *Mark) {
@@ -870,15 +891,19 @@ type Measure struct {
 	Entry
 }
 
-// MeasureFromJS is casting a js.Wrapper into Measure.
-func MeasureFromJS(value js.Wrapper) *Measure {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MeasureFromJS is casting a js.Value into Measure.
+func MeasureFromJS(value js.Value) *Measure {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Measure{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MeasureFromJS is casting from something that holds a js.Value into Measure.
+func MeasureFromWrapper(input core.Wrapper) *Measure {
+	return MeasureFromJS(input.JSValue())
 }
 
 // Detail returning attribute 'detail' with
@@ -900,15 +925,19 @@ func (_this *Navigation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// NavigationFromJS is casting a js.Wrapper into Navigation.
-func NavigationFromJS(value js.Wrapper) *Navigation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigationFromJS is casting a js.Value into Navigation.
+func NavigationFromJS(value js.Value) *Navigation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Navigation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigationFromJS is casting from something that holds a js.Value into Navigation.
+func NavigationFromWrapper(input core.Wrapper) *Navigation {
+	return NavigationFromJS(input.JSValue())
 }
 
 const (
@@ -955,15 +984,19 @@ type NavigationTiming struct {
 	ResourceTiming
 }
 
-// NavigationTimingFromJS is casting a js.Wrapper into NavigationTiming.
-func NavigationTimingFromJS(value js.Wrapper) *NavigationTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// NavigationTimingFromJS is casting a js.Value into NavigationTiming.
+func NavigationTimingFromJS(value js.Value) *NavigationTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &NavigationTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// NavigationTimingFromJS is casting from something that holds a js.Value into NavigationTiming.
+func NavigationTimingFromWrapper(input core.Wrapper) *NavigationTiming {
+	return NavigationTimingFromJS(input.JSValue())
 }
 
 // UnloadEventStart returning attribute 'unloadEventStart' with
@@ -1080,15 +1113,19 @@ func (_this *Observer) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObserverFromJS is casting a js.Wrapper into Observer.
-func ObserverFromJS(value js.Wrapper) *Observer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObserverFromJS is casting a js.Value into Observer.
+func ObserverFromJS(value js.Value) *Observer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Observer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObserverFromJS is casting from something that holds a js.Value into Observer.
+func ObserverFromWrapper(input core.Wrapper) *Observer {
+	return ObserverFromJS(input.JSValue())
 }
 
 // SupportedEntryTypes returning attribute 'supportedEntryTypes' with
@@ -1179,15 +1216,19 @@ func (_this *ObserverEntryList) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ObserverEntryListFromJS is casting a js.Wrapper into ObserverEntryList.
-func ObserverEntryListFromJS(value js.Wrapper) *ObserverEntryList {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ObserverEntryListFromJS is casting a js.Value into ObserverEntryList.
+func ObserverEntryListFromJS(value js.Value) *ObserverEntryList {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ObserverEntryList{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ObserverEntryListFromJS is casting from something that holds a js.Value into ObserverEntryList.
+func ObserverEntryListFromWrapper(input core.Wrapper) *ObserverEntryList {
+	return ObserverEntryListFromJS(input.JSValue())
 }
 
 func (_this *ObserverEntryList) GetEntries() (_result []*Entry) {
@@ -1278,15 +1319,19 @@ type Performance struct {
 	domcore.EventTarget
 }
 
-// PerformanceFromJS is casting a js.Wrapper into Performance.
-func PerformanceFromJS(value js.Wrapper) *Performance {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PerformanceFromJS is casting a js.Value into Performance.
+func PerformanceFromJS(value js.Value) *Performance {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Performance{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PerformanceFromJS is casting from something that holds a js.Value into Performance.
+func PerformanceFromWrapper(input core.Wrapper) *Performance {
+	return PerformanceFromJS(input.JSValue())
 }
 
 // TimeOrigin returning attribute 'timeOrigin' with
@@ -1598,15 +1643,19 @@ type PerformancePaintTiming struct {
 	Entry
 }
 
-// PerformancePaintTimingFromJS is casting a js.Wrapper into PerformancePaintTiming.
-func PerformancePaintTimingFromJS(value js.Wrapper) *PerformancePaintTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PerformancePaintTimingFromJS is casting a js.Value into PerformancePaintTiming.
+func PerformancePaintTimingFromJS(value js.Value) *PerformancePaintTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PerformancePaintTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PerformancePaintTimingFromJS is casting from something that holds a js.Value into PerformancePaintTiming.
+func PerformancePaintTimingFromWrapper(input core.Wrapper) *PerformancePaintTiming {
+	return PerformancePaintTimingFromJS(input.JSValue())
 }
 
 // class: PerformanceResourceTiming
@@ -1614,15 +1663,19 @@ type ResourceTiming struct {
 	Entry
 }
 
-// ResourceTimingFromJS is casting a js.Wrapper into ResourceTiming.
-func ResourceTimingFromJS(value js.Wrapper) *ResourceTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ResourceTimingFromJS is casting a js.Value into ResourceTiming.
+func ResourceTimingFromJS(value js.Value) *ResourceTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ResourceTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ResourceTimingFromJS is casting from something that holds a js.Value into ResourceTiming.
+func ResourceTimingFromWrapper(input core.Wrapper) *ResourceTiming {
+	return ResourceTimingFromJS(input.JSValue())
 }
 
 // InitiatorType returning attribute 'initiatorType' with
@@ -1811,15 +1864,19 @@ func (_this *ServerTiming) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ServerTimingFromJS is casting a js.Wrapper into ServerTiming.
-func ServerTimingFromJS(value js.Wrapper) *ServerTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServerTimingFromJS is casting a js.Value into ServerTiming.
+func ServerTimingFromJS(value js.Value) *ServerTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServerTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServerTimingFromJS is casting from something that holds a js.Value into ServerTiming.
+func ServerTimingFromWrapper(input core.Wrapper) *ServerTiming {
+	return ServerTimingFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -1868,15 +1925,19 @@ type TaskAttributionTiming struct {
 	Entry
 }
 
-// TaskAttributionTimingFromJS is casting a js.Wrapper into TaskAttributionTiming.
-func TaskAttributionTimingFromJS(value js.Wrapper) *TaskAttributionTiming {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TaskAttributionTimingFromJS is casting a js.Value into TaskAttributionTiming.
+func TaskAttributionTimingFromJS(value js.Value) *TaskAttributionTiming {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &TaskAttributionTiming{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TaskAttributionTimingFromJS is casting from something that holds a js.Value into TaskAttributionTiming.
+func TaskAttributionTimingFromWrapper(input core.Wrapper) *TaskAttributionTiming {
+	return TaskAttributionTimingFromJS(input.JSValue())
 }
 
 // ContainerType returning attribute 'containerType' with
@@ -1925,15 +1986,19 @@ func (_this *Timing) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// TimingFromJS is casting a js.Wrapper into Timing.
-func TimingFromJS(value js.Wrapper) *Timing {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// TimingFromJS is casting a js.Value into Timing.
+func TimingFromJS(value js.Value) *Timing {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Timing{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// TimingFromJS is casting from something that holds a js.Value into Timing.
+func TimingFromWrapper(input core.Wrapper) *Timing {
+	return TimingFromJS(input.JSValue())
 }
 
 // NavigationStart returning attribute 'navigationStart' with

--- a/push/push.go
+++ b/push/push.go
@@ -7,6 +7,7 @@ package push
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/javascript"
@@ -378,7 +379,7 @@ type EventInit struct {
 	Data       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -394,10 +395,8 @@ func (_this *EventInit) JSValue() js.Value {
 }
 
 // EventInitFromJS is allocating a new
-// EventInit object and copy all values from
-// input javascript object
-func EventInitFromJS(value js.Wrapper) *EventInit {
-	input := value.JSValue()
+// EventInit object and copy all values in the value javascript object.
+func EventInitFromJS(value js.Value) *EventInit {
 	var out EventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -405,13 +404,13 @@ func EventInitFromJS(value js.Wrapper) *EventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Union // javascript: Union {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = UnionFromJS(input.Get("data"))
+	value3 = UnionFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -425,7 +424,7 @@ type SubscriptionChangeInit struct {
 	OldSubscription *Subscription
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionChangeInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -443,10 +442,8 @@ func (_this *SubscriptionChangeInit) JSValue() js.Value {
 }
 
 // SubscriptionChangeInitFromJS is allocating a new
-// SubscriptionChangeInit object and copy all values from
-// input javascript object
-func SubscriptionChangeInitFromJS(value js.Wrapper) *SubscriptionChangeInit {
-	input := value.JSValue()
+// SubscriptionChangeInit object and copy all values in the value javascript object.
+func SubscriptionChangeInitFromJS(value js.Value) *SubscriptionChangeInit {
 	var out SubscriptionChangeInit
 	var (
 		value0 bool          // javascript: boolean {bubbles Bubbles bubbles}
@@ -455,15 +452,15 @@ func SubscriptionChangeInitFromJS(value js.Wrapper) *SubscriptionChangeInit {
 		value3 *Subscription // javascript: PushSubscription {newSubscription NewSubscription newSubscription}
 		value4 *Subscription // javascript: PushSubscription {oldSubscription OldSubscription oldSubscription}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SubscriptionFromJS(input.Get("newSubscription"))
+	value3 = SubscriptionFromJS(value.Get("newSubscription"))
 	out.NewSubscription = value3
-	value4 = SubscriptionFromJS(input.Get("oldSubscription"))
+	value4 = SubscriptionFromJS(value.Get("oldSubscription"))
 	out.OldSubscription = value4
 	return &out
 }
@@ -474,7 +471,7 @@ type SubscriptionJSON struct {
 	ExpirationTime *int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionJSON) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -492,19 +489,17 @@ func (_this *SubscriptionJSON) JSValue() js.Value {
 }
 
 // SubscriptionJSONFromJS is allocating a new
-// SubscriptionJSON object and copy all values from
-// input javascript object
-func SubscriptionJSONFromJS(value js.Wrapper) *SubscriptionJSON {
-	input := value.JSValue()
+// SubscriptionJSON object and copy all values in the value javascript object.
+func SubscriptionJSONFromJS(value js.Value) *SubscriptionJSON {
 	var out SubscriptionJSON
 	var (
 		value0 string // javascript: USVString {endpoint Endpoint endpoint}
 		value1 *int   // javascript: unsigned long long {expirationTime ExpirationTime expirationTime}
 	)
-	value0 = (input.Get("endpoint")).String()
+	value0 = (value.Get("endpoint")).String()
 	out.Endpoint = value0
-	if input.Get("expirationTime").Type() != js.TypeNull && input.Get("expirationTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expirationTime")).Int()
+	if value.Get("expirationTime").Type() != js.TypeNull && value.Get("expirationTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expirationTime")).Int()
 		value1 = &__tmp
 	}
 	out.ExpirationTime = value1
@@ -517,7 +512,7 @@ type SubscriptionOptionsInit struct {
 	ApplicationServerKey *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionOptionsInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -529,19 +524,17 @@ func (_this *SubscriptionOptionsInit) JSValue() js.Value {
 }
 
 // SubscriptionOptionsInitFromJS is allocating a new
-// SubscriptionOptionsInit object and copy all values from
-// input javascript object
-func SubscriptionOptionsInitFromJS(value js.Wrapper) *SubscriptionOptionsInit {
-	input := value.JSValue()
+// SubscriptionOptionsInit object and copy all values in the value javascript object.
+func SubscriptionOptionsInitFromJS(value js.Value) *SubscriptionOptionsInit {
 	var out SubscriptionOptionsInit
 	var (
 		value0 bool   // javascript: boolean {userVisibleOnly UserVisibleOnly userVisibleOnly}
 		value1 *Union // javascript: Union {applicationServerKey ApplicationServerKey applicationServerKey}
 	)
-	value0 = (input.Get("userVisibleOnly")).Bool()
+	value0 = (value.Get("userVisibleOnly")).Bool()
 	out.UserVisibleOnly = value0
-	if input.Get("applicationServerKey").Type() != js.TypeNull && input.Get("applicationServerKey").Type() != js.TypeUndefined {
-		value1 = UnionFromJS(input.Get("applicationServerKey"))
+	if value.Get("applicationServerKey").Type() != js.TypeNull && value.Get("applicationServerKey").Type() != js.TypeUndefined {
+		value1 = UnionFromJS(value.Get("applicationServerKey"))
 	}
 	out.ApplicationServerKey = value1
 	return &out
@@ -552,15 +545,19 @@ type Event struct {
 	domcore.ExtendableEvent
 }
 
-// EventFromJS is casting a js.Wrapper into Event.
-func EventFromJS(value js.Wrapper) *Event {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventFromJS is casting a js.Value into Event.
+func EventFromJS(value js.Value) *Event {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Event{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventFromJS is casting from something that holds a js.Value into Event.
+func EventFromWrapper(input core.Wrapper) *Event {
+	return EventFromJS(input.JSValue())
 }
 
 func NewPushEvent(_type string, eventInitDict *EventInit) (_result *Event) {
@@ -607,15 +604,19 @@ func (_this *Manager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManagerFromJS is casting a js.Wrapper into Manager.
-func ManagerFromJS(value js.Wrapper) *Manager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManagerFromJS is casting a js.Value into Manager.
+func ManagerFromJS(value js.Value) *Manager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Manager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManagerFromJS is casting from something that holds a js.Value into Manager.
+func ManagerFromWrapper(input core.Wrapper) *Manager {
+	return ManagerFromJS(input.JSValue())
 }
 
 // SupportedContentEncodings returning attribute 'supportedContentEncodings' with
@@ -690,15 +691,19 @@ func (_this *MessageData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MessageDataFromJS is casting a js.Wrapper into MessageData.
-func MessageDataFromJS(value js.Wrapper) *MessageData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageDataFromJS is casting a js.Value into MessageData.
+func MessageDataFromJS(value js.Value) *MessageData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageDataFromJS is casting from something that holds a js.Value into MessageData.
+func MessageDataFromWrapper(input core.Wrapper) *MessageData {
+	return MessageDataFromJS(input.JSValue())
 }
 
 func (_this *MessageData) ArrayBuffer() (_result *javascript.ArrayBuffer) {
@@ -767,15 +772,19 @@ func (_this *PromiseNilSubscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilSubscriptionFromJS is casting a js.Wrapper into PromiseNilSubscription.
-func PromiseNilSubscriptionFromJS(value js.Wrapper) *PromiseNilSubscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilSubscriptionFromJS is casting a js.Value into PromiseNilSubscription.
+func PromiseNilSubscriptionFromJS(value js.Value) *PromiseNilSubscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilSubscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilSubscriptionFromJS is casting from something that holds a js.Value into PromiseNilSubscription.
+func PromiseNilSubscriptionFromWrapper(input core.Wrapper) *PromiseNilSubscription {
+	return PromiseNilSubscriptionFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilSubscription) Then(onFulfilled *PromiseNilSubscriptionOnFulfilled, onRejected *PromiseNilSubscriptionOnRejected) (_result *PromiseNilSubscription) {
@@ -872,15 +881,19 @@ func (_this *PromisePermissionState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionStateFromJS is casting a js.Wrapper into PromisePermissionState.
-func PromisePermissionStateFromJS(value js.Wrapper) *PromisePermissionState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionStateFromJS is casting a js.Value into PromisePermissionState.
+func PromisePermissionStateFromJS(value js.Value) *PromisePermissionState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionStateFromJS is casting from something that holds a js.Value into PromisePermissionState.
+func PromisePermissionStateFromWrapper(input core.Wrapper) *PromisePermissionState {
+	return PromisePermissionStateFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionState) Then(onFulfilled *PromisePermissionStateOnFulfilled, onRejected *PromisePermissionStateOnRejected) (_result *PromisePermissionState) {
@@ -977,15 +990,19 @@ func (_this *PromiseSubscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSubscriptionFromJS is casting a js.Wrapper into PromiseSubscription.
-func PromiseSubscriptionFromJS(value js.Wrapper) *PromiseSubscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSubscriptionFromJS is casting a js.Value into PromiseSubscription.
+func PromiseSubscriptionFromJS(value js.Value) *PromiseSubscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSubscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSubscriptionFromJS is casting from something that holds a js.Value into PromiseSubscription.
+func PromiseSubscriptionFromWrapper(input core.Wrapper) *PromiseSubscription {
+	return PromiseSubscriptionFromJS(input.JSValue())
 }
 
 func (_this *PromiseSubscription) Then(onFulfilled *PromiseSubscriptionOnFulfilled, onRejected *PromiseSubscriptionOnRejected) (_result *PromiseSubscription) {
@@ -1082,15 +1099,19 @@ func (_this *Subscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubscriptionFromJS is casting a js.Wrapper into Subscription.
-func SubscriptionFromJS(value js.Wrapper) *Subscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionFromJS is casting a js.Value into Subscription.
+func SubscriptionFromJS(value js.Value) *Subscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Subscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionFromJS is casting from something that holds a js.Value into Subscription.
+func SubscriptionFromWrapper(input core.Wrapper) *Subscription {
+	return SubscriptionFromJS(input.JSValue())
 }
 
 // Endpoint returning attribute 'endpoint' with
@@ -1175,15 +1196,19 @@ type SubscriptionChangeEvent struct {
 	domcore.ExtendableEvent
 }
 
-// SubscriptionChangeEventFromJS is casting a js.Wrapper into SubscriptionChangeEvent.
-func SubscriptionChangeEventFromJS(value js.Wrapper) *SubscriptionChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionChangeEventFromJS is casting a js.Value into SubscriptionChangeEvent.
+func SubscriptionChangeEventFromJS(value js.Value) *SubscriptionChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubscriptionChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionChangeEventFromJS is casting from something that holds a js.Value into SubscriptionChangeEvent.
+func SubscriptionChangeEventFromWrapper(input core.Wrapper) *SubscriptionChangeEvent {
+	return SubscriptionChangeEventFromJS(input.JSValue())
 }
 
 func NewPushSubscriptionChangeEvent(_type string, eventInitDict *SubscriptionChangeInit) (_result *SubscriptionChangeEvent) {
@@ -1241,15 +1266,19 @@ func (_this *SubscriptionOptions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubscriptionOptionsFromJS is casting a js.Wrapper into SubscriptionOptions.
-func SubscriptionOptionsFromJS(value js.Wrapper) *SubscriptionOptions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionOptionsFromJS is casting a js.Value into SubscriptionOptions.
+func SubscriptionOptionsFromJS(value js.Value) *SubscriptionOptions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubscriptionOptions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionOptionsFromJS is casting from something that holds a js.Value into SubscriptionOptions.
+func SubscriptionOptionsFromWrapper(input core.Wrapper) *SubscriptionOptions {
+	return SubscriptionOptionsFromJS(input.JSValue())
 }
 
 // UserVisibleOnly returning attribute 'userVisibleOnly' with

--- a/push/push_js.go
+++ b/push/push_js.go
@@ -5,6 +5,7 @@ package push
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/javascript"
@@ -376,7 +377,7 @@ type EventInit struct {
 	Data       *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *EventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -392,10 +393,8 @@ func (_this *EventInit) JSValue() js.Value {
 }
 
 // EventInitFromJS is allocating a new
-// EventInit object and copy all values from
-// input javascript object
-func EventInitFromJS(value js.Wrapper) *EventInit {
-	input := value.JSValue()
+// EventInit object and copy all values in the value javascript object.
+func EventInitFromJS(value js.Value) *EventInit {
 	var out EventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -403,13 +402,13 @@ func EventInitFromJS(value js.Wrapper) *EventInit {
 		value2 bool   // javascript: boolean {composed Composed composed}
 		value3 *Union // javascript: Union {data Data data}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = UnionFromJS(input.Get("data"))
+	value3 = UnionFromJS(value.Get("data"))
 	out.Data = value3
 	return &out
 }
@@ -423,7 +422,7 @@ type SubscriptionChangeInit struct {
 	OldSubscription *Subscription
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionChangeInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -441,10 +440,8 @@ func (_this *SubscriptionChangeInit) JSValue() js.Value {
 }
 
 // SubscriptionChangeInitFromJS is allocating a new
-// SubscriptionChangeInit object and copy all values from
-// input javascript object
-func SubscriptionChangeInitFromJS(value js.Wrapper) *SubscriptionChangeInit {
-	input := value.JSValue()
+// SubscriptionChangeInit object and copy all values in the value javascript object.
+func SubscriptionChangeInitFromJS(value js.Value) *SubscriptionChangeInit {
 	var out SubscriptionChangeInit
 	var (
 		value0 bool          // javascript: boolean {bubbles Bubbles bubbles}
@@ -453,15 +450,15 @@ func SubscriptionChangeInitFromJS(value js.Wrapper) *SubscriptionChangeInit {
 		value3 *Subscription // javascript: PushSubscription {newSubscription NewSubscription newSubscription}
 		value4 *Subscription // javascript: PushSubscription {oldSubscription OldSubscription oldSubscription}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = SubscriptionFromJS(input.Get("newSubscription"))
+	value3 = SubscriptionFromJS(value.Get("newSubscription"))
 	out.NewSubscription = value3
-	value4 = SubscriptionFromJS(input.Get("oldSubscription"))
+	value4 = SubscriptionFromJS(value.Get("oldSubscription"))
 	out.OldSubscription = value4
 	return &out
 }
@@ -472,7 +469,7 @@ type SubscriptionJSON struct {
 	ExpirationTime *int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionJSON) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -490,19 +487,17 @@ func (_this *SubscriptionJSON) JSValue() js.Value {
 }
 
 // SubscriptionJSONFromJS is allocating a new
-// SubscriptionJSON object and copy all values from
-// input javascript object
-func SubscriptionJSONFromJS(value js.Wrapper) *SubscriptionJSON {
-	input := value.JSValue()
+// SubscriptionJSON object and copy all values in the value javascript object.
+func SubscriptionJSONFromJS(value js.Value) *SubscriptionJSON {
 	var out SubscriptionJSON
 	var (
 		value0 string // javascript: USVString {endpoint Endpoint endpoint}
 		value1 *int   // javascript: unsigned long long {expirationTime ExpirationTime expirationTime}
 	)
-	value0 = (input.Get("endpoint")).String()
+	value0 = (value.Get("endpoint")).String()
 	out.Endpoint = value0
-	if input.Get("expirationTime").Type() != js.TypeNull && input.Get("expirationTime").Type() != js.TypeUndefined {
-		__tmp := (input.Get("expirationTime")).Int()
+	if value.Get("expirationTime").Type() != js.TypeNull && value.Get("expirationTime").Type() != js.TypeUndefined {
+		__tmp := (value.Get("expirationTime")).Int()
 		value1 = &__tmp
 	}
 	out.ExpirationTime = value1
@@ -515,7 +510,7 @@ type SubscriptionOptionsInit struct {
 	ApplicationServerKey *Union
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SubscriptionOptionsInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -527,19 +522,17 @@ func (_this *SubscriptionOptionsInit) JSValue() js.Value {
 }
 
 // SubscriptionOptionsInitFromJS is allocating a new
-// SubscriptionOptionsInit object and copy all values from
-// input javascript object
-func SubscriptionOptionsInitFromJS(value js.Wrapper) *SubscriptionOptionsInit {
-	input := value.JSValue()
+// SubscriptionOptionsInit object and copy all values in the value javascript object.
+func SubscriptionOptionsInitFromJS(value js.Value) *SubscriptionOptionsInit {
 	var out SubscriptionOptionsInit
 	var (
 		value0 bool   // javascript: boolean {userVisibleOnly UserVisibleOnly userVisibleOnly}
 		value1 *Union // javascript: Union {applicationServerKey ApplicationServerKey applicationServerKey}
 	)
-	value0 = (input.Get("userVisibleOnly")).Bool()
+	value0 = (value.Get("userVisibleOnly")).Bool()
 	out.UserVisibleOnly = value0
-	if input.Get("applicationServerKey").Type() != js.TypeNull && input.Get("applicationServerKey").Type() != js.TypeUndefined {
-		value1 = UnionFromJS(input.Get("applicationServerKey"))
+	if value.Get("applicationServerKey").Type() != js.TypeNull && value.Get("applicationServerKey").Type() != js.TypeUndefined {
+		value1 = UnionFromJS(value.Get("applicationServerKey"))
 	}
 	out.ApplicationServerKey = value1
 	return &out
@@ -550,15 +543,19 @@ type Event struct {
 	domcore.ExtendableEvent
 }
 
-// EventFromJS is casting a js.Wrapper into Event.
-func EventFromJS(value js.Wrapper) *Event {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// EventFromJS is casting a js.Value into Event.
+func EventFromJS(value js.Value) *Event {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Event{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// EventFromJS is casting from something that holds a js.Value into Event.
+func EventFromWrapper(input core.Wrapper) *Event {
+	return EventFromJS(input.JSValue())
 }
 
 func NewPushEvent(_type string, eventInitDict *EventInit) (_result *Event) {
@@ -605,15 +602,19 @@ func (_this *Manager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ManagerFromJS is casting a js.Wrapper into Manager.
-func ManagerFromJS(value js.Wrapper) *Manager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ManagerFromJS is casting a js.Value into Manager.
+func ManagerFromJS(value js.Value) *Manager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Manager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ManagerFromJS is casting from something that holds a js.Value into Manager.
+func ManagerFromWrapper(input core.Wrapper) *Manager {
+	return ManagerFromJS(input.JSValue())
 }
 
 // SupportedContentEncodings returning attribute 'supportedContentEncodings' with
@@ -688,15 +689,19 @@ func (_this *MessageData) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MessageDataFromJS is casting a js.Wrapper into MessageData.
-func MessageDataFromJS(value js.Wrapper) *MessageData {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MessageDataFromJS is casting a js.Value into MessageData.
+func MessageDataFromJS(value js.Value) *MessageData {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MessageData{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MessageDataFromJS is casting from something that holds a js.Value into MessageData.
+func MessageDataFromWrapper(input core.Wrapper) *MessageData {
+	return MessageDataFromJS(input.JSValue())
 }
 
 func (_this *MessageData) ArrayBuffer() (_result *javascript.ArrayBuffer) {
@@ -765,15 +770,19 @@ func (_this *PromiseNilSubscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilSubscriptionFromJS is casting a js.Wrapper into PromiseNilSubscription.
-func PromiseNilSubscriptionFromJS(value js.Wrapper) *PromiseNilSubscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilSubscriptionFromJS is casting a js.Value into PromiseNilSubscription.
+func PromiseNilSubscriptionFromJS(value js.Value) *PromiseNilSubscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilSubscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilSubscriptionFromJS is casting from something that holds a js.Value into PromiseNilSubscription.
+func PromiseNilSubscriptionFromWrapper(input core.Wrapper) *PromiseNilSubscription {
+	return PromiseNilSubscriptionFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilSubscription) Then(onFulfilled *PromiseNilSubscriptionOnFulfilled, onRejected *PromiseNilSubscriptionOnRejected) (_result *PromiseNilSubscription) {
@@ -870,15 +879,19 @@ func (_this *PromisePermissionState) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromisePermissionStateFromJS is casting a js.Wrapper into PromisePermissionState.
-func PromisePermissionStateFromJS(value js.Wrapper) *PromisePermissionState {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromisePermissionStateFromJS is casting a js.Value into PromisePermissionState.
+func PromisePermissionStateFromJS(value js.Value) *PromisePermissionState {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromisePermissionState{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromisePermissionStateFromJS is casting from something that holds a js.Value into PromisePermissionState.
+func PromisePermissionStateFromWrapper(input core.Wrapper) *PromisePermissionState {
+	return PromisePermissionStateFromJS(input.JSValue())
 }
 
 func (_this *PromisePermissionState) Then(onFulfilled *PromisePermissionStateOnFulfilled, onRejected *PromisePermissionStateOnRejected) (_result *PromisePermissionState) {
@@ -975,15 +988,19 @@ func (_this *PromiseSubscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSubscriptionFromJS is casting a js.Wrapper into PromiseSubscription.
-func PromiseSubscriptionFromJS(value js.Wrapper) *PromiseSubscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSubscriptionFromJS is casting a js.Value into PromiseSubscription.
+func PromiseSubscriptionFromJS(value js.Value) *PromiseSubscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSubscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSubscriptionFromJS is casting from something that holds a js.Value into PromiseSubscription.
+func PromiseSubscriptionFromWrapper(input core.Wrapper) *PromiseSubscription {
+	return PromiseSubscriptionFromJS(input.JSValue())
 }
 
 func (_this *PromiseSubscription) Then(onFulfilled *PromiseSubscriptionOnFulfilled, onRejected *PromiseSubscriptionOnRejected) (_result *PromiseSubscription) {
@@ -1080,15 +1097,19 @@ func (_this *Subscription) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubscriptionFromJS is casting a js.Wrapper into Subscription.
-func SubscriptionFromJS(value js.Wrapper) *Subscription {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionFromJS is casting a js.Value into Subscription.
+func SubscriptionFromJS(value js.Value) *Subscription {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Subscription{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionFromJS is casting from something that holds a js.Value into Subscription.
+func SubscriptionFromWrapper(input core.Wrapper) *Subscription {
+	return SubscriptionFromJS(input.JSValue())
 }
 
 // Endpoint returning attribute 'endpoint' with
@@ -1173,15 +1194,19 @@ type SubscriptionChangeEvent struct {
 	domcore.ExtendableEvent
 }
 
-// SubscriptionChangeEventFromJS is casting a js.Wrapper into SubscriptionChangeEvent.
-func SubscriptionChangeEventFromJS(value js.Wrapper) *SubscriptionChangeEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionChangeEventFromJS is casting a js.Value into SubscriptionChangeEvent.
+func SubscriptionChangeEventFromJS(value js.Value) *SubscriptionChangeEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubscriptionChangeEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionChangeEventFromJS is casting from something that holds a js.Value into SubscriptionChangeEvent.
+func SubscriptionChangeEventFromWrapper(input core.Wrapper) *SubscriptionChangeEvent {
+	return SubscriptionChangeEventFromJS(input.JSValue())
 }
 
 func NewPushSubscriptionChangeEvent(_type string, eventInitDict *SubscriptionChangeInit) (_result *SubscriptionChangeEvent) {
@@ -1239,15 +1264,19 @@ func (_this *SubscriptionOptions) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SubscriptionOptionsFromJS is casting a js.Wrapper into SubscriptionOptions.
-func SubscriptionOptionsFromJS(value js.Wrapper) *SubscriptionOptions {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SubscriptionOptionsFromJS is casting a js.Value into SubscriptionOptions.
+func SubscriptionOptionsFromJS(value js.Value) *SubscriptionOptions {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SubscriptionOptions{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SubscriptionOptionsFromJS is casting from something that holds a js.Value into SubscriptionOptions.
+func SubscriptionOptionsFromWrapper(input core.Wrapper) *SubscriptionOptions {
+	return SubscriptionOptionsFromJS(input.JSValue())
 }
 
 // UserVisibleOnly returning attribute 'userVisibleOnly' with

--- a/reporting/reporting.go
+++ b/reporting/reporting.go
@@ -7,6 +7,7 @@ package reporting
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript/missingtypes"
 )
 
@@ -99,7 +100,7 @@ type GenerateTestReportParameters struct {
 	Group   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GenerateTestReportParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -111,18 +112,16 @@ func (_this *GenerateTestReportParameters) JSValue() js.Value {
 }
 
 // GenerateTestReportParametersFromJS is allocating a new
-// GenerateTestReportParameters object and copy all values from
-// input javascript object
-func GenerateTestReportParametersFromJS(value js.Wrapper) *GenerateTestReportParameters {
-	input := value.JSValue()
+// GenerateTestReportParameters object and copy all values in the value javascript object.
+func GenerateTestReportParametersFromJS(value js.Value) *GenerateTestReportParameters {
 	var out GenerateTestReportParameters
 	var (
 		value0 string // javascript: DOMString {message Message message}
 		value1 string // javascript: DOMString {group Group group}
 	)
-	value0 = (input.Get("message")).String()
+	value0 = (value.Get("message")).String()
 	out.Message = value0
-	value1 = (input.Get("group")).String()
+	value1 = (value.Get("group")).String()
 	out.Group = value1
 	return &out
 }
@@ -133,7 +132,7 @@ type ReportingObserverOptions struct {
 	Buffered bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReportingObserverOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -149,26 +148,24 @@ func (_this *ReportingObserverOptions) JSValue() js.Value {
 }
 
 // ReportingObserverOptionsFromJS is allocating a new
-// ReportingObserverOptions object and copy all values from
-// input javascript object
-func ReportingObserverOptionsFromJS(value js.Wrapper) *ReportingObserverOptions {
-	input := value.JSValue()
+// ReportingObserverOptions object and copy all values in the value javascript object.
+func ReportingObserverOptionsFromJS(value js.Value) *ReportingObserverOptions {
 	var out ReportingObserverOptions
 	var (
 		value0 []string // javascript: sequence<DOMString> {types Types types}
 		value1 bool     // javascript: boolean {buffered Buffered buffered}
 	)
-	__length0 := input.Get("types").Length()
+	__length0 := value.Get("types").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("types").Index(__idx0)
+		__seq_in0 := value.Get("types").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Types = value0
-	value1 = (input.Get("buffered")).Bool()
+	value1 = (value.Get("buffered")).Bool()
 	out.Buffered = value1
 	return &out
 }
@@ -178,15 +175,19 @@ type CrashReportBody struct {
 	ReportBody
 }
 
-// CrashReportBodyFromJS is casting a js.Wrapper into CrashReportBody.
-func CrashReportBodyFromJS(value js.Wrapper) *CrashReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CrashReportBodyFromJS is casting a js.Value into CrashReportBody.
+func CrashReportBodyFromJS(value js.Value) *CrashReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CrashReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CrashReportBodyFromJS is casting from something that holds a js.Value into CrashReportBody.
+func CrashReportBodyFromWrapper(input core.Wrapper) *CrashReportBody {
+	return CrashReportBodyFromJS(input.JSValue())
 }
 
 // Reason returning attribute 'reason' with
@@ -206,15 +207,19 @@ type DeprecationReportBody struct {
 	ReportBody
 }
 
-// DeprecationReportBodyFromJS is casting a js.Wrapper into DeprecationReportBody.
-func DeprecationReportBodyFromJS(value js.Wrapper) *DeprecationReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeprecationReportBodyFromJS is casting a js.Value into DeprecationReportBody.
+func DeprecationReportBodyFromJS(value js.Value) *DeprecationReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeprecationReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeprecationReportBodyFromJS is casting from something that holds a js.Value into DeprecationReportBody.
+func DeprecationReportBodyFromWrapper(input core.Wrapper) *DeprecationReportBody {
+	return DeprecationReportBodyFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -287,15 +292,19 @@ type InterventionReportBody struct {
 	ReportBody
 }
 
-// InterventionReportBodyFromJS is casting a js.Wrapper into InterventionReportBody.
-func InterventionReportBodyFromJS(value js.Wrapper) *InterventionReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InterventionReportBodyFromJS is casting a js.Value into InterventionReportBody.
+func InterventionReportBodyFromJS(value js.Value) *InterventionReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InterventionReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InterventionReportBodyFromJS is casting from something that holds a js.Value into InterventionReportBody.
+func InterventionReportBodyFromWrapper(input core.Wrapper) *InterventionReportBody {
+	return InterventionReportBodyFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -362,15 +371,19 @@ func (_this *Report) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportFromJS is casting a js.Wrapper into Report.
-func ReportFromJS(value js.Wrapper) *Report {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportFromJS is casting a js.Value into Report.
+func ReportFromJS(value js.Value) *Report {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Report{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportFromJS is casting from something that holds a js.Value into Report.
+func ReportFromWrapper(input core.Wrapper) *Report {
+	return ReportFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -412,15 +425,19 @@ func (_this *ReportBody) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportBodyFromJS is casting a js.Wrapper into ReportBody.
-func ReportBodyFromJS(value js.Wrapper) *ReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportBodyFromJS is casting a js.Value into ReportBody.
+func ReportBodyFromJS(value js.Value) *ReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportBodyFromJS is casting from something that holds a js.Value into ReportBody.
+func ReportBodyFromWrapper(input core.Wrapper) *ReportBody {
+	return ReportBodyFromJS(input.JSValue())
 }
 
 // class: ReportingObserver
@@ -433,15 +450,19 @@ func (_this *ReportingObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportingObserverFromJS is casting a js.Wrapper into ReportingObserver.
-func ReportingObserverFromJS(value js.Wrapper) *ReportingObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportingObserverFromJS is casting a js.Value into ReportingObserver.
+func ReportingObserverFromJS(value js.Value) *ReportingObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReportingObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportingObserverFromJS is casting from something that holds a js.Value into ReportingObserver.
+func ReportingObserverFromWrapper(input core.Wrapper) *ReportingObserver {
+	return ReportingObserverFromJS(input.JSValue())
 }
 
 func NewReportingObserver(callback *ReportingObserverCallback, options *ReportingObserverOptions) (_result *ReportingObserver) {

--- a/reporting/reporting_js.go
+++ b/reporting/reporting_js.go
@@ -5,6 +5,7 @@ package reporting
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript/missingtypes"
 )
 
@@ -97,7 +98,7 @@ type GenerateTestReportParameters struct {
 	Group   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *GenerateTestReportParameters) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -109,18 +110,16 @@ func (_this *GenerateTestReportParameters) JSValue() js.Value {
 }
 
 // GenerateTestReportParametersFromJS is allocating a new
-// GenerateTestReportParameters object and copy all values from
-// input javascript object
-func GenerateTestReportParametersFromJS(value js.Wrapper) *GenerateTestReportParameters {
-	input := value.JSValue()
+// GenerateTestReportParameters object and copy all values in the value javascript object.
+func GenerateTestReportParametersFromJS(value js.Value) *GenerateTestReportParameters {
 	var out GenerateTestReportParameters
 	var (
 		value0 string // javascript: DOMString {message Message message}
 		value1 string // javascript: DOMString {group Group group}
 	)
-	value0 = (input.Get("message")).String()
+	value0 = (value.Get("message")).String()
 	out.Message = value0
-	value1 = (input.Get("group")).String()
+	value1 = (value.Get("group")).String()
 	out.Group = value1
 	return &out
 }
@@ -131,7 +130,7 @@ type ReportingObserverOptions struct {
 	Buffered bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ReportingObserverOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -147,26 +146,24 @@ func (_this *ReportingObserverOptions) JSValue() js.Value {
 }
 
 // ReportingObserverOptionsFromJS is allocating a new
-// ReportingObserverOptions object and copy all values from
-// input javascript object
-func ReportingObserverOptionsFromJS(value js.Wrapper) *ReportingObserverOptions {
-	input := value.JSValue()
+// ReportingObserverOptions object and copy all values in the value javascript object.
+func ReportingObserverOptionsFromJS(value js.Value) *ReportingObserverOptions {
 	var out ReportingObserverOptions
 	var (
 		value0 []string // javascript: sequence<DOMString> {types Types types}
 		value1 bool     // javascript: boolean {buffered Buffered buffered}
 	)
-	__length0 := input.Get("types").Length()
+	__length0 := value.Get("types").Length()
 	__array0 := make([]string, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 string
-		__seq_in0 := input.Get("types").Index(__idx0)
+		__seq_in0 := value.Get("types").Index(__idx0)
 		__seq_out0 = (__seq_in0).String()
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Types = value0
-	value1 = (input.Get("buffered")).Bool()
+	value1 = (value.Get("buffered")).Bool()
 	out.Buffered = value1
 	return &out
 }
@@ -176,15 +173,19 @@ type CrashReportBody struct {
 	ReportBody
 }
 
-// CrashReportBodyFromJS is casting a js.Wrapper into CrashReportBody.
-func CrashReportBodyFromJS(value js.Wrapper) *CrashReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CrashReportBodyFromJS is casting a js.Value into CrashReportBody.
+func CrashReportBodyFromJS(value js.Value) *CrashReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CrashReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CrashReportBodyFromJS is casting from something that holds a js.Value into CrashReportBody.
+func CrashReportBodyFromWrapper(input core.Wrapper) *CrashReportBody {
+	return CrashReportBodyFromJS(input.JSValue())
 }
 
 // Reason returning attribute 'reason' with
@@ -204,15 +205,19 @@ type DeprecationReportBody struct {
 	ReportBody
 }
 
-// DeprecationReportBodyFromJS is casting a js.Wrapper into DeprecationReportBody.
-func DeprecationReportBodyFromJS(value js.Wrapper) *DeprecationReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DeprecationReportBodyFromJS is casting a js.Value into DeprecationReportBody.
+func DeprecationReportBodyFromJS(value js.Value) *DeprecationReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DeprecationReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DeprecationReportBodyFromJS is casting from something that holds a js.Value into DeprecationReportBody.
+func DeprecationReportBodyFromWrapper(input core.Wrapper) *DeprecationReportBody {
+	return DeprecationReportBodyFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -285,15 +290,19 @@ type InterventionReportBody struct {
 	ReportBody
 }
 
-// InterventionReportBodyFromJS is casting a js.Wrapper into InterventionReportBody.
-func InterventionReportBodyFromJS(value js.Wrapper) *InterventionReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// InterventionReportBodyFromJS is casting a js.Value into InterventionReportBody.
+func InterventionReportBodyFromJS(value js.Value) *InterventionReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &InterventionReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// InterventionReportBodyFromJS is casting from something that holds a js.Value into InterventionReportBody.
+func InterventionReportBodyFromWrapper(input core.Wrapper) *InterventionReportBody {
+	return InterventionReportBodyFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -360,15 +369,19 @@ func (_this *Report) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportFromJS is casting a js.Wrapper into Report.
-func ReportFromJS(value js.Wrapper) *Report {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportFromJS is casting a js.Value into Report.
+func ReportFromJS(value js.Value) *Report {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Report{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportFromJS is casting from something that holds a js.Value into Report.
+func ReportFromWrapper(input core.Wrapper) *Report {
+	return ReportFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -410,15 +423,19 @@ func (_this *ReportBody) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportBodyFromJS is casting a js.Wrapper into ReportBody.
-func ReportBodyFromJS(value js.Wrapper) *ReportBody {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportBodyFromJS is casting a js.Value into ReportBody.
+func ReportBodyFromJS(value js.Value) *ReportBody {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReportBody{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportBodyFromJS is casting from something that holds a js.Value into ReportBody.
+func ReportBodyFromWrapper(input core.Wrapper) *ReportBody {
+	return ReportBodyFromJS(input.JSValue())
 }
 
 // class: ReportingObserver
@@ -431,15 +448,19 @@ func (_this *ReportingObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ReportingObserverFromJS is casting a js.Wrapper into ReportingObserver.
-func ReportingObserverFromJS(value js.Wrapper) *ReportingObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ReportingObserverFromJS is casting a js.Value into ReportingObserver.
+func ReportingObserverFromJS(value js.Value) *ReportingObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ReportingObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ReportingObserverFromJS is casting from something that holds a js.Value into ReportingObserver.
+func ReportingObserverFromWrapper(input core.Wrapper) *ReportingObserver {
+	return ReportingObserverFromJS(input.JSValue())
 }
 
 func NewReportingObserver(callback *ReportingObserverCallback, options *ReportingObserverOptions) (_result *ReportingObserver) {

--- a/serviceworker/client/client.go
+++ b/serviceworker/client/client.go
@@ -7,6 +7,7 @@ package client
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -300,15 +301,19 @@ func (_this *Client) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ClientFromJS is casting a js.Wrapper into Client.
-func ClientFromJS(value js.Wrapper) *Client {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClientFromJS is casting a js.Value into Client.
+func ClientFromJS(value js.Value) *Client {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Client{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClientFromJS is casting from something that holds a js.Value into Client.
+func ClientFromWrapper(input core.Wrapper) *Client {
+	return ClientFromJS(input.JSValue())
 }
 
 // Url returning attribute 'url' with
@@ -378,15 +383,19 @@ func (_this *PromiseNilWindowClient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilWindowClientFromJS is casting a js.Wrapper into PromiseNilWindowClient.
-func PromiseNilWindowClientFromJS(value js.Wrapper) *PromiseNilWindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilWindowClientFromJS is casting a js.Value into PromiseNilWindowClient.
+func PromiseNilWindowClientFromJS(value js.Value) *PromiseNilWindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilWindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilWindowClientFromJS is casting from something that holds a js.Value into PromiseNilWindowClient.
+func PromiseNilWindowClientFromWrapper(input core.Wrapper) *PromiseNilWindowClient {
+	return PromiseNilWindowClientFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilWindowClient) Then(onFulfilled *PromiseNilWindowClientOnFulfilled, onRejected *PromiseNilWindowClientOnRejected) (_result *PromiseNilWindowClient) {
@@ -483,15 +492,19 @@ func (_this *PromiseWindowClient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseWindowClientFromJS is casting a js.Wrapper into PromiseWindowClient.
-func PromiseWindowClientFromJS(value js.Wrapper) *PromiseWindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseWindowClientFromJS is casting a js.Value into PromiseWindowClient.
+func PromiseWindowClientFromJS(value js.Value) *PromiseWindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseWindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseWindowClientFromJS is casting from something that holds a js.Value into PromiseWindowClient.
+func PromiseWindowClientFromWrapper(input core.Wrapper) *PromiseWindowClient {
+	return PromiseWindowClientFromJS(input.JSValue())
 }
 
 func (_this *PromiseWindowClient) Then(onFulfilled *PromiseWindowClientOnFulfilled, onRejected *PromiseWindowClientOnRejected) (_result *PromiseWindowClient) {
@@ -583,15 +596,19 @@ type WindowClient struct {
 	Client
 }
 
-// WindowClientFromJS is casting a js.Wrapper into WindowClient.
-func WindowClientFromJS(value js.Wrapper) *WindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WindowClientFromJS is casting a js.Value into WindowClient.
+func WindowClientFromJS(value js.Value) *WindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WindowClientFromJS is casting from something that holds a js.Value into WindowClient.
+func WindowClientFromWrapper(input core.Wrapper) *WindowClient {
+	return WindowClientFromJS(input.JSValue())
 }
 
 // VisibilityState returning attribute 'visibilityState' with

--- a/serviceworker/client/client_js.go
+++ b/serviceworker/client/client_js.go
@@ -5,6 +5,7 @@ package client
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -298,15 +299,19 @@ func (_this *Client) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ClientFromJS is casting a js.Wrapper into Client.
-func ClientFromJS(value js.Wrapper) *Client {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClientFromJS is casting a js.Value into Client.
+func ClientFromJS(value js.Value) *Client {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Client{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClientFromJS is casting from something that holds a js.Value into Client.
+func ClientFromWrapper(input core.Wrapper) *Client {
+	return ClientFromJS(input.JSValue())
 }
 
 // Url returning attribute 'url' with
@@ -376,15 +381,19 @@ func (_this *PromiseNilWindowClient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilWindowClientFromJS is casting a js.Wrapper into PromiseNilWindowClient.
-func PromiseNilWindowClientFromJS(value js.Wrapper) *PromiseNilWindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilWindowClientFromJS is casting a js.Value into PromiseNilWindowClient.
+func PromiseNilWindowClientFromJS(value js.Value) *PromiseNilWindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilWindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilWindowClientFromJS is casting from something that holds a js.Value into PromiseNilWindowClient.
+func PromiseNilWindowClientFromWrapper(input core.Wrapper) *PromiseNilWindowClient {
+	return PromiseNilWindowClientFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilWindowClient) Then(onFulfilled *PromiseNilWindowClientOnFulfilled, onRejected *PromiseNilWindowClientOnRejected) (_result *PromiseNilWindowClient) {
@@ -481,15 +490,19 @@ func (_this *PromiseWindowClient) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseWindowClientFromJS is casting a js.Wrapper into PromiseWindowClient.
-func PromiseWindowClientFromJS(value js.Wrapper) *PromiseWindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseWindowClientFromJS is casting a js.Value into PromiseWindowClient.
+func PromiseWindowClientFromJS(value js.Value) *PromiseWindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseWindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseWindowClientFromJS is casting from something that holds a js.Value into PromiseWindowClient.
+func PromiseWindowClientFromWrapper(input core.Wrapper) *PromiseWindowClient {
+	return PromiseWindowClientFromJS(input.JSValue())
 }
 
 func (_this *PromiseWindowClient) Then(onFulfilled *PromiseWindowClientOnFulfilled, onRejected *PromiseWindowClientOnRejected) (_result *PromiseWindowClient) {
@@ -581,15 +594,19 @@ type WindowClient struct {
 	Client
 }
 
-// WindowClientFromJS is casting a js.Wrapper into WindowClient.
-func WindowClientFromJS(value js.Wrapper) *WindowClient {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WindowClientFromJS is casting a js.Value into WindowClient.
+func WindowClientFromJS(value js.Value) *WindowClient {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WindowClient{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WindowClientFromJS is casting from something that holds a js.Value into WindowClient.
+func WindowClientFromWrapper(input core.Wrapper) *WindowClient {
+	return WindowClientFromJS(input.JSValue())
 }
 
 // VisibilityState returning attribute 'visibilityState' with

--- a/serviceworker/serviceworker.go
+++ b/serviceworker/serviceworker.go
@@ -8,6 +8,7 @@ import js "github.com/gowebapi/webapi/core/js"
 
 import (
 	"github.com/gowebapi/webapi/appmanifest/appmenifestres"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/fetch"
 	"github.com/gowebapi/webapi/html/channel"
@@ -749,7 +750,7 @@ type BackgroundFetchEventInit struct {
 	Registration *BackgroundFetchRegistration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -765,10 +766,8 @@ func (_this *BackgroundFetchEventInit) JSValue() js.Value {
 }
 
 // BackgroundFetchEventInitFromJS is allocating a new
-// BackgroundFetchEventInit object and copy all values from
-// input javascript object
-func BackgroundFetchEventInitFromJS(value js.Wrapper) *BackgroundFetchEventInit {
-	input := value.JSValue()
+// BackgroundFetchEventInit object and copy all values in the value javascript object.
+func BackgroundFetchEventInitFromJS(value js.Value) *BackgroundFetchEventInit {
 	var out BackgroundFetchEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -776,13 +775,13 @@ func BackgroundFetchEventInitFromJS(value js.Wrapper) *BackgroundFetchEventInit 
 		value2 bool                         // javascript: boolean {composed Composed composed}
 		value3 *BackgroundFetchRegistration // javascript: BackgroundFetchRegistration {registration Registration registration}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = BackgroundFetchRegistrationFromJS(input.Get("registration"))
+	value3 = BackgroundFetchRegistrationFromJS(value.Get("registration"))
 	out.Registration = value3
 	return &out
 }
@@ -794,7 +793,7 @@ type BackgroundFetchOptions struct {
 	DownloadTotal int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -812,29 +811,27 @@ func (_this *BackgroundFetchOptions) JSValue() js.Value {
 }
 
 // BackgroundFetchOptionsFromJS is allocating a new
-// BackgroundFetchOptions object and copy all values from
-// input javascript object
-func BackgroundFetchOptionsFromJS(value js.Wrapper) *BackgroundFetchOptions {
-	input := value.JSValue()
+// BackgroundFetchOptions object and copy all values in the value javascript object.
+func BackgroundFetchOptionsFromJS(value js.Value) *BackgroundFetchOptions {
 	var out BackgroundFetchOptions
 	var (
 		value0 []*appmenifestres.ImageResource // javascript: sequence<ImageResource> {icons Icons icons}
 		value1 string                          // javascript: DOMString {title Title title}
 		value2 int                             // javascript: unsigned long long {downloadTotal DownloadTotal downloadTotal}
 	)
-	__length0 := input.Get("icons").Length()
+	__length0 := value.Get("icons").Length()
 	__array0 := make([]*appmenifestres.ImageResource, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *appmenifestres.ImageResource
-		__seq_in0 := input.Get("icons").Index(__idx0)
+		__seq_in0 := value.Get("icons").Index(__idx0)
 		__seq_out0 = appmenifestres.ImageResourceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Icons = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
-	value2 = (input.Get("downloadTotal")).Int()
+	value2 = (value.Get("downloadTotal")).Int()
 	out.DownloadTotal = value2
 	return &out
 }
@@ -845,7 +842,7 @@ type BackgroundFetchUIOptions struct {
 	Title string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchUIOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -861,26 +858,24 @@ func (_this *BackgroundFetchUIOptions) JSValue() js.Value {
 }
 
 // BackgroundFetchUIOptionsFromJS is allocating a new
-// BackgroundFetchUIOptions object and copy all values from
-// input javascript object
-func BackgroundFetchUIOptionsFromJS(value js.Wrapper) *BackgroundFetchUIOptions {
-	input := value.JSValue()
+// BackgroundFetchUIOptions object and copy all values in the value javascript object.
+func BackgroundFetchUIOptionsFromJS(value js.Value) *BackgroundFetchUIOptions {
 	var out BackgroundFetchUIOptions
 	var (
 		value0 []*appmenifestres.ImageResource // javascript: sequence<ImageResource> {icons Icons icons}
 		value1 string                          // javascript: DOMString {title Title title}
 	)
-	__length0 := input.Get("icons").Length()
+	__length0 := value.Get("icons").Length()
 	__array0 := make([]*appmenifestres.ImageResource, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *appmenifestres.ImageResource
-		__seq_in0 := input.Get("icons").Index(__idx0)
+		__seq_in0 := value.Get("icons").Index(__idx0)
 		__seq_out0 = appmenifestres.ImageResourceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Icons = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
 	return &out
 }
@@ -892,7 +887,7 @@ type CacheQueryOptions struct {
 	IgnoreVary   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CacheQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -906,21 +901,19 @@ func (_this *CacheQueryOptions) JSValue() js.Value {
 }
 
 // CacheQueryOptionsFromJS is allocating a new
-// CacheQueryOptions object and copy all values from
-// input javascript object
-func CacheQueryOptionsFromJS(value js.Wrapper) *CacheQueryOptions {
-	input := value.JSValue()
+// CacheQueryOptions object and copy all values in the value javascript object.
+func CacheQueryOptionsFromJS(value js.Value) *CacheQueryOptions {
 	var out CacheQueryOptions
 	var (
 		value0 bool // javascript: boolean {ignoreSearch IgnoreSearch ignoreSearch}
 		value1 bool // javascript: boolean {ignoreMethod IgnoreMethod ignoreMethod}
 		value2 bool // javascript: boolean {ignoreVary IgnoreVary ignoreVary}
 	)
-	value0 = (input.Get("ignoreSearch")).Bool()
+	value0 = (value.Get("ignoreSearch")).Bool()
 	out.IgnoreSearch = value0
-	value1 = (input.Get("ignoreMethod")).Bool()
+	value1 = (value.Get("ignoreMethod")).Bool()
 	out.IgnoreMethod = value1
-	value2 = (input.Get("ignoreVary")).Bool()
+	value2 = (value.Get("ignoreVary")).Bool()
 	out.IgnoreVary = value2
 	return &out
 }
@@ -931,7 +924,7 @@ type ClientQueryOptions struct {
 	Type                client.ClientType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClientQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -943,18 +936,16 @@ func (_this *ClientQueryOptions) JSValue() js.Value {
 }
 
 // ClientQueryOptionsFromJS is allocating a new
-// ClientQueryOptions object and copy all values from
-// input javascript object
-func ClientQueryOptionsFromJS(value js.Wrapper) *ClientQueryOptions {
-	input := value.JSValue()
+// ClientQueryOptions object and copy all values in the value javascript object.
+func ClientQueryOptionsFromJS(value js.Value) *ClientQueryOptions {
 	var out ClientQueryOptions
 	var (
 		value0 bool              // javascript: boolean {includeUncontrolled IncludeUncontrolled includeUncontrolled}
 		value1 client.ClientType // javascript: ClientType {type Type _type}
 	)
-	value0 = (input.Get("includeUncontrolled")).Bool()
+	value0 = (value.Get("includeUncontrolled")).Bool()
 	out.IncludeUncontrolled = value0
-	value1 = client.ClientTypeFromJS(input.Get("type"))
+	value1 = client.ClientTypeFromJS(value.Get("type"))
 	out.Type = value1
 	return &out
 }
@@ -971,7 +962,7 @@ type ExtendableMessageEventInit struct {
 	Ports       []*channel.MessagePort
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableMessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -999,10 +990,8 @@ func (_this *ExtendableMessageEventInit) JSValue() js.Value {
 }
 
 // ExtendableMessageEventInitFromJS is allocating a new
-// ExtendableMessageEventInit object and copy all values from
-// input javascript object
-func ExtendableMessageEventInitFromJS(value js.Wrapper) *ExtendableMessageEventInit {
-	input := value.JSValue()
+// ExtendableMessageEventInit object and copy all values in the value javascript object.
+func ExtendableMessageEventInitFromJS(value js.Value) *ExtendableMessageEventInit {
 	var out ExtendableMessageEventInit
 	var (
 		value0 bool                   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1014,27 +1003,27 @@ func ExtendableMessageEventInitFromJS(value js.Wrapper) *ExtendableMessageEventI
 		value6 *Union                 // javascript: Union {source Source source}
 		value7 []*channel.MessagePort // javascript: sequence<MessagePort> {ports Ports ports}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("data")
+	value3 = value.Get("data")
 	out.Data = value3
-	value4 = (input.Get("origin")).String()
+	value4 = (value.Get("origin")).String()
 	out.Origin = value4
-	value5 = (input.Get("lastEventId")).String()
+	value5 = (value.Get("lastEventId")).String()
 	out.LastEventId = value5
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value6 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value6 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value6
-	__length7 := input.Get("ports").Length()
+	__length7 := value.Get("ports").Length()
 	__array7 := make([]*channel.MessagePort, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 *channel.MessagePort
-		__seq_in7 := input.Get("ports").Index(__idx7)
+		__seq_in7 := value.Get("ports").Index(__idx7)
 		__seq_out7 = channel.MessagePortFromJS(__seq_in7)
 		__array7[__idx7] = __seq_out7
 	}
@@ -1052,7 +1041,7 @@ type FetchEventInit struct {
 	ClientId   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FetchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1070,10 +1059,8 @@ func (_this *FetchEventInit) JSValue() js.Value {
 }
 
 // FetchEventInitFromJS is allocating a new
-// FetchEventInit object and copy all values from
-// input javascript object
-func FetchEventInitFromJS(value js.Wrapper) *FetchEventInit {
-	input := value.JSValue()
+// FetchEventInit object and copy all values in the value javascript object.
+func FetchEventInitFromJS(value js.Value) *FetchEventInit {
 	var out FetchEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -1082,15 +1069,15 @@ func FetchEventInitFromJS(value js.Wrapper) *FetchEventInit {
 		value3 *fetch.Request // javascript: Request {request Request request}
 		value4 string         // javascript: DOMString {clientId ClientId clientId}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = fetch.RequestFromJS(input.Get("request"))
+	value3 = fetch.RequestFromJS(value.Get("request"))
 	out.Request = value3
-	value4 = (input.Get("clientId")).String()
+	value4 = (value.Get("clientId")).String()
 	out.ClientId = value4
 	return &out
 }
@@ -1103,7 +1090,7 @@ type MultiCacheQueryOptions struct {
 	CacheName    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MultiCacheQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1119,10 +1106,8 @@ func (_this *MultiCacheQueryOptions) JSValue() js.Value {
 }
 
 // MultiCacheQueryOptionsFromJS is allocating a new
-// MultiCacheQueryOptions object and copy all values from
-// input javascript object
-func MultiCacheQueryOptionsFromJS(value js.Wrapper) *MultiCacheQueryOptions {
-	input := value.JSValue()
+// MultiCacheQueryOptions object and copy all values in the value javascript object.
+func MultiCacheQueryOptionsFromJS(value js.Value) *MultiCacheQueryOptions {
 	var out MultiCacheQueryOptions
 	var (
 		value0 bool   // javascript: boolean {ignoreSearch IgnoreSearch ignoreSearch}
@@ -1130,13 +1115,13 @@ func MultiCacheQueryOptionsFromJS(value js.Wrapper) *MultiCacheQueryOptions {
 		value2 bool   // javascript: boolean {ignoreVary IgnoreVary ignoreVary}
 		value3 string // javascript: DOMString {cacheName CacheName cacheName}
 	)
-	value0 = (input.Get("ignoreSearch")).Bool()
+	value0 = (value.Get("ignoreSearch")).Bool()
 	out.IgnoreSearch = value0
-	value1 = (input.Get("ignoreMethod")).Bool()
+	value1 = (value.Get("ignoreMethod")).Bool()
 	out.IgnoreMethod = value1
-	value2 = (input.Get("ignoreVary")).Bool()
+	value2 = (value.Get("ignoreVary")).Bool()
 	out.IgnoreVary = value2
-	value3 = (input.Get("cacheName")).String()
+	value3 = (value.Get("cacheName")).String()
 	out.CacheName = value3
 	return &out
 }
@@ -1148,7 +1133,7 @@ type RegistrationOptions struct {
 	UpdateViaCache ServiceWorkerUpdateViaCache
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RegistrationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1162,21 +1147,19 @@ func (_this *RegistrationOptions) JSValue() js.Value {
 }
 
 // RegistrationOptionsFromJS is allocating a new
-// RegistrationOptions object and copy all values from
-// input javascript object
-func RegistrationOptionsFromJS(value js.Wrapper) *RegistrationOptions {
-	input := value.JSValue()
+// RegistrationOptions object and copy all values in the value javascript object.
+func RegistrationOptionsFromJS(value js.Value) *RegistrationOptions {
 	var out RegistrationOptions
 	var (
 		value0 string                      // javascript: USVString {scope Scope scope}
 		value1 htmlcommon.WorkerType       // javascript: WorkerType {type Type _type}
 		value2 ServiceWorkerUpdateViaCache // javascript: ServiceWorkerUpdateViaCache {updateViaCache UpdateViaCache updateViaCache}
 	)
-	value0 = (input.Get("scope")).String()
+	value0 = (value.Get("scope")).String()
 	out.Scope = value0
-	value1 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value1 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = ServiceWorkerUpdateViaCacheFromJS(input.Get("updateViaCache"))
+	value2 = ServiceWorkerUpdateViaCacheFromJS(value.Get("updateViaCache"))
 	out.UpdateViaCache = value2
 	return &out
 }
@@ -1190,7 +1173,7 @@ type SyncEventInit struct {
 	LastChance bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SyncEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1208,10 +1191,8 @@ func (_this *SyncEventInit) JSValue() js.Value {
 }
 
 // SyncEventInitFromJS is allocating a new
-// SyncEventInit object and copy all values from
-// input javascript object
-func SyncEventInitFromJS(value js.Wrapper) *SyncEventInit {
-	input := value.JSValue()
+// SyncEventInit object and copy all values in the value javascript object.
+func SyncEventInitFromJS(value js.Value) *SyncEventInit {
 	var out SyncEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1220,15 +1201,15 @@ func SyncEventInitFromJS(value js.Wrapper) *SyncEventInit {
 		value3 string // javascript: DOMString {tag Tag tag}
 		value4 bool   // javascript: boolean {lastChance LastChance lastChance}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("tag")).String()
+	value3 = (value.Get("tag")).String()
 	out.Tag = value3
-	value4 = (input.Get("lastChance")).Bool()
+	value4 = (value.Get("lastChance")).Bool()
 	out.LastChance = value4
 	return &out
 }
@@ -1238,15 +1219,19 @@ type BackgroundFetchEvent struct {
 	domcore.ExtendableEvent
 }
 
-// BackgroundFetchEventFromJS is casting a js.Wrapper into BackgroundFetchEvent.
-func BackgroundFetchEventFromJS(value js.Wrapper) *BackgroundFetchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchEventFromJS is casting a js.Value into BackgroundFetchEvent.
+func BackgroundFetchEventFromJS(value js.Value) *BackgroundFetchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchEventFromJS is casting from something that holds a js.Value into BackgroundFetchEvent.
+func BackgroundFetchEventFromWrapper(input core.Wrapper) *BackgroundFetchEvent {
+	return BackgroundFetchEventFromJS(input.JSValue())
 }
 
 func NewBackgroundFetchEvent(_type string, init *BackgroundFetchEventInit) (_result *BackgroundFetchEvent) {
@@ -1289,15 +1274,19 @@ func (_this *BackgroundFetchManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BackgroundFetchManagerFromJS is casting a js.Wrapper into BackgroundFetchManager.
-func BackgroundFetchManagerFromJS(value js.Wrapper) *BackgroundFetchManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchManagerFromJS is casting a js.Value into BackgroundFetchManager.
+func BackgroundFetchManagerFromJS(value js.Value) *BackgroundFetchManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchManagerFromJS is casting from something that holds a js.Value into BackgroundFetchManager.
+func BackgroundFetchManagerFromWrapper(input core.Wrapper) *BackgroundFetchManager {
+	return BackgroundFetchManagerFromJS(input.JSValue())
 }
 
 func (_this *BackgroundFetchManager) Fetch(id string, requests *Union, options *BackgroundFetchOptions) (_result *PromiseBackgroundFetchRegistration) {
@@ -1366,15 +1355,19 @@ func (_this *BackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BackgroundFetchRecordFromJS is casting a js.Wrapper into BackgroundFetchRecord.
-func BackgroundFetchRecordFromJS(value js.Wrapper) *BackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchRecordFromJS is casting a js.Value into BackgroundFetchRecord.
+func BackgroundFetchRecordFromJS(value js.Value) *BackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchRecordFromJS is casting from something that holds a js.Value into BackgroundFetchRecord.
+func BackgroundFetchRecordFromWrapper(input core.Wrapper) *BackgroundFetchRecord {
+	return BackgroundFetchRecordFromJS(input.JSValue())
 }
 
 // Request returning attribute 'request' with
@@ -1400,15 +1393,19 @@ type BackgroundFetchRegistration struct {
 	domcore.EventTarget
 }
 
-// BackgroundFetchRegistrationFromJS is casting a js.Wrapper into BackgroundFetchRegistration.
-func BackgroundFetchRegistrationFromJS(value js.Wrapper) *BackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchRegistrationFromJS is casting a js.Value into BackgroundFetchRegistration.
+func BackgroundFetchRegistrationFromJS(value js.Value) *BackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into BackgroundFetchRegistration.
+func BackgroundFetchRegistrationFromWrapper(input core.Wrapper) *BackgroundFetchRegistration {
+	return BackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1589,15 +1586,19 @@ type BackgroundFetchUpdateUIEvent struct {
 	BackgroundFetchEvent
 }
 
-// BackgroundFetchUpdateUIEventFromJS is casting a js.Wrapper into BackgroundFetchUpdateUIEvent.
-func BackgroundFetchUpdateUIEventFromJS(value js.Wrapper) *BackgroundFetchUpdateUIEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchUpdateUIEventFromJS is casting a js.Value into BackgroundFetchUpdateUIEvent.
+func BackgroundFetchUpdateUIEventFromJS(value js.Value) *BackgroundFetchUpdateUIEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchUpdateUIEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchUpdateUIEventFromJS is casting from something that holds a js.Value into BackgroundFetchUpdateUIEvent.
+func BackgroundFetchUpdateUIEventFromWrapper(input core.Wrapper) *BackgroundFetchUpdateUIEvent {
+	return BackgroundFetchUpdateUIEventFromJS(input.JSValue())
 }
 
 func NewBackgroundFetchUpdateUIEvent(_type string, init *BackgroundFetchEventInit) (_result *BackgroundFetchUpdateUIEvent) {
@@ -1650,15 +1651,19 @@ func (_this *Cache) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CacheFromJS is casting a js.Wrapper into Cache.
-func CacheFromJS(value js.Wrapper) *Cache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CacheFromJS is casting a js.Value into Cache.
+func CacheFromJS(value js.Value) *Cache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Cache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CacheFromJS is casting from something that holds a js.Value into Cache.
+func CacheFromWrapper(input core.Wrapper) *Cache {
+	return CacheFromJS(input.JSValue())
 }
 
 func (_this *Cache) Match(request *Union, options *CacheQueryOptions) (_result *javascript.Promise) {
@@ -1821,15 +1826,19 @@ func (_this *CacheStorage) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CacheStorageFromJS is casting a js.Wrapper into CacheStorage.
-func CacheStorageFromJS(value js.Wrapper) *CacheStorage {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CacheStorageFromJS is casting a js.Value into CacheStorage.
+func CacheStorageFromJS(value js.Value) *CacheStorage {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CacheStorage{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CacheStorageFromJS is casting from something that holds a js.Value into CacheStorage.
+func CacheStorageFromWrapper(input core.Wrapper) *CacheStorage {
+	return CacheStorageFromJS(input.JSValue())
 }
 
 func (_this *CacheStorage) Match(request *Union, options *MultiCacheQueryOptions) (_result *javascript.Promise) {
@@ -1929,15 +1938,19 @@ func (_this *Clients) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ClientsFromJS is casting a js.Wrapper into Clients.
-func ClientsFromJS(value js.Wrapper) *Clients {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClientsFromJS is casting a js.Value into Clients.
+func ClientsFromJS(value js.Value) *Clients {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Clients{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClientsFromJS is casting from something that holds a js.Value into Clients.
+func ClientsFromWrapper(input core.Wrapper) *Clients {
+	return ClientsFromJS(input.JSValue())
 }
 
 func (_this *Clients) Get(id string) (_result *javascript.Promise) {
@@ -2012,15 +2025,19 @@ type ExtendableMessageEvent struct {
 	domcore.ExtendableEvent
 }
 
-// ExtendableMessageEventFromJS is casting a js.Wrapper into ExtendableMessageEvent.
-func ExtendableMessageEventFromJS(value js.Wrapper) *ExtendableMessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableMessageEventFromJS is casting a js.Value into ExtendableMessageEvent.
+func ExtendableMessageEventFromJS(value js.Value) *ExtendableMessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableMessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableMessageEventFromJS is casting from something that holds a js.Value into ExtendableMessageEvent.
+func ExtendableMessageEventFromWrapper(input core.Wrapper) *ExtendableMessageEvent {
+	return ExtendableMessageEventFromJS(input.JSValue())
 }
 
 func NewExtendableMessageEvent(_type string, eventInitDict *ExtendableMessageEventInit) (_result *ExtendableMessageEvent) {
@@ -2098,15 +2115,19 @@ type FetchEvent struct {
 	domcore.ExtendableEvent
 }
 
-// FetchEventFromJS is casting a js.Wrapper into FetchEvent.
-func FetchEventFromJS(value js.Wrapper) *FetchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FetchEventFromJS is casting a js.Value into FetchEvent.
+func FetchEventFromJS(value js.Value) *FetchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FetchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FetchEventFromJS is casting from something that holds a js.Value into FetchEvent.
+func FetchEventFromWrapper(input core.Wrapper) *FetchEvent {
+	return FetchEventFromJS(input.JSValue())
 }
 
 func NewFetchEvent(_type string, eventInitDict *FetchEventInit) (_result *FetchEvent) {
@@ -2170,15 +2191,19 @@ func (_this *PromiseBackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBackgroundFetchRecordFromJS is casting a js.Wrapper into PromiseBackgroundFetchRecord.
-func PromiseBackgroundFetchRecordFromJS(value js.Wrapper) *PromiseBackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBackgroundFetchRecordFromJS is casting a js.Value into PromiseBackgroundFetchRecord.
+func PromiseBackgroundFetchRecordFromJS(value js.Value) *PromiseBackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBackgroundFetchRecordFromJS is casting from something that holds a js.Value into PromiseBackgroundFetchRecord.
+func PromiseBackgroundFetchRecordFromWrapper(input core.Wrapper) *PromiseBackgroundFetchRecord {
+	return PromiseBackgroundFetchRecordFromJS(input.JSValue())
 }
 
 func (_this *PromiseBackgroundFetchRecord) Then(onFulfilled *PromiseBackgroundFetchRecordOnFulfilled, onRejected *PromiseBackgroundFetchRecordOnRejected) (_result *PromiseBackgroundFetchRecord) {
@@ -2275,15 +2300,19 @@ func (_this *PromiseBackgroundFetchRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBackgroundFetchRegistrationFromJS is casting a js.Wrapper into PromiseBackgroundFetchRegistration.
-func PromiseBackgroundFetchRegistrationFromJS(value js.Wrapper) *PromiseBackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBackgroundFetchRegistrationFromJS is casting a js.Value into PromiseBackgroundFetchRegistration.
+func PromiseBackgroundFetchRegistrationFromJS(value js.Value) *PromiseBackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into PromiseBackgroundFetchRegistration.
+func PromiseBackgroundFetchRegistrationFromWrapper(input core.Wrapper) *PromiseBackgroundFetchRegistration {
+	return PromiseBackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseBackgroundFetchRegistration) Then(onFulfilled *PromiseBackgroundFetchRegistrationOnFulfilled, onRejected *PromiseBackgroundFetchRegistrationOnRejected) (_result *PromiseBackgroundFetchRegistration) {
@@ -2380,15 +2409,19 @@ func (_this *PromiseCache) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCacheFromJS is casting a js.Wrapper into PromiseCache.
-func PromiseCacheFromJS(value js.Wrapper) *PromiseCache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCacheFromJS is casting a js.Value into PromiseCache.
+func PromiseCacheFromJS(value js.Value) *PromiseCache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCacheFromJS is casting from something that holds a js.Value into PromiseCache.
+func PromiseCacheFromWrapper(input core.Wrapper) *PromiseCache {
+	return PromiseCacheFromJS(input.JSValue())
 }
 
 func (_this *PromiseCache) Then(onFulfilled *PromiseCacheOnFulfilled, onRejected *PromiseCacheOnRejected) (_result *PromiseCache) {
@@ -2485,15 +2518,19 @@ func (_this *PromiseNilBackgroundFetchRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilBackgroundFetchRegistrationFromJS is casting a js.Wrapper into PromiseNilBackgroundFetchRegistration.
-func PromiseNilBackgroundFetchRegistrationFromJS(value js.Wrapper) *PromiseNilBackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilBackgroundFetchRegistrationFromJS is casting a js.Value into PromiseNilBackgroundFetchRegistration.
+func PromiseNilBackgroundFetchRegistrationFromJS(value js.Value) *PromiseNilBackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilBackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilBackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into PromiseNilBackgroundFetchRegistration.
+func PromiseNilBackgroundFetchRegistrationFromWrapper(input core.Wrapper) *PromiseNilBackgroundFetchRegistration {
+	return PromiseNilBackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilBackgroundFetchRegistration) Then(onFulfilled *PromiseNilBackgroundFetchRegistrationOnFulfilled, onRejected *PromiseNilBackgroundFetchRegistrationOnRejected) (_result *PromiseNilBackgroundFetchRegistration) {
@@ -2590,15 +2627,19 @@ func (_this *PromiseSequenceBackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceBackgroundFetchRecordFromJS is casting a js.Wrapper into PromiseSequenceBackgroundFetchRecord.
-func PromiseSequenceBackgroundFetchRecordFromJS(value js.Wrapper) *PromiseSequenceBackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceBackgroundFetchRecordFromJS is casting a js.Value into PromiseSequenceBackgroundFetchRecord.
+func PromiseSequenceBackgroundFetchRecordFromJS(value js.Value) *PromiseSequenceBackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceBackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceBackgroundFetchRecordFromJS is casting from something that holds a js.Value into PromiseSequenceBackgroundFetchRecord.
+func PromiseSequenceBackgroundFetchRecordFromWrapper(input core.Wrapper) *PromiseSequenceBackgroundFetchRecord {
+	return PromiseSequenceBackgroundFetchRecordFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceBackgroundFetchRecord) Then(onFulfilled *PromiseSequenceBackgroundFetchRecordOnFulfilled, onRejected *PromiseSequenceBackgroundFetchRecordOnRejected) (_result *PromiseSequenceBackgroundFetchRecord) {
@@ -2695,15 +2736,19 @@ func (_this *PromiseServiceWorkerRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseServiceWorkerRegistrationFromJS is casting a js.Wrapper into PromiseServiceWorkerRegistration.
-func PromiseServiceWorkerRegistrationFromJS(value js.Wrapper) *PromiseServiceWorkerRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseServiceWorkerRegistrationFromJS is casting a js.Value into PromiseServiceWorkerRegistration.
+func PromiseServiceWorkerRegistrationFromJS(value js.Value) *PromiseServiceWorkerRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseServiceWorkerRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseServiceWorkerRegistrationFromJS is casting from something that holds a js.Value into PromiseServiceWorkerRegistration.
+func PromiseServiceWorkerRegistrationFromWrapper(input core.Wrapper) *PromiseServiceWorkerRegistration {
+	return PromiseServiceWorkerRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseServiceWorkerRegistration) Then(onFulfilled *PromiseServiceWorkerRegistrationOnFulfilled, onRejected *PromiseServiceWorkerRegistrationOnRejected) (_result *PromiseServiceWorkerRegistration) {
@@ -2795,15 +2840,19 @@ type ServiceWorker struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerFromJS is casting a js.Wrapper into ServiceWorker.
-func ServiceWorkerFromJS(value js.Wrapper) *ServiceWorker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerFromJS is casting a js.Value into ServiceWorker.
+func ServiceWorkerFromJS(value js.Value) *ServiceWorker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerFromJS is casting from something that holds a js.Value into ServiceWorker.
+func ServiceWorkerFromWrapper(input core.Wrapper) *ServiceWorker {
+	return ServiceWorkerFromJS(input.JSValue())
 }
 
 // ScriptURL returning attribute 'scriptURL' with
@@ -2918,15 +2967,19 @@ type ServiceWorkerContainer struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerContainerFromJS is casting a js.Wrapper into ServiceWorkerContainer.
-func ServiceWorkerContainerFromJS(value js.Wrapper) *ServiceWorkerContainer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerContainerFromJS is casting a js.Value into ServiceWorkerContainer.
+func ServiceWorkerContainerFromJS(value js.Value) *ServiceWorkerContainer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerContainer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerContainerFromJS is casting from something that holds a js.Value into ServiceWorkerContainer.
+func ServiceWorkerContainerFromWrapper(input core.Wrapper) *ServiceWorkerContainer {
+	return ServiceWorkerContainerFromJS(input.JSValue())
 }
 
 // Controller returning attribute 'controller' with
@@ -3147,15 +3200,19 @@ type ServiceWorkerRegistration struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerRegistrationFromJS is casting a js.Wrapper into ServiceWorkerRegistration.
-func ServiceWorkerRegistrationFromJS(value js.Wrapper) *ServiceWorkerRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerRegistrationFromJS is casting a js.Value into ServiceWorkerRegistration.
+func ServiceWorkerRegistrationFromJS(value js.Value) *ServiceWorkerRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerRegistrationFromJS is casting from something that holds a js.Value into ServiceWorkerRegistration.
+func ServiceWorkerRegistrationFromWrapper(input core.Wrapper) *ServiceWorkerRegistration {
+	return ServiceWorkerRegistrationFromJS(input.JSValue())
 }
 
 // Installing returning attribute 'installing' with
@@ -3319,15 +3376,19 @@ type SyncEvent struct {
 	domcore.ExtendableEvent
 }
 
-// SyncEventFromJS is casting a js.Wrapper into SyncEvent.
-func SyncEventFromJS(value js.Wrapper) *SyncEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncEventFromJS is casting a js.Value into SyncEvent.
+func SyncEventFromJS(value js.Value) *SyncEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SyncEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncEventFromJS is casting from something that holds a js.Value into SyncEvent.
+func SyncEventFromWrapper(input core.Wrapper) *SyncEvent {
+	return SyncEventFromJS(input.JSValue())
 }
 
 func NewSyncEvent(_type string, init *SyncEventInit) (_result *SyncEvent) {
@@ -3379,15 +3440,19 @@ func (_this *SyncManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SyncManagerFromJS is casting a js.Wrapper into SyncManager.
-func SyncManagerFromJS(value js.Wrapper) *SyncManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncManagerFromJS is casting a js.Value into SyncManager.
+func SyncManagerFromJS(value js.Value) *SyncManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SyncManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncManagerFromJS is casting from something that holds a js.Value into SyncManager.
+func SyncManagerFromWrapper(input core.Wrapper) *SyncManager {
+	return SyncManagerFromJS(input.JSValue())
 }
 
 func (_this *SyncManager) Register(tag string) (_result *javascript.PromiseVoid) {

--- a/serviceworker/serviceworker_js.go
+++ b/serviceworker/serviceworker_js.go
@@ -6,6 +6,7 @@ import "syscall/js"
 
 import (
 	"github.com/gowebapi/webapi/appmanifest/appmenifestres"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/dom/domcore"
 	"github.com/gowebapi/webapi/fetch"
 	"github.com/gowebapi/webapi/html/channel"
@@ -747,7 +748,7 @@ type BackgroundFetchEventInit struct {
 	Registration *BackgroundFetchRegistration
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -763,10 +764,8 @@ func (_this *BackgroundFetchEventInit) JSValue() js.Value {
 }
 
 // BackgroundFetchEventInitFromJS is allocating a new
-// BackgroundFetchEventInit object and copy all values from
-// input javascript object
-func BackgroundFetchEventInitFromJS(value js.Wrapper) *BackgroundFetchEventInit {
-	input := value.JSValue()
+// BackgroundFetchEventInit object and copy all values in the value javascript object.
+func BackgroundFetchEventInitFromJS(value js.Value) *BackgroundFetchEventInit {
 	var out BackgroundFetchEventInit
 	var (
 		value0 bool                         // javascript: boolean {bubbles Bubbles bubbles}
@@ -774,13 +773,13 @@ func BackgroundFetchEventInitFromJS(value js.Wrapper) *BackgroundFetchEventInit 
 		value2 bool                         // javascript: boolean {composed Composed composed}
 		value3 *BackgroundFetchRegistration // javascript: BackgroundFetchRegistration {registration Registration registration}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = BackgroundFetchRegistrationFromJS(input.Get("registration"))
+	value3 = BackgroundFetchRegistrationFromJS(value.Get("registration"))
 	out.Registration = value3
 	return &out
 }
@@ -792,7 +791,7 @@ type BackgroundFetchOptions struct {
 	DownloadTotal int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -810,29 +809,27 @@ func (_this *BackgroundFetchOptions) JSValue() js.Value {
 }
 
 // BackgroundFetchOptionsFromJS is allocating a new
-// BackgroundFetchOptions object and copy all values from
-// input javascript object
-func BackgroundFetchOptionsFromJS(value js.Wrapper) *BackgroundFetchOptions {
-	input := value.JSValue()
+// BackgroundFetchOptions object and copy all values in the value javascript object.
+func BackgroundFetchOptionsFromJS(value js.Value) *BackgroundFetchOptions {
 	var out BackgroundFetchOptions
 	var (
 		value0 []*appmenifestres.ImageResource // javascript: sequence<ImageResource> {icons Icons icons}
 		value1 string                          // javascript: DOMString {title Title title}
 		value2 int                             // javascript: unsigned long long {downloadTotal DownloadTotal downloadTotal}
 	)
-	__length0 := input.Get("icons").Length()
+	__length0 := value.Get("icons").Length()
 	__array0 := make([]*appmenifestres.ImageResource, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *appmenifestres.ImageResource
-		__seq_in0 := input.Get("icons").Index(__idx0)
+		__seq_in0 := value.Get("icons").Index(__idx0)
 		__seq_out0 = appmenifestres.ImageResourceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Icons = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
-	value2 = (input.Get("downloadTotal")).Int()
+	value2 = (value.Get("downloadTotal")).Int()
 	out.DownloadTotal = value2
 	return &out
 }
@@ -843,7 +840,7 @@ type BackgroundFetchUIOptions struct {
 	Title string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *BackgroundFetchUIOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -859,26 +856,24 @@ func (_this *BackgroundFetchUIOptions) JSValue() js.Value {
 }
 
 // BackgroundFetchUIOptionsFromJS is allocating a new
-// BackgroundFetchUIOptions object and copy all values from
-// input javascript object
-func BackgroundFetchUIOptionsFromJS(value js.Wrapper) *BackgroundFetchUIOptions {
-	input := value.JSValue()
+// BackgroundFetchUIOptions object and copy all values in the value javascript object.
+func BackgroundFetchUIOptionsFromJS(value js.Value) *BackgroundFetchUIOptions {
 	var out BackgroundFetchUIOptions
 	var (
 		value0 []*appmenifestres.ImageResource // javascript: sequence<ImageResource> {icons Icons icons}
 		value1 string                          // javascript: DOMString {title Title title}
 	)
-	__length0 := input.Get("icons").Length()
+	__length0 := value.Get("icons").Length()
 	__array0 := make([]*appmenifestres.ImageResource, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *appmenifestres.ImageResource
-		__seq_in0 := input.Get("icons").Index(__idx0)
+		__seq_in0 := value.Get("icons").Index(__idx0)
 		__seq_out0 = appmenifestres.ImageResourceFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Icons = value0
-	value1 = (input.Get("title")).String()
+	value1 = (value.Get("title")).String()
 	out.Title = value1
 	return &out
 }
@@ -890,7 +885,7 @@ type CacheQueryOptions struct {
 	IgnoreVary   bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *CacheQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -904,21 +899,19 @@ func (_this *CacheQueryOptions) JSValue() js.Value {
 }
 
 // CacheQueryOptionsFromJS is allocating a new
-// CacheQueryOptions object and copy all values from
-// input javascript object
-func CacheQueryOptionsFromJS(value js.Wrapper) *CacheQueryOptions {
-	input := value.JSValue()
+// CacheQueryOptions object and copy all values in the value javascript object.
+func CacheQueryOptionsFromJS(value js.Value) *CacheQueryOptions {
 	var out CacheQueryOptions
 	var (
 		value0 bool // javascript: boolean {ignoreSearch IgnoreSearch ignoreSearch}
 		value1 bool // javascript: boolean {ignoreMethod IgnoreMethod ignoreMethod}
 		value2 bool // javascript: boolean {ignoreVary IgnoreVary ignoreVary}
 	)
-	value0 = (input.Get("ignoreSearch")).Bool()
+	value0 = (value.Get("ignoreSearch")).Bool()
 	out.IgnoreSearch = value0
-	value1 = (input.Get("ignoreMethod")).Bool()
+	value1 = (value.Get("ignoreMethod")).Bool()
 	out.IgnoreMethod = value1
-	value2 = (input.Get("ignoreVary")).Bool()
+	value2 = (value.Get("ignoreVary")).Bool()
 	out.IgnoreVary = value2
 	return &out
 }
@@ -929,7 +922,7 @@ type ClientQueryOptions struct {
 	Type                client.ClientType
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ClientQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -941,18 +934,16 @@ func (_this *ClientQueryOptions) JSValue() js.Value {
 }
 
 // ClientQueryOptionsFromJS is allocating a new
-// ClientQueryOptions object and copy all values from
-// input javascript object
-func ClientQueryOptionsFromJS(value js.Wrapper) *ClientQueryOptions {
-	input := value.JSValue()
+// ClientQueryOptions object and copy all values in the value javascript object.
+func ClientQueryOptionsFromJS(value js.Value) *ClientQueryOptions {
 	var out ClientQueryOptions
 	var (
 		value0 bool              // javascript: boolean {includeUncontrolled IncludeUncontrolled includeUncontrolled}
 		value1 client.ClientType // javascript: ClientType {type Type _type}
 	)
-	value0 = (input.Get("includeUncontrolled")).Bool()
+	value0 = (value.Get("includeUncontrolled")).Bool()
 	out.IncludeUncontrolled = value0
-	value1 = client.ClientTypeFromJS(input.Get("type"))
+	value1 = client.ClientTypeFromJS(value.Get("type"))
 	out.Type = value1
 	return &out
 }
@@ -969,7 +960,7 @@ type ExtendableMessageEventInit struct {
 	Ports       []*channel.MessagePort
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ExtendableMessageEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -997,10 +988,8 @@ func (_this *ExtendableMessageEventInit) JSValue() js.Value {
 }
 
 // ExtendableMessageEventInitFromJS is allocating a new
-// ExtendableMessageEventInit object and copy all values from
-// input javascript object
-func ExtendableMessageEventInitFromJS(value js.Wrapper) *ExtendableMessageEventInit {
-	input := value.JSValue()
+// ExtendableMessageEventInit object and copy all values in the value javascript object.
+func ExtendableMessageEventInitFromJS(value js.Value) *ExtendableMessageEventInit {
 	var out ExtendableMessageEventInit
 	var (
 		value0 bool                   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1012,27 +1001,27 @@ func ExtendableMessageEventInitFromJS(value js.Wrapper) *ExtendableMessageEventI
 		value6 *Union                 // javascript: Union {source Source source}
 		value7 []*channel.MessagePort // javascript: sequence<MessagePort> {ports Ports ports}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = input.Get("data")
+	value3 = value.Get("data")
 	out.Data = value3
-	value4 = (input.Get("origin")).String()
+	value4 = (value.Get("origin")).String()
 	out.Origin = value4
-	value5 = (input.Get("lastEventId")).String()
+	value5 = (value.Get("lastEventId")).String()
 	out.LastEventId = value5
-	if input.Get("source").Type() != js.TypeNull && input.Get("source").Type() != js.TypeUndefined {
-		value6 = UnionFromJS(input.Get("source"))
+	if value.Get("source").Type() != js.TypeNull && value.Get("source").Type() != js.TypeUndefined {
+		value6 = UnionFromJS(value.Get("source"))
 	}
 	out.Source = value6
-	__length7 := input.Get("ports").Length()
+	__length7 := value.Get("ports").Length()
 	__array7 := make([]*channel.MessagePort, __length7, __length7)
 	for __idx7 := 0; __idx7 < __length7; __idx7++ {
 		var __seq_out7 *channel.MessagePort
-		__seq_in7 := input.Get("ports").Index(__idx7)
+		__seq_in7 := value.Get("ports").Index(__idx7)
 		__seq_out7 = channel.MessagePortFromJS(__seq_in7)
 		__array7[__idx7] = __seq_out7
 	}
@@ -1050,7 +1039,7 @@ type FetchEventInit struct {
 	ClientId   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *FetchEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1068,10 +1057,8 @@ func (_this *FetchEventInit) JSValue() js.Value {
 }
 
 // FetchEventInitFromJS is allocating a new
-// FetchEventInit object and copy all values from
-// input javascript object
-func FetchEventInitFromJS(value js.Wrapper) *FetchEventInit {
-	input := value.JSValue()
+// FetchEventInit object and copy all values in the value javascript object.
+func FetchEventInitFromJS(value js.Value) *FetchEventInit {
 	var out FetchEventInit
 	var (
 		value0 bool           // javascript: boolean {bubbles Bubbles bubbles}
@@ -1080,15 +1067,15 @@ func FetchEventInitFromJS(value js.Wrapper) *FetchEventInit {
 		value3 *fetch.Request // javascript: Request {request Request request}
 		value4 string         // javascript: DOMString {clientId ClientId clientId}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = fetch.RequestFromJS(input.Get("request"))
+	value3 = fetch.RequestFromJS(value.Get("request"))
 	out.Request = value3
-	value4 = (input.Get("clientId")).String()
+	value4 = (value.Get("clientId")).String()
 	out.ClientId = value4
 	return &out
 }
@@ -1101,7 +1088,7 @@ type MultiCacheQueryOptions struct {
 	CacheName    string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MultiCacheQueryOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1117,10 +1104,8 @@ func (_this *MultiCacheQueryOptions) JSValue() js.Value {
 }
 
 // MultiCacheQueryOptionsFromJS is allocating a new
-// MultiCacheQueryOptions object and copy all values from
-// input javascript object
-func MultiCacheQueryOptionsFromJS(value js.Wrapper) *MultiCacheQueryOptions {
-	input := value.JSValue()
+// MultiCacheQueryOptions object and copy all values in the value javascript object.
+func MultiCacheQueryOptionsFromJS(value js.Value) *MultiCacheQueryOptions {
 	var out MultiCacheQueryOptions
 	var (
 		value0 bool   // javascript: boolean {ignoreSearch IgnoreSearch ignoreSearch}
@@ -1128,13 +1113,13 @@ func MultiCacheQueryOptionsFromJS(value js.Wrapper) *MultiCacheQueryOptions {
 		value2 bool   // javascript: boolean {ignoreVary IgnoreVary ignoreVary}
 		value3 string // javascript: DOMString {cacheName CacheName cacheName}
 	)
-	value0 = (input.Get("ignoreSearch")).Bool()
+	value0 = (value.Get("ignoreSearch")).Bool()
 	out.IgnoreSearch = value0
-	value1 = (input.Get("ignoreMethod")).Bool()
+	value1 = (value.Get("ignoreMethod")).Bool()
 	out.IgnoreMethod = value1
-	value2 = (input.Get("ignoreVary")).Bool()
+	value2 = (value.Get("ignoreVary")).Bool()
 	out.IgnoreVary = value2
-	value3 = (input.Get("cacheName")).String()
+	value3 = (value.Get("cacheName")).String()
 	out.CacheName = value3
 	return &out
 }
@@ -1146,7 +1131,7 @@ type RegistrationOptions struct {
 	UpdateViaCache ServiceWorkerUpdateViaCache
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *RegistrationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1160,21 +1145,19 @@ func (_this *RegistrationOptions) JSValue() js.Value {
 }
 
 // RegistrationOptionsFromJS is allocating a new
-// RegistrationOptions object and copy all values from
-// input javascript object
-func RegistrationOptionsFromJS(value js.Wrapper) *RegistrationOptions {
-	input := value.JSValue()
+// RegistrationOptions object and copy all values in the value javascript object.
+func RegistrationOptionsFromJS(value js.Value) *RegistrationOptions {
 	var out RegistrationOptions
 	var (
 		value0 string                      // javascript: USVString {scope Scope scope}
 		value1 htmlcommon.WorkerType       // javascript: WorkerType {type Type _type}
 		value2 ServiceWorkerUpdateViaCache // javascript: ServiceWorkerUpdateViaCache {updateViaCache UpdateViaCache updateViaCache}
 	)
-	value0 = (input.Get("scope")).String()
+	value0 = (value.Get("scope")).String()
 	out.Scope = value0
-	value1 = htmlcommon.WorkerTypeFromJS(input.Get("type"))
+	value1 = htmlcommon.WorkerTypeFromJS(value.Get("type"))
 	out.Type = value1
-	value2 = ServiceWorkerUpdateViaCacheFromJS(input.Get("updateViaCache"))
+	value2 = ServiceWorkerUpdateViaCacheFromJS(value.Get("updateViaCache"))
 	out.UpdateViaCache = value2
 	return &out
 }
@@ -1188,7 +1171,7 @@ type SyncEventInit struct {
 	LastChance bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *SyncEventInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -1206,10 +1189,8 @@ func (_this *SyncEventInit) JSValue() js.Value {
 }
 
 // SyncEventInitFromJS is allocating a new
-// SyncEventInit object and copy all values from
-// input javascript object
-func SyncEventInitFromJS(value js.Wrapper) *SyncEventInit {
-	input := value.JSValue()
+// SyncEventInit object and copy all values in the value javascript object.
+func SyncEventInitFromJS(value js.Value) *SyncEventInit {
 	var out SyncEventInit
 	var (
 		value0 bool   // javascript: boolean {bubbles Bubbles bubbles}
@@ -1218,15 +1199,15 @@ func SyncEventInitFromJS(value js.Wrapper) *SyncEventInit {
 		value3 string // javascript: DOMString {tag Tag tag}
 		value4 bool   // javascript: boolean {lastChance LastChance lastChance}
 	)
-	value0 = (input.Get("bubbles")).Bool()
+	value0 = (value.Get("bubbles")).Bool()
 	out.Bubbles = value0
-	value1 = (input.Get("cancelable")).Bool()
+	value1 = (value.Get("cancelable")).Bool()
 	out.Cancelable = value1
-	value2 = (input.Get("composed")).Bool()
+	value2 = (value.Get("composed")).Bool()
 	out.Composed = value2
-	value3 = (input.Get("tag")).String()
+	value3 = (value.Get("tag")).String()
 	out.Tag = value3
-	value4 = (input.Get("lastChance")).Bool()
+	value4 = (value.Get("lastChance")).Bool()
 	out.LastChance = value4
 	return &out
 }
@@ -1236,15 +1217,19 @@ type BackgroundFetchEvent struct {
 	domcore.ExtendableEvent
 }
 
-// BackgroundFetchEventFromJS is casting a js.Wrapper into BackgroundFetchEvent.
-func BackgroundFetchEventFromJS(value js.Wrapper) *BackgroundFetchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchEventFromJS is casting a js.Value into BackgroundFetchEvent.
+func BackgroundFetchEventFromJS(value js.Value) *BackgroundFetchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchEventFromJS is casting from something that holds a js.Value into BackgroundFetchEvent.
+func BackgroundFetchEventFromWrapper(input core.Wrapper) *BackgroundFetchEvent {
+	return BackgroundFetchEventFromJS(input.JSValue())
 }
 
 func NewBackgroundFetchEvent(_type string, init *BackgroundFetchEventInit) (_result *BackgroundFetchEvent) {
@@ -1287,15 +1272,19 @@ func (_this *BackgroundFetchManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BackgroundFetchManagerFromJS is casting a js.Wrapper into BackgroundFetchManager.
-func BackgroundFetchManagerFromJS(value js.Wrapper) *BackgroundFetchManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchManagerFromJS is casting a js.Value into BackgroundFetchManager.
+func BackgroundFetchManagerFromJS(value js.Value) *BackgroundFetchManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchManagerFromJS is casting from something that holds a js.Value into BackgroundFetchManager.
+func BackgroundFetchManagerFromWrapper(input core.Wrapper) *BackgroundFetchManager {
+	return BackgroundFetchManagerFromJS(input.JSValue())
 }
 
 func (_this *BackgroundFetchManager) Fetch(id string, requests *Union, options *BackgroundFetchOptions) (_result *PromiseBackgroundFetchRegistration) {
@@ -1364,15 +1353,19 @@ func (_this *BackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// BackgroundFetchRecordFromJS is casting a js.Wrapper into BackgroundFetchRecord.
-func BackgroundFetchRecordFromJS(value js.Wrapper) *BackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchRecordFromJS is casting a js.Value into BackgroundFetchRecord.
+func BackgroundFetchRecordFromJS(value js.Value) *BackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchRecordFromJS is casting from something that holds a js.Value into BackgroundFetchRecord.
+func BackgroundFetchRecordFromWrapper(input core.Wrapper) *BackgroundFetchRecord {
+	return BackgroundFetchRecordFromJS(input.JSValue())
 }
 
 // Request returning attribute 'request' with
@@ -1398,15 +1391,19 @@ type BackgroundFetchRegistration struct {
 	domcore.EventTarget
 }
 
-// BackgroundFetchRegistrationFromJS is casting a js.Wrapper into BackgroundFetchRegistration.
-func BackgroundFetchRegistrationFromJS(value js.Wrapper) *BackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchRegistrationFromJS is casting a js.Value into BackgroundFetchRegistration.
+func BackgroundFetchRegistrationFromJS(value js.Value) *BackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into BackgroundFetchRegistration.
+func BackgroundFetchRegistrationFromWrapper(input core.Wrapper) *BackgroundFetchRegistration {
+	return BackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 // Id returning attribute 'id' with
@@ -1587,15 +1584,19 @@ type BackgroundFetchUpdateUIEvent struct {
 	BackgroundFetchEvent
 }
 
-// BackgroundFetchUpdateUIEventFromJS is casting a js.Wrapper into BackgroundFetchUpdateUIEvent.
-func BackgroundFetchUpdateUIEventFromJS(value js.Wrapper) *BackgroundFetchUpdateUIEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// BackgroundFetchUpdateUIEventFromJS is casting a js.Value into BackgroundFetchUpdateUIEvent.
+func BackgroundFetchUpdateUIEventFromJS(value js.Value) *BackgroundFetchUpdateUIEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &BackgroundFetchUpdateUIEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// BackgroundFetchUpdateUIEventFromJS is casting from something that holds a js.Value into BackgroundFetchUpdateUIEvent.
+func BackgroundFetchUpdateUIEventFromWrapper(input core.Wrapper) *BackgroundFetchUpdateUIEvent {
+	return BackgroundFetchUpdateUIEventFromJS(input.JSValue())
 }
 
 func NewBackgroundFetchUpdateUIEvent(_type string, init *BackgroundFetchEventInit) (_result *BackgroundFetchUpdateUIEvent) {
@@ -1648,15 +1649,19 @@ func (_this *Cache) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CacheFromJS is casting a js.Wrapper into Cache.
-func CacheFromJS(value js.Wrapper) *Cache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CacheFromJS is casting a js.Value into Cache.
+func CacheFromJS(value js.Value) *Cache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Cache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CacheFromJS is casting from something that holds a js.Value into Cache.
+func CacheFromWrapper(input core.Wrapper) *Cache {
+	return CacheFromJS(input.JSValue())
 }
 
 func (_this *Cache) Match(request *Union, options *CacheQueryOptions) (_result *javascript.Promise) {
@@ -1819,15 +1824,19 @@ func (_this *CacheStorage) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// CacheStorageFromJS is casting a js.Wrapper into CacheStorage.
-func CacheStorageFromJS(value js.Wrapper) *CacheStorage {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// CacheStorageFromJS is casting a js.Value into CacheStorage.
+func CacheStorageFromJS(value js.Value) *CacheStorage {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &CacheStorage{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// CacheStorageFromJS is casting from something that holds a js.Value into CacheStorage.
+func CacheStorageFromWrapper(input core.Wrapper) *CacheStorage {
+	return CacheStorageFromJS(input.JSValue())
 }
 
 func (_this *CacheStorage) Match(request *Union, options *MultiCacheQueryOptions) (_result *javascript.Promise) {
@@ -1927,15 +1936,19 @@ func (_this *Clients) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// ClientsFromJS is casting a js.Wrapper into Clients.
-func ClientsFromJS(value js.Wrapper) *Clients {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ClientsFromJS is casting a js.Value into Clients.
+func ClientsFromJS(value js.Value) *Clients {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Clients{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ClientsFromJS is casting from something that holds a js.Value into Clients.
+func ClientsFromWrapper(input core.Wrapper) *Clients {
+	return ClientsFromJS(input.JSValue())
 }
 
 func (_this *Clients) Get(id string) (_result *javascript.Promise) {
@@ -2010,15 +2023,19 @@ type ExtendableMessageEvent struct {
 	domcore.ExtendableEvent
 }
 
-// ExtendableMessageEventFromJS is casting a js.Wrapper into ExtendableMessageEvent.
-func ExtendableMessageEventFromJS(value js.Wrapper) *ExtendableMessageEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ExtendableMessageEventFromJS is casting a js.Value into ExtendableMessageEvent.
+func ExtendableMessageEventFromJS(value js.Value) *ExtendableMessageEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ExtendableMessageEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ExtendableMessageEventFromJS is casting from something that holds a js.Value into ExtendableMessageEvent.
+func ExtendableMessageEventFromWrapper(input core.Wrapper) *ExtendableMessageEvent {
+	return ExtendableMessageEventFromJS(input.JSValue())
 }
 
 func NewExtendableMessageEvent(_type string, eventInitDict *ExtendableMessageEventInit) (_result *ExtendableMessageEvent) {
@@ -2096,15 +2113,19 @@ type FetchEvent struct {
 	domcore.ExtendableEvent
 }
 
-// FetchEventFromJS is casting a js.Wrapper into FetchEvent.
-func FetchEventFromJS(value js.Wrapper) *FetchEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// FetchEventFromJS is casting a js.Value into FetchEvent.
+func FetchEventFromJS(value js.Value) *FetchEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &FetchEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// FetchEventFromJS is casting from something that holds a js.Value into FetchEvent.
+func FetchEventFromWrapper(input core.Wrapper) *FetchEvent {
+	return FetchEventFromJS(input.JSValue())
 }
 
 func NewFetchEvent(_type string, eventInitDict *FetchEventInit) (_result *FetchEvent) {
@@ -2168,15 +2189,19 @@ func (_this *PromiseBackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBackgroundFetchRecordFromJS is casting a js.Wrapper into PromiseBackgroundFetchRecord.
-func PromiseBackgroundFetchRecordFromJS(value js.Wrapper) *PromiseBackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBackgroundFetchRecordFromJS is casting a js.Value into PromiseBackgroundFetchRecord.
+func PromiseBackgroundFetchRecordFromJS(value js.Value) *PromiseBackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBackgroundFetchRecordFromJS is casting from something that holds a js.Value into PromiseBackgroundFetchRecord.
+func PromiseBackgroundFetchRecordFromWrapper(input core.Wrapper) *PromiseBackgroundFetchRecord {
+	return PromiseBackgroundFetchRecordFromJS(input.JSValue())
 }
 
 func (_this *PromiseBackgroundFetchRecord) Then(onFulfilled *PromiseBackgroundFetchRecordOnFulfilled, onRejected *PromiseBackgroundFetchRecordOnRejected) (_result *PromiseBackgroundFetchRecord) {
@@ -2273,15 +2298,19 @@ func (_this *PromiseBackgroundFetchRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseBackgroundFetchRegistrationFromJS is casting a js.Wrapper into PromiseBackgroundFetchRegistration.
-func PromiseBackgroundFetchRegistrationFromJS(value js.Wrapper) *PromiseBackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseBackgroundFetchRegistrationFromJS is casting a js.Value into PromiseBackgroundFetchRegistration.
+func PromiseBackgroundFetchRegistrationFromJS(value js.Value) *PromiseBackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseBackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseBackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into PromiseBackgroundFetchRegistration.
+func PromiseBackgroundFetchRegistrationFromWrapper(input core.Wrapper) *PromiseBackgroundFetchRegistration {
+	return PromiseBackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseBackgroundFetchRegistration) Then(onFulfilled *PromiseBackgroundFetchRegistrationOnFulfilled, onRejected *PromiseBackgroundFetchRegistrationOnRejected) (_result *PromiseBackgroundFetchRegistration) {
@@ -2378,15 +2407,19 @@ func (_this *PromiseCache) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseCacheFromJS is casting a js.Wrapper into PromiseCache.
-func PromiseCacheFromJS(value js.Wrapper) *PromiseCache {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseCacheFromJS is casting a js.Value into PromiseCache.
+func PromiseCacheFromJS(value js.Value) *PromiseCache {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseCache{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseCacheFromJS is casting from something that holds a js.Value into PromiseCache.
+func PromiseCacheFromWrapper(input core.Wrapper) *PromiseCache {
+	return PromiseCacheFromJS(input.JSValue())
 }
 
 func (_this *PromiseCache) Then(onFulfilled *PromiseCacheOnFulfilled, onRejected *PromiseCacheOnRejected) (_result *PromiseCache) {
@@ -2483,15 +2516,19 @@ func (_this *PromiseNilBackgroundFetchRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseNilBackgroundFetchRegistrationFromJS is casting a js.Wrapper into PromiseNilBackgroundFetchRegistration.
-func PromiseNilBackgroundFetchRegistrationFromJS(value js.Wrapper) *PromiseNilBackgroundFetchRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseNilBackgroundFetchRegistrationFromJS is casting a js.Value into PromiseNilBackgroundFetchRegistration.
+func PromiseNilBackgroundFetchRegistrationFromJS(value js.Value) *PromiseNilBackgroundFetchRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseNilBackgroundFetchRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseNilBackgroundFetchRegistrationFromJS is casting from something that holds a js.Value into PromiseNilBackgroundFetchRegistration.
+func PromiseNilBackgroundFetchRegistrationFromWrapper(input core.Wrapper) *PromiseNilBackgroundFetchRegistration {
+	return PromiseNilBackgroundFetchRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseNilBackgroundFetchRegistration) Then(onFulfilled *PromiseNilBackgroundFetchRegistrationOnFulfilled, onRejected *PromiseNilBackgroundFetchRegistrationOnRejected) (_result *PromiseNilBackgroundFetchRegistration) {
@@ -2588,15 +2625,19 @@ func (_this *PromiseSequenceBackgroundFetchRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseSequenceBackgroundFetchRecordFromJS is casting a js.Wrapper into PromiseSequenceBackgroundFetchRecord.
-func PromiseSequenceBackgroundFetchRecordFromJS(value js.Wrapper) *PromiseSequenceBackgroundFetchRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseSequenceBackgroundFetchRecordFromJS is casting a js.Value into PromiseSequenceBackgroundFetchRecord.
+func PromiseSequenceBackgroundFetchRecordFromJS(value js.Value) *PromiseSequenceBackgroundFetchRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseSequenceBackgroundFetchRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseSequenceBackgroundFetchRecordFromJS is casting from something that holds a js.Value into PromiseSequenceBackgroundFetchRecord.
+func PromiseSequenceBackgroundFetchRecordFromWrapper(input core.Wrapper) *PromiseSequenceBackgroundFetchRecord {
+	return PromiseSequenceBackgroundFetchRecordFromJS(input.JSValue())
 }
 
 func (_this *PromiseSequenceBackgroundFetchRecord) Then(onFulfilled *PromiseSequenceBackgroundFetchRecordOnFulfilled, onRejected *PromiseSequenceBackgroundFetchRecordOnRejected) (_result *PromiseSequenceBackgroundFetchRecord) {
@@ -2693,15 +2734,19 @@ func (_this *PromiseServiceWorkerRegistration) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseServiceWorkerRegistrationFromJS is casting a js.Wrapper into PromiseServiceWorkerRegistration.
-func PromiseServiceWorkerRegistrationFromJS(value js.Wrapper) *PromiseServiceWorkerRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseServiceWorkerRegistrationFromJS is casting a js.Value into PromiseServiceWorkerRegistration.
+func PromiseServiceWorkerRegistrationFromJS(value js.Value) *PromiseServiceWorkerRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseServiceWorkerRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseServiceWorkerRegistrationFromJS is casting from something that holds a js.Value into PromiseServiceWorkerRegistration.
+func PromiseServiceWorkerRegistrationFromWrapper(input core.Wrapper) *PromiseServiceWorkerRegistration {
+	return PromiseServiceWorkerRegistrationFromJS(input.JSValue())
 }
 
 func (_this *PromiseServiceWorkerRegistration) Then(onFulfilled *PromiseServiceWorkerRegistrationOnFulfilled, onRejected *PromiseServiceWorkerRegistrationOnRejected) (_result *PromiseServiceWorkerRegistration) {
@@ -2793,15 +2838,19 @@ type ServiceWorker struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerFromJS is casting a js.Wrapper into ServiceWorker.
-func ServiceWorkerFromJS(value js.Wrapper) *ServiceWorker {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerFromJS is casting a js.Value into ServiceWorker.
+func ServiceWorkerFromJS(value js.Value) *ServiceWorker {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorker{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerFromJS is casting from something that holds a js.Value into ServiceWorker.
+func ServiceWorkerFromWrapper(input core.Wrapper) *ServiceWorker {
+	return ServiceWorkerFromJS(input.JSValue())
 }
 
 // ScriptURL returning attribute 'scriptURL' with
@@ -2916,15 +2965,19 @@ type ServiceWorkerContainer struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerContainerFromJS is casting a js.Wrapper into ServiceWorkerContainer.
-func ServiceWorkerContainerFromJS(value js.Wrapper) *ServiceWorkerContainer {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerContainerFromJS is casting a js.Value into ServiceWorkerContainer.
+func ServiceWorkerContainerFromJS(value js.Value) *ServiceWorkerContainer {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerContainer{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerContainerFromJS is casting from something that holds a js.Value into ServiceWorkerContainer.
+func ServiceWorkerContainerFromWrapper(input core.Wrapper) *ServiceWorkerContainer {
+	return ServiceWorkerContainerFromJS(input.JSValue())
 }
 
 // Controller returning attribute 'controller' with
@@ -3145,15 +3198,19 @@ type ServiceWorkerRegistration struct {
 	domcore.EventTarget
 }
 
-// ServiceWorkerRegistrationFromJS is casting a js.Wrapper into ServiceWorkerRegistration.
-func ServiceWorkerRegistrationFromJS(value js.Wrapper) *ServiceWorkerRegistration {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// ServiceWorkerRegistrationFromJS is casting a js.Value into ServiceWorkerRegistration.
+func ServiceWorkerRegistrationFromJS(value js.Value) *ServiceWorkerRegistration {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &ServiceWorkerRegistration{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// ServiceWorkerRegistrationFromJS is casting from something that holds a js.Value into ServiceWorkerRegistration.
+func ServiceWorkerRegistrationFromWrapper(input core.Wrapper) *ServiceWorkerRegistration {
+	return ServiceWorkerRegistrationFromJS(input.JSValue())
 }
 
 // Installing returning attribute 'installing' with
@@ -3317,15 +3374,19 @@ type SyncEvent struct {
 	domcore.ExtendableEvent
 }
 
-// SyncEventFromJS is casting a js.Wrapper into SyncEvent.
-func SyncEventFromJS(value js.Wrapper) *SyncEvent {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncEventFromJS is casting a js.Value into SyncEvent.
+func SyncEventFromJS(value js.Value) *SyncEvent {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SyncEvent{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncEventFromJS is casting from something that holds a js.Value into SyncEvent.
+func SyncEventFromWrapper(input core.Wrapper) *SyncEvent {
+	return SyncEventFromJS(input.JSValue())
 }
 
 func NewSyncEvent(_type string, init *SyncEventInit) (_result *SyncEvent) {
@@ -3377,15 +3438,19 @@ func (_this *SyncManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// SyncManagerFromJS is casting a js.Wrapper into SyncManager.
-func SyncManagerFromJS(value js.Wrapper) *SyncManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// SyncManagerFromJS is casting a js.Value into SyncManager.
+func SyncManagerFromJS(value js.Value) *SyncManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &SyncManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// SyncManagerFromJS is casting from something that holds a js.Value into SyncManager.
+func SyncManagerFromWrapper(input core.Wrapper) *SyncManager {
+	return SyncManagerFromJS(input.JSValue())
 }
 
 func (_this *SyncManager) Register(tag string) (_result *javascript.PromiseVoid) {

--- a/share/share.go
+++ b/share/share.go
@@ -38,7 +38,7 @@ type ShareData struct {
 	Url   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ShareData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -52,21 +52,19 @@ func (_this *ShareData) JSValue() js.Value {
 }
 
 // ShareDataFromJS is allocating a new
-// ShareData object and copy all values from
-// input javascript object
-func ShareDataFromJS(value js.Wrapper) *ShareData {
-	input := value.JSValue()
+// ShareData object and copy all values in the value javascript object.
+func ShareDataFromJS(value js.Value) *ShareData {
 	var out ShareData
 	var (
 		value0 string // javascript: USVString {title Title title}
 		value1 string // javascript: USVString {text Text text}
 		value2 string // javascript: USVString {url Url url}
 	)
-	value0 = (input.Get("title")).String()
+	value0 = (value.Get("title")).String()
 	out.Title = value0
-	value1 = (input.Get("text")).String()
+	value1 = (value.Get("text")).String()
 	out.Text = value1
-	value2 = (input.Get("url")).String()
+	value2 = (value.Get("url")).String()
 	out.Url = value2
 	return &out
 }

--- a/share/share_js.go
+++ b/share/share_js.go
@@ -36,7 +36,7 @@ type ShareData struct {
 	Url   string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ShareData) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -50,21 +50,19 @@ func (_this *ShareData) JSValue() js.Value {
 }
 
 // ShareDataFromJS is allocating a new
-// ShareData object and copy all values from
-// input javascript object
-func ShareDataFromJS(value js.Wrapper) *ShareData {
-	input := value.JSValue()
+// ShareData object and copy all values in the value javascript object.
+func ShareDataFromJS(value js.Value) *ShareData {
 	var out ShareData
 	var (
 		value0 string // javascript: USVString {title Title title}
 		value1 string // javascript: USVString {text Text text}
 		value2 string // javascript: USVString {url Url url}
 	)
-	value0 = (input.Get("title")).String()
+	value0 = (value.Get("title")).String()
 	out.Title = value0
-	value1 = (input.Get("text")).String()
+	value1 = (value.Get("text")).String()
 	out.Text = value1
-	value2 = (input.Get("url")).String()
+	value2 = (value.Get("url")).String()
 	out.Url = value2
 	return &out
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -7,6 +7,7 @@ package storage
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -125,7 +126,7 @@ type StorageEstimate struct {
 	Quota int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StorageEstimate) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -137,18 +138,16 @@ func (_this *StorageEstimate) JSValue() js.Value {
 }
 
 // StorageEstimateFromJS is allocating a new
-// StorageEstimate object and copy all values from
-// input javascript object
-func StorageEstimateFromJS(value js.Wrapper) *StorageEstimate {
-	input := value.JSValue()
+// StorageEstimate object and copy all values in the value javascript object.
+func StorageEstimateFromJS(value js.Value) *StorageEstimate {
 	var out StorageEstimate
 	var (
 		value0 int // javascript: unsigned long long {usage Usage usage}
 		value1 int // javascript: unsigned long long {quota Quota quota}
 	)
-	value0 = (input.Get("usage")).Int()
+	value0 = (value.Get("usage")).Int()
 	out.Usage = value0
-	value1 = (input.Get("quota")).Int()
+	value1 = (value.Get("quota")).Int()
 	out.Quota = value1
 	return &out
 }
@@ -163,15 +162,19 @@ func (_this *PromiseStorageEstimate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStorageEstimateFromJS is casting a js.Wrapper into PromiseStorageEstimate.
-func PromiseStorageEstimateFromJS(value js.Wrapper) *PromiseStorageEstimate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStorageEstimateFromJS is casting a js.Value into PromiseStorageEstimate.
+func PromiseStorageEstimateFromJS(value js.Value) *PromiseStorageEstimate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseStorageEstimate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStorageEstimateFromJS is casting from something that holds a js.Value into PromiseStorageEstimate.
+func PromiseStorageEstimateFromWrapper(input core.Wrapper) *PromiseStorageEstimate {
+	return PromiseStorageEstimateFromJS(input.JSValue())
 }
 
 func (_this *PromiseStorageEstimate) Then(onFulfilled *PromiseStorageEstimateOnFulfilled, onRejected *PromiseStorageEstimateOnRejected) (_result *PromiseStorageEstimate) {
@@ -268,15 +271,19 @@ func (_this *StorageManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StorageManagerFromJS is casting a js.Wrapper into StorageManager.
-func StorageManagerFromJS(value js.Wrapper) *StorageManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageManagerFromJS is casting a js.Value into StorageManager.
+func StorageManagerFromJS(value js.Value) *StorageManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StorageManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageManagerFromJS is casting from something that holds a js.Value into StorageManager.
+func StorageManagerFromWrapper(input core.Wrapper) *StorageManager {
+	return StorageManagerFromJS(input.JSValue())
 }
 
 func (_this *StorageManager) Persisted() (_result *javascript.PromiseBool) {

--- a/storage/storage_js.go
+++ b/storage/storage_js.go
@@ -5,6 +5,7 @@ package storage
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/javascript"
 )
 
@@ -123,7 +124,7 @@ type StorageEstimate struct {
 	Quota int
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *StorageEstimate) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -135,18 +136,16 @@ func (_this *StorageEstimate) JSValue() js.Value {
 }
 
 // StorageEstimateFromJS is allocating a new
-// StorageEstimate object and copy all values from
-// input javascript object
-func StorageEstimateFromJS(value js.Wrapper) *StorageEstimate {
-	input := value.JSValue()
+// StorageEstimate object and copy all values in the value javascript object.
+func StorageEstimateFromJS(value js.Value) *StorageEstimate {
 	var out StorageEstimate
 	var (
 		value0 int // javascript: unsigned long long {usage Usage usage}
 		value1 int // javascript: unsigned long long {quota Quota quota}
 	)
-	value0 = (input.Get("usage")).Int()
+	value0 = (value.Get("usage")).Int()
 	out.Usage = value0
-	value1 = (input.Get("quota")).Int()
+	value1 = (value.Get("quota")).Int()
 	out.Quota = value1
 	return &out
 }
@@ -161,15 +160,19 @@ func (_this *PromiseStorageEstimate) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// PromiseStorageEstimateFromJS is casting a js.Wrapper into PromiseStorageEstimate.
-func PromiseStorageEstimateFromJS(value js.Wrapper) *PromiseStorageEstimate {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// PromiseStorageEstimateFromJS is casting a js.Value into PromiseStorageEstimate.
+func PromiseStorageEstimateFromJS(value js.Value) *PromiseStorageEstimate {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &PromiseStorageEstimate{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// PromiseStorageEstimateFromJS is casting from something that holds a js.Value into PromiseStorageEstimate.
+func PromiseStorageEstimateFromWrapper(input core.Wrapper) *PromiseStorageEstimate {
+	return PromiseStorageEstimateFromJS(input.JSValue())
 }
 
 func (_this *PromiseStorageEstimate) Then(onFulfilled *PromiseStorageEstimateOnFulfilled, onRejected *PromiseStorageEstimateOnRejected) (_result *PromiseStorageEstimate) {
@@ -266,15 +269,19 @@ func (_this *StorageManager) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// StorageManagerFromJS is casting a js.Wrapper into StorageManager.
-func StorageManagerFromJS(value js.Wrapper) *StorageManager {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// StorageManagerFromJS is casting a js.Value into StorageManager.
+func StorageManagerFromJS(value js.Value) *StorageManager {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &StorageManager{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// StorageManagerFromJS is casting from something that holds a js.Value into StorageManager.
+func StorageManagerFromWrapper(input core.Wrapper) *StorageManager {
+	return StorageManagerFromJS(input.JSValue())
 }
 
 func (_this *StorageManager) Persisted() (_result *javascript.PromiseBool) {

--- a/url/url.go
+++ b/url/url.go
@@ -7,6 +7,7 @@ package url
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/media"
 )
@@ -94,7 +95,7 @@ type URLSearchParamsEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -110,26 +111,24 @@ func (_this *URLSearchParamsEntryIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsEntryIteratorValueFromJS is allocating a new
-// URLSearchParamsEntryIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsEntryIteratorValueFromJS(value js.Wrapper) *URLSearchParamsEntryIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsEntryIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsEntryIteratorValueFromJS(value js.Value) *URLSearchParamsEntryIteratorValue {
 	var out URLSearchParamsEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -140,7 +139,7 @@ type URLSearchParamsKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -152,18 +151,16 @@ func (_this *URLSearchParamsKeyIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsKeyIteratorValueFromJS is allocating a new
-// URLSearchParamsKeyIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsKeyIteratorValueFromJS(value js.Wrapper) *URLSearchParamsKeyIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsKeyIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsKeyIteratorValueFromJS(value js.Value) *URLSearchParamsKeyIteratorValue {
 	var out URLSearchParamsKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -174,7 +171,7 @@ type URLSearchParamsValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -186,18 +183,16 @@ func (_this *URLSearchParamsValueIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsValueIteratorValueFromJS is allocating a new
-// URLSearchParamsValueIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsValueIteratorValueFromJS(value js.Wrapper) *URLSearchParamsValueIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsValueIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsValueIteratorValueFromJS(value js.Value) *URLSearchParamsValueIteratorValue {
 	var out URLSearchParamsValueIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -212,15 +207,19 @@ func (_this *URL) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLFromJS is casting a js.Wrapper into URL.
-func URLFromJS(value js.Wrapper) *URL {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLFromJS is casting a js.Value into URL.
+func URLFromJS(value js.Value) *URL {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URL{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLFromJS is casting from something that holds a js.Value into URL.
+func URLFromWrapper(input core.Wrapper) *URL {
+	return URLFromJS(input.JSValue())
 }
 
 func CreateObjectURL(blob *file.Blob) (_result string) {
@@ -511,15 +510,19 @@ func (_this *URLSearchParams) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsFromJS is casting a js.Wrapper into URLSearchParams.
-func URLSearchParamsFromJS(value js.Wrapper) *URLSearchParams {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsFromJS is casting a js.Value into URLSearchParams.
+func URLSearchParamsFromJS(value js.Value) *URLSearchParams {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParams{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsFromJS is casting from something that holds a js.Value into URLSearchParams.
+func URLSearchParamsFromWrapper(input core.Wrapper) *URLSearchParams {
+	return URLSearchParamsFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParams) Append(name string, value string) {
@@ -725,15 +728,19 @@ func (_this *URLSearchParamsEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsEntryIteratorFromJS is casting a js.Wrapper into URLSearchParamsEntryIterator.
-func URLSearchParamsEntryIteratorFromJS(value js.Wrapper) *URLSearchParamsEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsEntryIteratorFromJS is casting a js.Value into URLSearchParamsEntryIterator.
+func URLSearchParamsEntryIteratorFromJS(value js.Value) *URLSearchParamsEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsEntryIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsEntryIterator.
+func URLSearchParamsEntryIteratorFromWrapper(input core.Wrapper) *URLSearchParamsEntryIterator {
+	return URLSearchParamsEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsEntryIterator) Next() (_result *URLSearchParamsEntryIteratorValue) {
@@ -760,15 +767,19 @@ func (_this *URLSearchParamsKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsKeyIteratorFromJS is casting a js.Wrapper into URLSearchParamsKeyIterator.
-func URLSearchParamsKeyIteratorFromJS(value js.Wrapper) *URLSearchParamsKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsKeyIteratorFromJS is casting a js.Value into URLSearchParamsKeyIterator.
+func URLSearchParamsKeyIteratorFromJS(value js.Value) *URLSearchParamsKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsKeyIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsKeyIterator.
+func URLSearchParamsKeyIteratorFromWrapper(input core.Wrapper) *URLSearchParamsKeyIterator {
+	return URLSearchParamsKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsKeyIterator) Next() (_result *URLSearchParamsKeyIteratorValue) {
@@ -795,15 +806,19 @@ func (_this *URLSearchParamsValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsValueIteratorFromJS is casting a js.Wrapper into URLSearchParamsValueIterator.
-func URLSearchParamsValueIteratorFromJS(value js.Wrapper) *URLSearchParamsValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsValueIteratorFromJS is casting a js.Value into URLSearchParamsValueIterator.
+func URLSearchParamsValueIteratorFromJS(value js.Value) *URLSearchParamsValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsValueIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsValueIterator.
+func URLSearchParamsValueIteratorFromWrapper(input core.Wrapper) *URLSearchParamsValueIterator {
+	return URLSearchParamsValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsValueIterator) Next() (_result *URLSearchParamsValueIteratorValue) {

--- a/url/url_js.go
+++ b/url/url_js.go
@@ -5,6 +5,7 @@ package url
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/file"
 	"github.com/gowebapi/webapi/html/media"
 )
@@ -92,7 +93,7 @@ type URLSearchParamsEntryIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsEntryIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -108,26 +109,24 @@ func (_this *URLSearchParamsEntryIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsEntryIteratorValueFromJS is allocating a new
-// URLSearchParamsEntryIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsEntryIteratorValueFromJS(value js.Wrapper) *URLSearchParamsEntryIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsEntryIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsEntryIteratorValueFromJS(value js.Value) *URLSearchParamsEntryIteratorValue {
 	var out URLSearchParamsEntryIteratorValue
 	var (
 		value0 []js.Value // javascript: sequence<any> {value Value value}
 		value1 bool       // javascript: boolean {done Done done}
 	)
-	__length0 := input.Get("value").Length()
+	__length0 := value.Get("value").Length()
 	__array0 := make([]js.Value, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 js.Value
-		__seq_in0 := input.Get("value").Index(__idx0)
+		__seq_in0 := value.Get("value").Index(__idx0)
 		__seq_out0 = __seq_in0
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -138,7 +137,7 @@ type URLSearchParamsKeyIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsKeyIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -150,18 +149,16 @@ func (_this *URLSearchParamsKeyIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsKeyIteratorValueFromJS is allocating a new
-// URLSearchParamsKeyIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsKeyIteratorValueFromJS(value js.Wrapper) *URLSearchParamsKeyIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsKeyIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsKeyIteratorValueFromJS(value js.Value) *URLSearchParamsKeyIteratorValue {
 	var out URLSearchParamsKeyIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -172,7 +169,7 @@ type URLSearchParamsValueIteratorValue struct {
 	Done  bool
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *URLSearchParamsValueIteratorValue) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -184,18 +181,16 @@ func (_this *URLSearchParamsValueIteratorValue) JSValue() js.Value {
 }
 
 // URLSearchParamsValueIteratorValueFromJS is allocating a new
-// URLSearchParamsValueIteratorValue object and copy all values from
-// input javascript object
-func URLSearchParamsValueIteratorValueFromJS(value js.Wrapper) *URLSearchParamsValueIteratorValue {
-	input := value.JSValue()
+// URLSearchParamsValueIteratorValue object and copy all values in the value javascript object.
+func URLSearchParamsValueIteratorValueFromJS(value js.Value) *URLSearchParamsValueIteratorValue {
 	var out URLSearchParamsValueIteratorValue
 	var (
 		value0 string // javascript: USVString {value Value value}
 		value1 bool   // javascript: boolean {done Done done}
 	)
-	value0 = (input.Get("value")).String()
+	value0 = (value.Get("value")).String()
 	out.Value = value0
-	value1 = (input.Get("done")).Bool()
+	value1 = (value.Get("done")).Bool()
 	out.Done = value1
 	return &out
 }
@@ -210,15 +205,19 @@ func (_this *URL) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLFromJS is casting a js.Wrapper into URL.
-func URLFromJS(value js.Wrapper) *URL {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLFromJS is casting a js.Value into URL.
+func URLFromJS(value js.Value) *URL {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URL{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLFromJS is casting from something that holds a js.Value into URL.
+func URLFromWrapper(input core.Wrapper) *URL {
+	return URLFromJS(input.JSValue())
 }
 
 func CreateObjectURL(blob *file.Blob) (_result string) {
@@ -509,15 +508,19 @@ func (_this *URLSearchParams) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsFromJS is casting a js.Wrapper into URLSearchParams.
-func URLSearchParamsFromJS(value js.Wrapper) *URLSearchParams {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsFromJS is casting a js.Value into URLSearchParams.
+func URLSearchParamsFromJS(value js.Value) *URLSearchParams {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParams{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsFromJS is casting from something that holds a js.Value into URLSearchParams.
+func URLSearchParamsFromWrapper(input core.Wrapper) *URLSearchParams {
+	return URLSearchParamsFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParams) Append(name string, value string) {
@@ -723,15 +726,19 @@ func (_this *URLSearchParamsEntryIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsEntryIteratorFromJS is casting a js.Wrapper into URLSearchParamsEntryIterator.
-func URLSearchParamsEntryIteratorFromJS(value js.Wrapper) *URLSearchParamsEntryIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsEntryIteratorFromJS is casting a js.Value into URLSearchParamsEntryIterator.
+func URLSearchParamsEntryIteratorFromJS(value js.Value) *URLSearchParamsEntryIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsEntryIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsEntryIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsEntryIterator.
+func URLSearchParamsEntryIteratorFromWrapper(input core.Wrapper) *URLSearchParamsEntryIterator {
+	return URLSearchParamsEntryIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsEntryIterator) Next() (_result *URLSearchParamsEntryIteratorValue) {
@@ -758,15 +765,19 @@ func (_this *URLSearchParamsKeyIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsKeyIteratorFromJS is casting a js.Wrapper into URLSearchParamsKeyIterator.
-func URLSearchParamsKeyIteratorFromJS(value js.Wrapper) *URLSearchParamsKeyIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsKeyIteratorFromJS is casting a js.Value into URLSearchParamsKeyIterator.
+func URLSearchParamsKeyIteratorFromJS(value js.Value) *URLSearchParamsKeyIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsKeyIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsKeyIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsKeyIterator.
+func URLSearchParamsKeyIteratorFromWrapper(input core.Wrapper) *URLSearchParamsKeyIterator {
+	return URLSearchParamsKeyIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsKeyIterator) Next() (_result *URLSearchParamsKeyIteratorValue) {
@@ -793,15 +804,19 @@ func (_this *URLSearchParamsValueIterator) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// URLSearchParamsValueIteratorFromJS is casting a js.Wrapper into URLSearchParamsValueIterator.
-func URLSearchParamsValueIteratorFromJS(value js.Wrapper) *URLSearchParamsValueIterator {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// URLSearchParamsValueIteratorFromJS is casting a js.Value into URLSearchParamsValueIterator.
+func URLSearchParamsValueIteratorFromJS(value js.Value) *URLSearchParamsValueIterator {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &URLSearchParamsValueIterator{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// URLSearchParamsValueIteratorFromJS is casting from something that holds a js.Value into URLSearchParamsValueIterator.
+func URLSearchParamsValueIteratorFromWrapper(input core.Wrapper) *URLSearchParamsValueIterator {
+	return URLSearchParamsValueIteratorFromJS(input.JSValue())
 }
 
 func (_this *URLSearchParamsValueIterator) Next() (_result *URLSearchParamsValueIteratorValue) {

--- a/webapi.go
+++ b/webapi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
 	"github.com/gowebapi/webapi/cookie"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
@@ -284,7 +285,7 @@ type ElementCreationOptions struct {
 	Is string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ElementCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -294,15 +295,13 @@ func (_this *ElementCreationOptions) JSValue() js.Value {
 }
 
 // ElementCreationOptionsFromJS is allocating a new
-// ElementCreationOptions object and copy all values from
-// input javascript object
-func ElementCreationOptionsFromJS(value js.Wrapper) *ElementCreationOptions {
-	input := value.JSValue()
+// ElementCreationOptions object and copy all values in the value javascript object.
+func ElementCreationOptionsFromJS(value js.Value) *ElementCreationOptions {
 	var out ElementCreationOptions
 	var (
 		value0 string // javascript: DOMString {is Is is}
 	)
-	value0 = (input.Get("is")).String()
+	value0 = (value.Get("is")).String()
 	out.Is = value0
 	return &out
 }
@@ -318,7 +317,7 @@ type MutationObserverInit struct {
 	AttributeFilter       []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MutationObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -344,10 +343,8 @@ func (_this *MutationObserverInit) JSValue() js.Value {
 }
 
 // MutationObserverInitFromJS is allocating a new
-// MutationObserverInit object and copy all values from
-// input javascript object
-func MutationObserverInitFromJS(value js.Wrapper) *MutationObserverInit {
-	input := value.JSValue()
+// MutationObserverInit object and copy all values in the value javascript object.
+func MutationObserverInitFromJS(value js.Value) *MutationObserverInit {
 	var out MutationObserverInit
 	var (
 		value0 bool     // javascript: boolean {childList ChildList childList}
@@ -358,23 +355,23 @@ func MutationObserverInitFromJS(value js.Wrapper) *MutationObserverInit {
 		value5 bool     // javascript: boolean {characterDataOldValue CharacterDataOldValue characterDataOldValue}
 		value6 []string // javascript: sequence<DOMString> {attributeFilter AttributeFilter attributeFilter}
 	)
-	value0 = (input.Get("childList")).Bool()
+	value0 = (value.Get("childList")).Bool()
 	out.ChildList = value0
-	value1 = (input.Get("attributes")).Bool()
+	value1 = (value.Get("attributes")).Bool()
 	out.Attributes = value1
-	value2 = (input.Get("characterData")).Bool()
+	value2 = (value.Get("characterData")).Bool()
 	out.CharacterData = value2
-	value3 = (input.Get("subtree")).Bool()
+	value3 = (value.Get("subtree")).Bool()
 	out.Subtree = value3
-	value4 = (input.Get("attributeOldValue")).Bool()
+	value4 = (value.Get("attributeOldValue")).Bool()
 	out.AttributeOldValue = value4
-	value5 = (input.Get("characterDataOldValue")).Bool()
+	value5 = (value.Get("characterDataOldValue")).Bool()
 	out.CharacterDataOldValue = value5
-	__length6 := input.Get("attributeFilter").Length()
+	__length6 := value.Get("attributeFilter").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("attributeFilter").Index(__idx6)
+		__seq_in6 := value.Get("attributeFilter").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -389,7 +386,7 @@ type WindowPostMessageOptions struct {
 	TargetOrigin string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WindowPostMessageOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -405,26 +402,24 @@ func (_this *WindowPostMessageOptions) JSValue() js.Value {
 }
 
 // WindowPostMessageOptionsFromJS is allocating a new
-// WindowPostMessageOptions object and copy all values from
-// input javascript object
-func WindowPostMessageOptionsFromJS(value js.Wrapper) *WindowPostMessageOptions {
-	input := value.JSValue()
+// WindowPostMessageOptions object and copy all values in the value javascript object.
+func WindowPostMessageOptionsFromJS(value js.Value) *WindowPostMessageOptions {
 	var out WindowPostMessageOptions
 	var (
 		value0 []*javascript.Object // javascript: sequence<object> {transfer Transfer transfer}
 		value1 string               // javascript: USVString {targetOrigin TargetOrigin targetOrigin}
 	)
-	__length0 := input.Get("transfer").Length()
+	__length0 := value.Get("transfer").Length()
 	__array0 := make([]*javascript.Object, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *javascript.Object
-		__seq_in0 := input.Get("transfer").Index(__idx0)
+		__seq_in0 := value.Get("transfer").Index(__idx0)
 		__seq_out0 = javascript.ObjectFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Transfer = value0
-	value1 = (input.Get("targetOrigin")).String()
+	value1 = (value.Get("targetOrigin")).String()
 	out.TargetOrigin = value1
 	return &out
 }
@@ -439,15 +434,19 @@ func (_this *DOMImplementation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMImplementationFromJS is casting a js.Wrapper into DOMImplementation.
-func DOMImplementationFromJS(value js.Wrapper) *DOMImplementation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMImplementationFromJS is casting a js.Value into DOMImplementation.
+func DOMImplementationFromJS(value js.Value) *DOMImplementation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMImplementation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMImplementationFromJS is casting from something that holds a js.Value into DOMImplementation.
+func DOMImplementationFromWrapper(input core.Wrapper) *DOMImplementation {
+	return DOMImplementationFromJS(input.JSValue())
 }
 
 func (_this *DOMImplementation) CreateDocumentType(qualifiedName string, publicId string, systemId string) (_result *dom.DocumentType) {
@@ -548,15 +547,19 @@ type Document struct {
 	dom.Node
 }
 
-// DocumentFromJS is casting a js.Wrapper into Document.
-func DocumentFromJS(value js.Wrapper) *Document {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentFromJS is casting a js.Value into Document.
+func DocumentFromJS(value js.Value) *Document {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Document{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentFromJS is casting from something that holds a js.Value into Document.
+func DocumentFromWrapper(input core.Wrapper) *Document {
+	return DocumentFromJS(input.JSValue())
 }
 
 func NewDocument() (_result *Document) {
@@ -5102,15 +5105,19 @@ type HTMLEmbedElement struct {
 	html.HTMLElement
 }
 
-// HTMLEmbedElementFromJS is casting a js.Wrapper into HTMLEmbedElement.
-func HTMLEmbedElementFromJS(value js.Wrapper) *HTMLEmbedElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLEmbedElementFromJS is casting a js.Value into HTMLEmbedElement.
+func HTMLEmbedElementFromJS(value js.Value) *HTMLEmbedElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLEmbedElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLEmbedElementFromJS is casting from something that holds a js.Value into HTMLEmbedElement.
+func HTMLEmbedElementFromWrapper(input core.Wrapper) *HTMLEmbedElement {
+	return HTMLEmbedElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -5230,15 +5237,19 @@ type HTMLFrameElement struct {
 	html.HTMLElement
 }
 
-// HTMLFrameElementFromJS is casting a js.Wrapper into HTMLFrameElement.
-func HTMLFrameElementFromJS(value js.Wrapper) *HTMLFrameElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFrameElementFromJS is casting a js.Value into HTMLFrameElement.
+func HTMLFrameElementFromJS(value js.Value) *HTMLFrameElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFrameElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFrameElementFromJS is casting from something that holds a js.Value into HTMLFrameElement.
+func HTMLFrameElementFromWrapper(input core.Wrapper) *HTMLFrameElement {
+	return HTMLFrameElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -5396,15 +5407,19 @@ type HTMLIFrameElement struct {
 	html.HTMLElement
 }
 
-// HTMLIFrameElementFromJS is casting a js.Wrapper into HTMLIFrameElement.
-func HTMLIFrameElementFromJS(value js.Wrapper) *HTMLIFrameElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLIFrameElementFromJS is casting a js.Value into HTMLIFrameElement.
+func HTMLIFrameElementFromJS(value js.Value) *HTMLIFrameElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLIFrameElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLIFrameElementFromJS is casting from something that holds a js.Value into HTMLIFrameElement.
+func HTMLIFrameElementFromWrapper(input core.Wrapper) *HTMLIFrameElement {
+	return HTMLIFrameElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -5724,15 +5739,19 @@ type HTMLObjectElement struct {
 	html.HTMLElement
 }
 
-// HTMLObjectElementFromJS is casting a js.Wrapper into HTMLObjectElement.
-func HTMLObjectElementFromJS(value js.Wrapper) *HTMLObjectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLObjectElementFromJS is casting a js.Value into HTMLObjectElement.
+func HTMLObjectElementFromJS(value js.Value) *HTMLObjectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLObjectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLObjectElementFromJS is casting from something that holds a js.Value into HTMLObjectElement.
+func HTMLObjectElementFromWrapper(input core.Wrapper) *HTMLObjectElement {
+	return HTMLObjectElementFromJS(input.JSValue())
 }
 
 // Data returning attribute 'data' with
@@ -6133,15 +6152,19 @@ func (_this *MutationObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MutationObserverFromJS is casting a js.Wrapper into MutationObserver.
-func MutationObserverFromJS(value js.Wrapper) *MutationObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MutationObserverFromJS is casting a js.Value into MutationObserver.
+func MutationObserverFromJS(value js.Value) *MutationObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MutationObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MutationObserverFromJS is casting from something that holds a js.Value into MutationObserver.
+func MutationObserverFromWrapper(input core.Wrapper) *MutationObserver {
+	return MutationObserverFromJS(input.JSValue())
 }
 
 func NewMutationObserver(callback *MutationCallback) (_result *MutationObserver) {
@@ -6227,15 +6250,19 @@ func (_this *MutationRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MutationRecordFromJS is casting a js.Wrapper into MutationRecord.
-func MutationRecordFromJS(value js.Wrapper) *MutationRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MutationRecordFromJS is casting a js.Value into MutationRecord.
+func MutationRecordFromJS(value js.Value) *MutationRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MutationRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MutationRecordFromJS is casting from something that holds a js.Value into MutationRecord.
+func MutationRecordFromWrapper(input core.Wrapper) *MutationRecord {
+	return MutationRecordFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -6337,15 +6364,19 @@ type Window struct {
 	domcore.EventTarget
 }
 
-// WindowFromJS is casting a js.Wrapper into Window.
-func WindowFromJS(value js.Wrapper) *Window {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WindowFromJS is casting a js.Value into Window.
+func WindowFromJS(value js.Value) *Window {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Window{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WindowFromJS is casting from something that holds a js.Value into Window.
+func WindowFromWrapper(input core.Wrapper) *Window {
+	return WindowFromJS(input.JSValue())
 }
 
 // Window returning attribute 'window' with
@@ -11150,13 +11181,17 @@ type XMLDocument struct {
 	Document
 }
 
-// XMLDocumentFromJS is casting a js.Wrapper into XMLDocument.
-func XMLDocumentFromJS(value js.Wrapper) *XMLDocument {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLDocumentFromJS is casting a js.Value into XMLDocument.
+func XMLDocumentFromJS(value js.Value) *XMLDocument {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLDocument{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLDocumentFromJS is casting from something that holds a js.Value into XMLDocument.
+func XMLDocumentFromWrapper(input core.Wrapper) *XMLDocument {
+	return XMLDocumentFromJS(input.JSValue())
 }

--- a/webapi_js.go
+++ b/webapi_js.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gowebapi/webapi/clipboard"
 	"github.com/gowebapi/webapi/communication/xhr"
 	"github.com/gowebapi/webapi/cookie"
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/crypto"
 	"github.com/gowebapi/webapi/csp"
 	"github.com/gowebapi/webapi/css/animations"
@@ -282,7 +283,7 @@ type ElementCreationOptions struct {
 	Is string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *ElementCreationOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -292,15 +293,13 @@ func (_this *ElementCreationOptions) JSValue() js.Value {
 }
 
 // ElementCreationOptionsFromJS is allocating a new
-// ElementCreationOptions object and copy all values from
-// input javascript object
-func ElementCreationOptionsFromJS(value js.Wrapper) *ElementCreationOptions {
-	input := value.JSValue()
+// ElementCreationOptions object and copy all values in the value javascript object.
+func ElementCreationOptionsFromJS(value js.Value) *ElementCreationOptions {
 	var out ElementCreationOptions
 	var (
 		value0 string // javascript: DOMString {is Is is}
 	)
-	value0 = (input.Get("is")).String()
+	value0 = (value.Get("is")).String()
 	out.Is = value0
 	return &out
 }
@@ -316,7 +315,7 @@ type MutationObserverInit struct {
 	AttributeFilter       []string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *MutationObserverInit) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -342,10 +341,8 @@ func (_this *MutationObserverInit) JSValue() js.Value {
 }
 
 // MutationObserverInitFromJS is allocating a new
-// MutationObserverInit object and copy all values from
-// input javascript object
-func MutationObserverInitFromJS(value js.Wrapper) *MutationObserverInit {
-	input := value.JSValue()
+// MutationObserverInit object and copy all values in the value javascript object.
+func MutationObserverInitFromJS(value js.Value) *MutationObserverInit {
 	var out MutationObserverInit
 	var (
 		value0 bool     // javascript: boolean {childList ChildList childList}
@@ -356,23 +353,23 @@ func MutationObserverInitFromJS(value js.Wrapper) *MutationObserverInit {
 		value5 bool     // javascript: boolean {characterDataOldValue CharacterDataOldValue characterDataOldValue}
 		value6 []string // javascript: sequence<DOMString> {attributeFilter AttributeFilter attributeFilter}
 	)
-	value0 = (input.Get("childList")).Bool()
+	value0 = (value.Get("childList")).Bool()
 	out.ChildList = value0
-	value1 = (input.Get("attributes")).Bool()
+	value1 = (value.Get("attributes")).Bool()
 	out.Attributes = value1
-	value2 = (input.Get("characterData")).Bool()
+	value2 = (value.Get("characterData")).Bool()
 	out.CharacterData = value2
-	value3 = (input.Get("subtree")).Bool()
+	value3 = (value.Get("subtree")).Bool()
 	out.Subtree = value3
-	value4 = (input.Get("attributeOldValue")).Bool()
+	value4 = (value.Get("attributeOldValue")).Bool()
 	out.AttributeOldValue = value4
-	value5 = (input.Get("characterDataOldValue")).Bool()
+	value5 = (value.Get("characterDataOldValue")).Bool()
 	out.CharacterDataOldValue = value5
-	__length6 := input.Get("attributeFilter").Length()
+	__length6 := value.Get("attributeFilter").Length()
 	__array6 := make([]string, __length6, __length6)
 	for __idx6 := 0; __idx6 < __length6; __idx6++ {
 		var __seq_out6 string
-		__seq_in6 := input.Get("attributeFilter").Index(__idx6)
+		__seq_in6 := value.Get("attributeFilter").Index(__idx6)
 		__seq_out6 = (__seq_in6).String()
 		__array6[__idx6] = __seq_out6
 	}
@@ -387,7 +384,7 @@ type WindowPostMessageOptions struct {
 	TargetOrigin string
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WindowPostMessageOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -403,26 +400,24 @@ func (_this *WindowPostMessageOptions) JSValue() js.Value {
 }
 
 // WindowPostMessageOptionsFromJS is allocating a new
-// WindowPostMessageOptions object and copy all values from
-// input javascript object
-func WindowPostMessageOptionsFromJS(value js.Wrapper) *WindowPostMessageOptions {
-	input := value.JSValue()
+// WindowPostMessageOptions object and copy all values in the value javascript object.
+func WindowPostMessageOptionsFromJS(value js.Value) *WindowPostMessageOptions {
 	var out WindowPostMessageOptions
 	var (
 		value0 []*javascript.Object // javascript: sequence<object> {transfer Transfer transfer}
 		value1 string               // javascript: USVString {targetOrigin TargetOrigin targetOrigin}
 	)
-	__length0 := input.Get("transfer").Length()
+	__length0 := value.Get("transfer").Length()
 	__array0 := make([]*javascript.Object, __length0, __length0)
 	for __idx0 := 0; __idx0 < __length0; __idx0++ {
 		var __seq_out0 *javascript.Object
-		__seq_in0 := input.Get("transfer").Index(__idx0)
+		__seq_in0 := value.Get("transfer").Index(__idx0)
 		__seq_out0 = javascript.ObjectFromJS(__seq_in0)
 		__array0[__idx0] = __seq_out0
 	}
 	value0 = __array0
 	out.Transfer = value0
-	value1 = (input.Get("targetOrigin")).String()
+	value1 = (value.Get("targetOrigin")).String()
 	out.TargetOrigin = value1
 	return &out
 }
@@ -437,15 +432,19 @@ func (_this *DOMImplementation) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// DOMImplementationFromJS is casting a js.Wrapper into DOMImplementation.
-func DOMImplementationFromJS(value js.Wrapper) *DOMImplementation {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DOMImplementationFromJS is casting a js.Value into DOMImplementation.
+func DOMImplementationFromJS(value js.Value) *DOMImplementation {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &DOMImplementation{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DOMImplementationFromJS is casting from something that holds a js.Value into DOMImplementation.
+func DOMImplementationFromWrapper(input core.Wrapper) *DOMImplementation {
+	return DOMImplementationFromJS(input.JSValue())
 }
 
 func (_this *DOMImplementation) CreateDocumentType(qualifiedName string, publicId string, systemId string) (_result *dom.DocumentType) {
@@ -546,15 +545,19 @@ type Document struct {
 	dom.Node
 }
 
-// DocumentFromJS is casting a js.Wrapper into Document.
-func DocumentFromJS(value js.Wrapper) *Document {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// DocumentFromJS is casting a js.Value into Document.
+func DocumentFromJS(value js.Value) *Document {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Document{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// DocumentFromJS is casting from something that holds a js.Value into Document.
+func DocumentFromWrapper(input core.Wrapper) *Document {
+	return DocumentFromJS(input.JSValue())
 }
 
 func NewDocument() (_result *Document) {
@@ -5100,15 +5103,19 @@ type HTMLEmbedElement struct {
 	html.HTMLElement
 }
 
-// HTMLEmbedElementFromJS is casting a js.Wrapper into HTMLEmbedElement.
-func HTMLEmbedElementFromJS(value js.Wrapper) *HTMLEmbedElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLEmbedElementFromJS is casting a js.Value into HTMLEmbedElement.
+func HTMLEmbedElementFromJS(value js.Value) *HTMLEmbedElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLEmbedElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLEmbedElementFromJS is casting from something that holds a js.Value into HTMLEmbedElement.
+func HTMLEmbedElementFromWrapper(input core.Wrapper) *HTMLEmbedElement {
+	return HTMLEmbedElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -5228,15 +5235,19 @@ type HTMLFrameElement struct {
 	html.HTMLElement
 }
 
-// HTMLFrameElementFromJS is casting a js.Wrapper into HTMLFrameElement.
-func HTMLFrameElementFromJS(value js.Wrapper) *HTMLFrameElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLFrameElementFromJS is casting a js.Value into HTMLFrameElement.
+func HTMLFrameElementFromJS(value js.Value) *HTMLFrameElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLFrameElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLFrameElementFromJS is casting from something that holds a js.Value into HTMLFrameElement.
+func HTMLFrameElementFromWrapper(input core.Wrapper) *HTMLFrameElement {
+	return HTMLFrameElementFromJS(input.JSValue())
 }
 
 // Name returning attribute 'name' with
@@ -5394,15 +5405,19 @@ type HTMLIFrameElement struct {
 	html.HTMLElement
 }
 
-// HTMLIFrameElementFromJS is casting a js.Wrapper into HTMLIFrameElement.
-func HTMLIFrameElementFromJS(value js.Wrapper) *HTMLIFrameElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLIFrameElementFromJS is casting a js.Value into HTMLIFrameElement.
+func HTMLIFrameElementFromJS(value js.Value) *HTMLIFrameElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLIFrameElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLIFrameElementFromJS is casting from something that holds a js.Value into HTMLIFrameElement.
+func HTMLIFrameElementFromWrapper(input core.Wrapper) *HTMLIFrameElement {
+	return HTMLIFrameElementFromJS(input.JSValue())
 }
 
 // Src returning attribute 'src' with
@@ -5722,15 +5737,19 @@ type HTMLObjectElement struct {
 	html.HTMLElement
 }
 
-// HTMLObjectElementFromJS is casting a js.Wrapper into HTMLObjectElement.
-func HTMLObjectElementFromJS(value js.Wrapper) *HTMLObjectElement {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// HTMLObjectElementFromJS is casting a js.Value into HTMLObjectElement.
+func HTMLObjectElementFromJS(value js.Value) *HTMLObjectElement {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &HTMLObjectElement{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// HTMLObjectElementFromJS is casting from something that holds a js.Value into HTMLObjectElement.
+func HTMLObjectElementFromWrapper(input core.Wrapper) *HTMLObjectElement {
+	return HTMLObjectElementFromJS(input.JSValue())
 }
 
 // Data returning attribute 'data' with
@@ -6131,15 +6150,19 @@ func (_this *MutationObserver) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MutationObserverFromJS is casting a js.Wrapper into MutationObserver.
-func MutationObserverFromJS(value js.Wrapper) *MutationObserver {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MutationObserverFromJS is casting a js.Value into MutationObserver.
+func MutationObserverFromJS(value js.Value) *MutationObserver {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MutationObserver{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MutationObserverFromJS is casting from something that holds a js.Value into MutationObserver.
+func MutationObserverFromWrapper(input core.Wrapper) *MutationObserver {
+	return MutationObserverFromJS(input.JSValue())
 }
 
 func NewMutationObserver(callback *MutationCallback) (_result *MutationObserver) {
@@ -6225,15 +6248,19 @@ func (_this *MutationRecord) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// MutationRecordFromJS is casting a js.Wrapper into MutationRecord.
-func MutationRecordFromJS(value js.Wrapper) *MutationRecord {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// MutationRecordFromJS is casting a js.Value into MutationRecord.
+func MutationRecordFromJS(value js.Value) *MutationRecord {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &MutationRecord{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// MutationRecordFromJS is casting from something that holds a js.Value into MutationRecord.
+func MutationRecordFromWrapper(input core.Wrapper) *MutationRecord {
+	return MutationRecordFromJS(input.JSValue())
 }
 
 // Type returning attribute 'type' with
@@ -6335,15 +6362,19 @@ type Window struct {
 	domcore.EventTarget
 }
 
-// WindowFromJS is casting a js.Wrapper into Window.
-func WindowFromJS(value js.Wrapper) *Window {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WindowFromJS is casting a js.Value into Window.
+func WindowFromJS(value js.Value) *Window {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Window{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WindowFromJS is casting from something that holds a js.Value into Window.
+func WindowFromWrapper(input core.Wrapper) *Window {
+	return WindowFromJS(input.JSValue())
 }
 
 // Window returning attribute 'window' with
@@ -11148,13 +11179,17 @@ type XMLDocument struct {
 	Document
 }
 
-// XMLDocumentFromJS is casting a js.Wrapper into XMLDocument.
-func XMLDocumentFromJS(value js.Wrapper) *XMLDocument {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// XMLDocumentFromJS is casting a js.Value into XMLDocument.
+func XMLDocumentFromJS(value js.Value) *XMLDocument {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &XMLDocument{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// XMLDocumentFromJS is casting from something that holds a js.Value into XMLDocument.
+func XMLDocumentFromWrapper(input core.Wrapper) *XMLDocument {
+	return XMLDocumentFromJS(input.JSValue())
 }

--- a/worklets/worklets.go
+++ b/worklets/worklets.go
@@ -7,6 +7,7 @@ package worklets
 import js "github.com/gowebapi/webapi/core/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/fetch"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -43,7 +44,7 @@ type WorkletOptions struct {
 	Credentials fetch.RequestCredentials
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WorkletOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -53,15 +54,13 @@ func (_this *WorkletOptions) JSValue() js.Value {
 }
 
 // WorkletOptionsFromJS is allocating a new
-// WorkletOptions object and copy all values from
-// input javascript object
-func WorkletOptionsFromJS(value js.Wrapper) *WorkletOptions {
-	input := value.JSValue()
+// WorkletOptions object and copy all values in the value javascript object.
+func WorkletOptionsFromJS(value js.Value) *WorkletOptions {
 	var out WorkletOptions
 	var (
 		value0 fetch.RequestCredentials // javascript: RequestCredentials {credentials Credentials credentials}
 	)
-	value0 = fetch.RequestCredentialsFromJS(input.Get("credentials"))
+	value0 = fetch.RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value0
 	return &out
 }
@@ -76,15 +75,19 @@ func (_this *Worklet) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkletFromJS is casting a js.Wrapper into Worklet.
-func WorkletFromJS(value js.Wrapper) *Worklet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkletFromJS is casting a js.Value into Worklet.
+func WorkletFromJS(value js.Value) *Worklet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Worklet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkletFromJS is casting from something that holds a js.Value into Worklet.
+func WorkletFromWrapper(input core.Wrapper) *Worklet {
+	return WorkletFromJS(input.JSValue())
 }
 
 func (_this *Worklet) AddModule(moduleURL string, options *WorkletOptions) (_result *javascript.PromiseVoid) {
@@ -119,13 +122,17 @@ func (_this *WorkletGlobalScope) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkletGlobalScopeFromJS is casting a js.Wrapper into WorkletGlobalScope.
-func WorkletGlobalScopeFromJS(value js.Wrapper) *WorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkletGlobalScopeFromJS is casting a js.Value into WorkletGlobalScope.
+func WorkletGlobalScopeFromJS(value js.Value) *WorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkletGlobalScopeFromJS is casting from something that holds a js.Value into WorkletGlobalScope.
+func WorkletGlobalScopeFromWrapper(input core.Wrapper) *WorkletGlobalScope {
+	return WorkletGlobalScopeFromJS(input.JSValue())
 }

--- a/worklets/worklets_js.go
+++ b/worklets/worklets_js.go
@@ -5,6 +5,7 @@ package worklets
 import "syscall/js"
 
 import (
+	"github.com/gowebapi/webapi/core"
 	"github.com/gowebapi/webapi/fetch"
 	"github.com/gowebapi/webapi/javascript"
 )
@@ -41,7 +42,7 @@ type WorkletOptions struct {
 	Credentials fetch.RequestCredentials
 }
 
-// JSValue is allocating a new javasript object and copy
+// JSValue is allocating a new javascript object and copy
 // all values
 func (_this *WorkletOptions) JSValue() js.Value {
 	out := js.Global().Get("Object").New()
@@ -51,15 +52,13 @@ func (_this *WorkletOptions) JSValue() js.Value {
 }
 
 // WorkletOptionsFromJS is allocating a new
-// WorkletOptions object and copy all values from
-// input javascript object
-func WorkletOptionsFromJS(value js.Wrapper) *WorkletOptions {
-	input := value.JSValue()
+// WorkletOptions object and copy all values in the value javascript object.
+func WorkletOptionsFromJS(value js.Value) *WorkletOptions {
 	var out WorkletOptions
 	var (
 		value0 fetch.RequestCredentials // javascript: RequestCredentials {credentials Credentials credentials}
 	)
-	value0 = fetch.RequestCredentialsFromJS(input.Get("credentials"))
+	value0 = fetch.RequestCredentialsFromJS(value.Get("credentials"))
 	out.Credentials = value0
 	return &out
 }
@@ -74,15 +73,19 @@ func (_this *Worklet) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkletFromJS is casting a js.Wrapper into Worklet.
-func WorkletFromJS(value js.Wrapper) *Worklet {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkletFromJS is casting a js.Value into Worklet.
+func WorkletFromJS(value js.Value) *Worklet {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &Worklet{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkletFromJS is casting from something that holds a js.Value into Worklet.
+func WorkletFromWrapper(input core.Wrapper) *Worklet {
+	return WorkletFromJS(input.JSValue())
 }
 
 func (_this *Worklet) AddModule(moduleURL string, options *WorkletOptions) (_result *javascript.PromiseVoid) {
@@ -117,13 +120,17 @@ func (_this *WorkletGlobalScope) JSValue() js.Value {
 	return _this.Value_JS
 }
 
-// WorkletGlobalScopeFromJS is casting a js.Wrapper into WorkletGlobalScope.
-func WorkletGlobalScopeFromJS(value js.Wrapper) *WorkletGlobalScope {
-	input := value.JSValue()
-	if typ := input.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
+// WorkletGlobalScopeFromJS is casting a js.Value into WorkletGlobalScope.
+func WorkletGlobalScopeFromJS(value js.Value) *WorkletGlobalScope {
+	if typ := value.Type(); typ == js.TypeNull || typ == js.TypeUndefined {
 		return nil
 	}
 	ret := &WorkletGlobalScope{}
-	ret.Value_JS = input
+	ret.Value_JS = value
 	return ret
+}
+
+// WorkletGlobalScopeFromJS is casting from something that holds a js.Value into WorkletGlobalScope.
+func WorkletGlobalScopeFromWrapper(input core.Wrapper) *WorkletGlobalScope {
+	return WorkletGlobalScopeFromJS(input.JSValue())
 }


### PR DESCRIPTION
See details in issue #15 